### PR TITLE
Implement Cascadia Basin seawater.

### DIFF
--- a/private/PROPOSAL/medium/Medium.cxx
+++ b/private/PROPOSAL/medium/Medium.cxx
@@ -710,6 +710,33 @@ AntaresWater::AntaresWater(double rho)
 
 }
 
+// chemical composition is normalized with respect to hydrogen: calculate a
+// total atomic weight that yields two hydrogen atoms; use this weight to
+// calculate the numbers of atoms for all other elements
+CascadiaBasinWater::CascadiaBasinWater(double rho)
+    : Medium(
+        "cascadiabasinwater",
+        rho,
+        75.,       // I
+        -3.5017,   // C
+        0.09116,   // a
+        3.4773,    // m
+        0.2400,    // X0
+        2.8004,    // X1
+        0.,        // d0
+        1.0400322, // massDensity
+        {
+            std::shared_ptr<Components::Component>(new Components::Hydrogen(2.0)),
+            std::shared_ptr<Components::Component>(new Components::Oxygen(1.0021)),
+            std::shared_ptr<Components::Component>(new Components::Sodium(8.7174e-3)),
+            std::shared_ptr<Components::Component>(new Components::Magnesium(9.8180e-4)),
+            std::shared_ptr<Components::Component>(new Components::Calcium(1.9113e-4)),
+            std::shared_ptr<Components::Component>(new Components::Potassium(1.8975e-4)),
+            std::shared_ptr<Components::Component>(new Components::Chlorine(1.0147e-2)),
+            std::shared_ptr<Components::Component>(new Components::Sulfur(5.2487e-4))
+        })
+{}
+
 /******************************************************************************
  *                        private Helper Funcitons                             *
  ******************************************************************************/

--- a/private/PROPOSAL/medium/Medium.cxx
+++ b/private/PROPOSAL/medium/Medium.cxx
@@ -726,14 +726,14 @@ CascadiaBasinWater::CascadiaBasinWater(double rho)
         0.,        // d0
         1.0400322, // massDensity
         {
-            std::shared_ptr<Components::Component>(new Components::Hydrogen(2.0)),
-            std::shared_ptr<Components::Component>(new Components::Oxygen(1.0021)),
-            std::shared_ptr<Components::Component>(new Components::Sodium(8.7174e-3)),
-            std::shared_ptr<Components::Component>(new Components::Magnesium(9.8180e-4)),
-            std::shared_ptr<Components::Component>(new Components::Calcium(1.9113e-4)),
-            std::shared_ptr<Components::Component>(new Components::Potassium(1.8975e-4)),
-            std::shared_ptr<Components::Component>(new Components::Chlorine(1.0147e-2)),
-            std::shared_ptr<Components::Component>(new Components::Sulfur(5.2487e-4))
+            std::make_shared<Components::Component>(Components::Hydrogen(2.0)),
+            std::make_shared<Components::Component>(Components::Oxygen(1.0021)),
+            std::make_shared<Components::Component>(Components::Sodium(8.7174e-3)),
+            std::make_shared<Components::Component>(Components::Magnesium(9.8180e-4)),
+            std::make_shared<Components::Component>(Components::Calcium(1.9113e-4)),
+            std::make_shared<Components::Component>(Components::Potassium(1.8975e-4)),
+            std::make_shared<Components::Component>(Components::Chlorine(1.0147e-2)),
+            std::make_shared<Components::Component>(Components::Sulfur(5.2487e-4))
         })
 {}
 

--- a/private/PROPOSAL/medium/MediumFactory.cxx
+++ b/private/PROPOSAL/medium/MediumFactory.cxx
@@ -27,6 +27,7 @@ MediumFactory::MediumFactory()
     Register("air", Air, &Air::create);
     Register("paraffin", Paraffin, &Paraffin::create);
     Register("antareswater", AntaresWater, &AntaresWater::create);
+    Register("cascadiabasinwater", CascadiaBasinWater, &CascadiaBasinWater::create);
 }
 
 MediumFactory::~MediumFactory()

--- a/public/PROPOSAL/medium/Medium.h
+++ b/public/PROPOSAL/medium/Medium.h
@@ -213,6 +213,25 @@ public:
 // |)}>#
 MEDIUM_DEF(AntaresWater)
 
+/// @brief Cascadia Basin seawater
+///
+/// Cascadia Basin is located in the Northeast Pacific Ocean at a depth of
+/// 2.66 km close to the coast of Victoria, Canada. Infrastructure for deep-sea
+/// experiments is provided by Ocean Networks Canada (ONC). Therefore, it is an
+/// interesting site for future neutrino telescopes.
+///
+/// The chemical composition of the Cacadia Basin seawater is based on the six
+/// most important (by reference salinity) materials dissolved in Standard
+/// Seawater, according to F. J. Millero et al., Deep Sea Research Part I:
+/// Oceanographic Research Papers 55.1 (2008), pp. 50-72. These materials are
+/// sodium, magnesium, calcium, potassium, chlorine, and sulfate ions.
+///
+/// The project https://kkrings.github.io/seawater/ is used to calculate the
+/// chemical composition of the Cascadia Basin seawater. The practical salinity
+/// of 34.6288 psu and the mass density of 1.0400322 g/cm3 are obtained from
+/// ONC measurements.
+MEDIUM_DEF(CascadiaBasinWater)
+
 } // namespace PROPOSAL
 
 #undef MEDIUM_DEF

--- a/public/PROPOSAL/medium/MediumFactory.h
+++ b/public/PROPOSAL/medium/MediumFactory.h
@@ -57,7 +57,8 @@ public:
         Uranium,
         Air,
         Paraffin,
-        AntaresWater
+        AntaresWater,
+        CascadiaBasinWater
     };
 
     struct Definition


### PR DESCRIPTION
This is a new seawater implementation for Cascadia Basin, which is located in the Northeast Pacific Ocean at a depth of 2.66 km. Cascadia Basin is a potential site for future neutrino telescopes.