### PR TITLE
Avoid pulling random numbers at scattering when they are not needed.

### DIFF
--- a/private/PROPOSAL/Sector.cxx
+++ b/private/PROPOSAL/Sector.cxx
@@ -630,9 +630,9 @@ void Sector::AdvanceParticle(double dr, double ei, double ef) {
     Vector3D n_i(particle_.GetDirection());
 
     if( sector_def_.scattering_model != ScatteringFactory::Enum::NoScattering ){
-        std::shared_ptr<std::pair<Vector3D, Vector3D>> directions = scattering_->Scatter(dr, ei, ef);
-        u = directions->first;
-        n_i = directions->second;
+        std::shared_ptr<Directions> directions = scattering_->Scatter(dr, ei, ef);
+        u = directions->u_;
+        n_i = directions->n_i_;
     }
 
     particle_.SetPosition(particle_.GetPosition() + dr * u);

--- a/private/PROPOSAL/Sector.cxx
+++ b/private/PROPOSAL/Sector.cxx
@@ -625,17 +625,18 @@ void Sector::AdvanceParticle(double dr, double ei, double ef) {
         time += dr / SPEED;
     }
 
-    std::pair<Vector3D, Vector3D> directions; // u, n_f
 
-    if( sector_def_.scattering_model == ScatteringFactory::Enum::NoScattering ){
-        directions.first = particle_.GetDirection();
-        directions.second = particle_.GetDirection();
-    } else {
-        directions = scattering_->Scatter(dr, ei, ef);
+    Vector3D u(particle_.GetDirection());
+    Vector3D n_i(particle_.GetDirection());
+
+    if( sector_def_.scattering_model != ScatteringFactory::Enum::NoScattering ){
+        std::shared_ptr<std::pair<Vector3D, Vector3D>> directions = scattering_->Scatter(dr, ei, ef);
+        u = directions->first;
+        n_i = directions->second;
     }
 
-    particle_.SetPosition(particle_.GetPosition() + dr * directions.first);
-    particle_.SetDirection(directions.second);
+    particle_.SetPosition(particle_.GetPosition() + dr * u);
+    particle_.SetDirection(n_i);
 
     particle_.SetPropagatedDistance(dist);
     particle_.SetTime(time);

--- a/private/PROPOSAL/Sector.cxx
+++ b/private/PROPOSAL/Sector.cxx
@@ -625,7 +625,21 @@ void Sector::AdvanceParticle(double dr, double ei, double ef) {
         time += dr / SPEED;
     }
 
-    scattering_->Scatter(dr, ei, ef);
+    std::pair<Vector3D, Vector3D> directions; // u, n_f
+
+    if( sector_def_.scattering_model == ScatteringFactory::Enum::NoScattering ){
+        directions.first = particle_.GetDirection();
+        directions.second = particle_.GetDirection();
+        double rnd1 = RandomGenerator::Get().RandomDouble();
+        double rnd2 = RandomGenerator::Get().RandomDouble();
+        double rnd3 = RandomGenerator::Get().RandomDouble();
+        double rnd4 = RandomGenerator::Get().RandomDouble();
+    } else {
+        directions = scattering_->Scatter(dr, ei, ef);
+    }
+
+    particle_.SetPosition(particle_.GetPosition() + dr * directions.first);
+    particle_.SetDirection(directions.second);
 
     particle_.SetPropagatedDistance(dist);
     particle_.SetTime(time);

--- a/private/PROPOSAL/Sector.cxx
+++ b/private/PROPOSAL/Sector.cxx
@@ -630,9 +630,9 @@ void Sector::AdvanceParticle(double dr, double ei, double ef) {
     Vector3D n_i(particle_.GetDirection());
 
     if( sector_def_.scattering_model != ScatteringFactory::Enum::NoScattering ){
-        std::shared_ptr<Directions> directions = scattering_->Scatter(dr, ei, ef);
-        u = directions->u_;
-        n_i = directions->n_i_;
+        Directions directions = scattering_->Scatter(dr, ei, ef);
+        u = directions.u_;
+        n_i = directions.n_i_;
     }
 
     particle_.SetPosition(particle_.GetPosition() + dr * u);

--- a/private/PROPOSAL/Sector.cxx
+++ b/private/PROPOSAL/Sector.cxx
@@ -630,10 +630,6 @@ void Sector::AdvanceParticle(double dr, double ei, double ef) {
     if( sector_def_.scattering_model == ScatteringFactory::Enum::NoScattering ){
         directions.first = particle_.GetDirection();
         directions.second = particle_.GetDirection();
-        double rnd1 = RandomGenerator::Get().RandomDouble();
-        double rnd2 = RandomGenerator::Get().RandomDouble();
-        double rnd3 = RandomGenerator::Get().RandomDouble();
-        double rnd4 = RandomGenerator::Get().RandomDouble();
     } else {
         directions = scattering_->Scatter(dr, ei, ef);
     }

--- a/private/PROPOSAL/Sector.cxx
+++ b/private/PROPOSAL/Sector.cxx
@@ -626,17 +626,14 @@ void Sector::AdvanceParticle(double dr, double ei, double ef) {
     }
 
 
-    Vector3D u(particle_.GetDirection());
-    Vector3D n_i(particle_.GetDirection());
-
     if( sector_def_.scattering_model != ScatteringFactory::Enum::NoScattering ){
         Directions directions = scattering_->Scatter(dr, ei, ef);
-        u = directions.u_;
-        n_i = directions.n_i_;
+        particle_.SetPosition(particle_.GetPosition() + dr * directions.u_);
+        particle_.SetDirection(directions.n_i_);
+    } else {
+        particle_.SetPosition(particle_.GetPosition() + dr * particle_.GetDirection());
     }
 
-    particle_.SetPosition(particle_.GetPosition() + dr * u);
-    particle_.SetDirection(n_i);
 
     particle_.SetPropagatedDistance(dist);
     particle_.SetTime(time);

--- a/private/PROPOSAL/scattering/Scattering.cxx
+++ b/private/PROPOSAL/scattering/Scattering.cxx
@@ -13,6 +13,7 @@
 #include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/particle/Particle.h"
 #include "PROPOSAL/scattering/Scattering.h"
+#include "PROPOSAL/math/RandomGenerator.h"
 
 using namespace PROPOSAL;
 
@@ -47,6 +48,16 @@ bool Scattering::operator!=(const Scattering& scattering) const
 
 std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, double ei, double ef)
 {
+    double rnd1 = RandomGenerator::Get().RandomDouble();
+    double rnd2 = RandomGenerator::Get().RandomDouble();
+    double rnd3 = RandomGenerator::Get().RandomDouble();
+    double rnd4 = RandomGenerator::Get().RandomDouble();
+
+    return Scattering::Scatter(dr, ei, ef, rnd1, rnd2, rnd3, rnd4);
+}
+
+std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4)
+{
     Vector3D u(0,0,0); // averaged continous propagation direction
     Vector3D n_i(particle_.GetDirection()); // direction after continous propagation
 
@@ -57,7 +68,7 @@ std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, do
 
     double sz, tz;
 
-    RandomAngles random_angles = CalculateRandomAngle(dr, ei, ef);
+    RandomAngles random_angles = CalculateRandomAngle(dr, ei, ef, rnd1, rnd2, rnd3, rnd4);
 
     sz = std::sqrt(std::max(1. - (random_angles.sx * random_angles.sx + random_angles.sy * random_angles.sy), 0.));
     tz = std::sqrt(std::max(1. - (random_angles.tx * random_angles.tx + random_angles.ty * random_angles.ty), 0.));
@@ -85,4 +96,14 @@ std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, do
     n_i.CalculateSphericalCoordinates();
 
     return std::make_shared<std::pair<Vector3D, Vector3D>>(std::make_pair(u, n_i));
+}
+
+Scattering::RandomAngles Scattering::CalculateRandomAngle(double dr, double ei, double ef)
+{
+    double rnd1 = RandomGenerator::Get().RandomDouble();
+    double rnd2 = RandomGenerator::Get().RandomDouble();
+    double rnd3 = RandomGenerator::Get().RandomDouble();
+    double rnd4 = RandomGenerator::Get().RandomDouble();
+
+    return this->CalculateRandomAngle(dr, ei, ef, rnd1, rnd2, rnd3, rnd4);
 }

--- a/private/PROPOSAL/scattering/Scattering.cxx
+++ b/private/PROPOSAL/scattering/Scattering.cxx
@@ -22,14 +22,12 @@ using namespace PROPOSAL;
  ******************************************************************************/
 
 Scattering::Scattering(Particle& particle)
-    : particle_(particle),
-      directions_(Vector3D(), Vector3D())
+    : particle_(particle)
 {
 }
 
 Scattering::Scattering(const Scattering& scattering)
-    : particle_(scattering.particle_),
-      directions_(scattering.directions_)
+    : particle_(scattering.particle_)
 {
 }
 
@@ -48,7 +46,7 @@ bool Scattering::operator!=(const Scattering& scattering) const
     return !(*this == scattering);
 }
 
-std::shared_ptr<Directions> Scattering::Scatter(double dr, double ei, double ef)
+Directions Scattering::Scatter(double dr, double ei, double ef)
 {
     double rnd1 = RandomGenerator::Get().RandomDouble();
     double rnd2 = RandomGenerator::Get().RandomDouble();
@@ -58,16 +56,16 @@ std::shared_ptr<Directions> Scattering::Scatter(double dr, double ei, double ef)
     return Scattering::Scatter(dr, ei, ef, rnd1, rnd2, rnd3, rnd4);
 }
 
-std::shared_ptr<Directions> Scattering::Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4)
+Directions Scattering::Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4)
 {
+    Directions directions_;
     // u averaged continous propagation direction
     // n_i direction after continous propagation
-    directions_.u_ = Vector3D(0, 0, 0);
     directions_.n_i_ = Vector3D(particle_.GetDirection());
 
     if(dr<=0)
     {
-        return std::make_shared<Directions>(directions_);
+        return directions_;
     }
 
     double sz, tz;
@@ -99,7 +97,7 @@ std::shared_ptr<Directions> Scattering::Scatter(double dr, double ei, double ef,
     directions_.n_i_ = directions_.n_i_ + random_angles.ty * rotate_vector_y;
     directions_.n_i_.CalculateSphericalCoordinates();
 
-    return std::make_shared<Directions>(directions_);
+    return directions_;
 }
 
 Scattering::RandomAngles Scattering::CalculateRandomAngle(double dr, double ei, double ef)

--- a/private/PROPOSAL/scattering/Scattering.cxx
+++ b/private/PROPOSAL/scattering/Scattering.cxx
@@ -8,6 +8,7 @@
  **/
 
 #include <cmath>
+#include <memory>
 
 #include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/particle/Particle.h"
@@ -44,13 +45,14 @@ bool Scattering::operator!=(const Scattering& scattering) const
     return !(*this == scattering);
 }
 
-std::pair<Vector3D, Vector3D> Scattering::Scatter(double dr, double ei, double ef)
+std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, double ei, double ef)
 {
-    std::pair<Vector3D, Vector3D> new_direction(Vector3D(0,0,0), particle_.GetDirection());
+    Vector3D u(0,0,0); // averaged continous propagation direction
+    Vector3D n_i(particle_.GetDirection()); // direction after continous propagation
 
     if(dr<=0)
     {
-        return new_direction;
+        return std::make_shared<std::pair<Vector3D, Vector3D>>(std::make_pair(u, n_i));
     }
 
     double sz, tz;
@@ -72,15 +74,15 @@ std::pair<Vector3D, Vector3D> Scattering::Scatter(double dr, double ei, double e
     const Vector3D rotate_vector_y = Vector3D(-sinph, cosph, 0.);
 
     // Rotation towards all tree axes
-    new_direction.first = sz * old_direction;
-    new_direction.first = new_direction.first + random_angles.sx * rotate_vector_x;
-    new_direction.first = new_direction.first + random_angles.sy * rotate_vector_y;
+    u = sz * old_direction;
+    u = u + random_angles.sx * rotate_vector_x;
+    u = u + random_angles.sy * rotate_vector_y;
 
     // Rotation towards all tree axes
-    new_direction.second = tz * old_direction;
-    new_direction.second = new_direction.second + random_angles.tx * rotate_vector_x;
-    new_direction.second = new_direction.second + random_angles.ty * rotate_vector_y;
-    new_direction.second.CalculateSphericalCoordinates();
+    n_i = tz * old_direction;
+    n_i = n_i + random_angles.tx * rotate_vector_x;
+    n_i = n_i + random_angles.ty * rotate_vector_y;
+    n_i.CalculateSphericalCoordinates();
 
-    return new_direction;
+    return std::make_shared<std::pair<Vector3D, Vector3D>>(std::make_pair(u, n_i));
 }

--- a/private/PROPOSAL/scattering/Scattering.cxx
+++ b/private/PROPOSAL/scattering/Scattering.cxx
@@ -64,11 +64,11 @@ std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, do
 
     const Vector3D old_direction = particle_.GetDirection();
 
-    long double sinth, costh, sinph, cosph;
-    sinth = (long double)std::sin(old_direction.GetTheta());
-    costh = (long double)std::cos(old_direction.GetTheta());
-    sinph = (long double)std::sin(old_direction.GetPhi());
-    cosph = (long double)std::cos(old_direction.GetPhi());
+    double sinth, costh, sinph, cosph;
+    sinth = std::sin(old_direction.GetTheta());
+    costh = std::cos(old_direction.GetTheta());
+    sinph = std::sin(old_direction.GetPhi());
+    cosph = std::cos(old_direction.GetPhi());
 
     const Vector3D rotate_vector_x = Vector3D(costh * cosph, costh * sinph, -sinth);
     const Vector3D rotate_vector_y = Vector3D(-sinph, cosph, 0.);

--- a/private/PROPOSAL/scattering/Scattering.cxx
+++ b/private/PROPOSAL/scattering/Scattering.cxx
@@ -22,12 +22,14 @@ using namespace PROPOSAL;
  ******************************************************************************/
 
 Scattering::Scattering(Particle& particle)
-    : particle_(particle)
+    : particle_(particle),
+      directions_(Vector3D(), Vector3D())
 {
 }
 
 Scattering::Scattering(const Scattering& scattering)
-    : particle_(scattering.particle_)
+    : particle_(scattering.particle_),
+      directions_(scattering.directions_)
 {
 }
 
@@ -46,7 +48,7 @@ bool Scattering::operator!=(const Scattering& scattering) const
     return !(*this == scattering);
 }
 
-std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, double ei, double ef)
+std::shared_ptr<Directions> Scattering::Scatter(double dr, double ei, double ef)
 {
     double rnd1 = RandomGenerator::Get().RandomDouble();
     double rnd2 = RandomGenerator::Get().RandomDouble();
@@ -56,14 +58,16 @@ std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, do
     return Scattering::Scatter(dr, ei, ef, rnd1, rnd2, rnd3, rnd4);
 }
 
-std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4)
+std::shared_ptr<Directions> Scattering::Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4)
 {
-    Vector3D u(0,0,0); // averaged continous propagation direction
-    Vector3D n_i(particle_.GetDirection()); // direction after continous propagation
+    // u averaged continous propagation direction
+    // n_i direction after continous propagation
+    directions_.u_ = Vector3D(0, 0, 0);
+    directions_.n_i_ = Vector3D(particle_.GetDirection());
 
     if(dr<=0)
     {
-        return std::make_shared<std::pair<Vector3D, Vector3D>>(std::make_pair(u, n_i));
+        return std::make_shared<Directions>(directions_);
     }
 
     double sz, tz;
@@ -85,17 +89,17 @@ std::shared_ptr<std::pair<Vector3D, Vector3D>> Scattering::Scatter(double dr, do
     const Vector3D rotate_vector_y = Vector3D(-sinph, cosph, 0.);
 
     // Rotation towards all tree axes
-    u = sz * old_direction;
-    u = u + random_angles.sx * rotate_vector_x;
-    u = u + random_angles.sy * rotate_vector_y;
+    directions_.u_ = sz * old_direction;
+    directions_.u_ = directions_.u_ + random_angles.sx * rotate_vector_x;
+    directions_.u_ = directions_.u_ + random_angles.sy * rotate_vector_y;
 
     // Rotation towards all tree axes
-    n_i = tz * old_direction;
-    n_i = n_i + random_angles.tx * rotate_vector_x;
-    n_i = n_i + random_angles.ty * rotate_vector_y;
-    n_i.CalculateSphericalCoordinates();
+    directions_.n_i_ = tz * old_direction;
+    directions_.n_i_ = directions_.n_i_ + random_angles.tx * rotate_vector_x;
+    directions_.n_i_ = directions_.n_i_ + random_angles.ty * rotate_vector_y;
+    directions_.n_i_.CalculateSphericalCoordinates();
 
-    return std::make_shared<std::pair<Vector3D, Vector3D>>(std::make_pair(u, n_i));
+    return std::make_shared<Directions>(directions_);
 }
 
 Scattering::RandomAngles Scattering::CalculateRandomAngle(double dr, double ei, double ef)

--- a/private/PROPOSAL/scattering/ScatteringHighland.cxx
+++ b/private/PROPOSAL/scattering/ScatteringHighland.cxx
@@ -68,25 +68,30 @@ double ScatteringHighland::CalculateTheta0(double dr) {
 
 //----------------------------------------------------------------------------//
 
+
 Scattering::RandomAngles ScatteringHighland::CalculateRandomAngle(double dr,
                                                                   double ei,
-                                                                  double ef) {
+                                                                  double ef,
+                                                                  double rnd1,
+                                                                  double rnd2,
+                                                                  double rnd3,
+                                                                  double rnd4) {
     (void)ei;
     (void)ef;
 
-    double Theta0, rnd1, rnd2;
+    double Theta0;
     Scattering::RandomAngles random_angles;
 
     Theta0 = CalculateTheta0(dr);
 
-    rnd1 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
-    rnd2 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
+    rnd1 = Theta0 * inverseErrorFunction(rnd1);
+    rnd2 = Theta0 * inverseErrorFunction(rnd2);
 
     random_angles.sx = 0.5 * (rnd1 / SQRT3 + rnd2);
     random_angles.tx = rnd2;
 
-    rnd1 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
-    rnd2 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
+    rnd1 = Theta0 * inverseErrorFunction(rnd3);
+    rnd2 = Theta0 * inverseErrorFunction(rnd4);
 
     random_angles.sy = 0.5 * (rnd1 / SQRT3 + rnd2);
     random_angles.ty = rnd2;

--- a/private/PROPOSAL/scattering/ScatteringHighlandIntegral.cxx
+++ b/private/PROPOSAL/scattering/ScatteringHighlandIntegral.cxx
@@ -110,21 +110,21 @@ long double ScatteringHighlandIntegral::CalculateTheta0(double dr, double ei, do
 
 //----------------------------------------------------------------------------//
 
-Scattering::RandomAngles ScatteringHighlandIntegral::CalculateRandomAngle(double dr, double ei, double ef)
+Scattering::RandomAngles ScatteringHighlandIntegral::CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4)
 {
-    double Theta0, rnd1, rnd2;
+    double Theta0;
     Scattering::RandomAngles random_angles;
 
     Theta0 = CalculateTheta0(dr, ei, ef);
 
-    rnd1 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
-    rnd2 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
+    rnd1 = Theta0 * inverseErrorFunction(rnd1);
+    rnd2 = Theta0 * inverseErrorFunction(rnd2);
 
     random_angles.sx = 0.5 * (rnd1 / SQRT3 + rnd2);
     random_angles.tx = rnd2;
 
-    rnd1 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
-    rnd2 = Theta0 * inverseErrorFunction(RandomGenerator::Get().RandomDouble());
+    rnd1 = Theta0 * inverseErrorFunction(rnd3);
+    rnd2 = Theta0 * inverseErrorFunction(rnd4);
 
     random_angles.sy = 0.5 * (rnd1 / SQRT3 + rnd2);
     random_angles.ty = rnd2;

--- a/private/PROPOSAL/scattering/ScatteringMoliere.cxx
+++ b/private/PROPOSAL/scattering/ScatteringMoliere.cxx
@@ -18,7 +18,11 @@ using namespace PROPOSAL;
 
 Scattering::RandomAngles ScatteringMoliere::CalculateRandomAngle(double dr,
                                                                  double ei,
-                                                                 double ef) {
+                                                                 double ef,
+                                                                 double rnd1,
+                                                                 double rnd2,
+                                                                 double rnd3,
+                                                                 double rnd4) {
     (void)ei;
     (void)ef;
 
@@ -80,16 +84,14 @@ Scattering::RandomAngles ScatteringMoliere::CalculateRandomAngle(double dr,
 
     double pre_factor = std::sqrt(chiCSq_ * B_[max_weight_index_]);
 
-    double rnd1, rnd2;
-
-    rnd1 = GetRandom(pre_factor);
-    rnd2 = GetRandom(pre_factor);
+    rnd1 = GetRandom(pre_factor, rnd1);
+    rnd2 = GetRandom(pre_factor, rnd2);
 
     random_angles.sx = 0.5 * (rnd1 / SQRT3 + rnd2);
     random_angles.tx = rnd2;
 
-    rnd1 = GetRandom(pre_factor);
-    rnd2 = GetRandom(pre_factor);
+    rnd1 = GetRandom(pre_factor, rnd3);
+    rnd2 = GetRandom(pre_factor, rnd4);
 
     random_angles.sy = 0.5 * (rnd1 / SQRT3 + rnd2);
     random_angles.ty = rnd2;
@@ -376,13 +378,11 @@ double ScatteringMoliere::F(double theta) {
 //-------------------------generate random angle------------------------------//
 //----------------------------------------------------------------------------//
 
-double ScatteringMoliere::GetRandom(double pre_factor) {
+double ScatteringMoliere::GetRandom(double pre_factor, double rnd) {
     //  Generate random angles following Moliere's distribution by comparing a
     //  uniformly distributed random number with the integral of the
     //  distribution. Therefore, determine the angle where the integral is equal
     //  to the random number.
-
-    double rnd = RandomGenerator::Get().RandomDouble();
 
     // Newton-Raphson method:
     double theta_n;

--- a/private/PROPOSAL/scattering/ScatteringNoScattering.cxx
+++ b/private/PROPOSAL/scattering/ScatteringNoScattering.cxx
@@ -53,11 +53,15 @@ bool ScatteringNoScattering::compare(const Scattering& scattering) const
 }
 
 //----------------------------------------------------------------------------//
-Scattering::RandomAngles ScatteringNoScattering::CalculateRandomAngle(double dr, double ei, double ef)
+Scattering::RandomAngles ScatteringNoScattering::CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4)
 {
     (void)ei;
     (void)ef;
     (void)dr;
+    (void)rnd1;
+    (void)rnd2;
+    (void)rnd3;
+    (void)rnd4;
 
     Scattering::RandomAngles random_angles;
 

--- a/private/python/pybindings.cxx
+++ b/private/python/pybindings.cxx
@@ -69,24 +69,24 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
         m, "EnergyCutSettings",
         R"pbdoc(
 			Settings for the lower integration limit.
-			Losses below the cut will be handeled continously and the 
+			Losses below the cut will be handeled continously and the
 			other stochasticaly.
 
-			.. math:: 
+			.. math::
 
 				\text{cut} = \begin{cases} e_\text{cut} & E * v_\text{cut} \geq e_\text{cut} \\ v_\text{cut} & \, \text{else} \end{cases}
 		)pbdoc")
         .def(py::init<>(),
              R"pbdoc(
-                    Initialize some standard settings. 
+                    Initialize some standard settings.
                     The default e_cut = 500 Mev and v_cut = 0.05 will be set.
                 )pbdoc")
         .def(py::init<double, double>(), py::arg("ecut"), py::arg("vcut"),
              R"pbdoc(
-                    Set the cut values manualy. 
-            
-                    Args: 
-                        ecut (float): static energy cut. 
+                    Set the cut values manualy.
+
+                    Args:
+                        ecut (float): static energy cut.
                         vcut (float): relativ energy cut.
                 )pbdoc")
         .def(py::init<const EnergyCutSettings&>())
@@ -119,14 +119,14 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
         m, "InterpolationDef",
         R"pbdoc(
 				The set standard values have been optimized for performance
-				and accuracy. They should not be changed any further 
+				and accuracy. They should not be changed any further
 				without a good reason.
 
 				Example:
-					For speed savings it makes sense to specify a path to 
+					For speed savings it makes sense to specify a path to
 					the tables, to reuse build tables if possible.
 
-					Sometimes it is usefull to look in the tables for a check. 
+					Sometimes it is usefull to look in the tables for a check.
 					To do this binary tables can be diabled.
 
 					>>> interpolDef = pp.InterpolationDef()
@@ -142,30 +142,30 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
 			)pbdoc")
         .def_readwrite("path_to_tables", &InterpolationDef::path_to_tables,
                        R"pbdoc(
-				Path where tables can be written from memory to disk to 
+				Path where tables can be written from memory to disk to
 				reuse it if possible.
 			)pbdoc")
         .def_readwrite("path_to_tables_readonly",
                        &InterpolationDef::path_to_tables_readonly,
                        R"pbdoc(
-				Path where tables can be read from disk to avoid to rebuild 
+				Path where tables can be read from disk to avoid to rebuild
 				it.
 			)pbdoc")
         .def_readwrite("max_node_energy", &InterpolationDef::max_node_energy,
                        R"pbdoc(
-				maximum energy that will be interpolated. Energies greater 
+				maximum energy that will be interpolated. Energies greater
 				than the value are extrapolated. Default: 1e14 MeV
 			)pbdoc")
         .def_readwrite("nodes_cross_section",
                        &InterpolationDef::nodes_cross_section,
                        R"pbdoc(
-				number of nodes used by evaluation of cross section 
+				number of nodes used by evaluation of cross section
 				integrals. Default: xxx
 			)pbdoc")
         .def_readwrite("nodes_continous_randomization",
                        &InterpolationDef::nodes_continous_randomization,
                        R"pbdoc(
-				number of nodes used by evaluation of continous 
+				number of nodes used by evaluation of continous
 				randomization integrals. Default: xxx
 			)pbdoc")
         .def_readwrite("nodes_propagate", &InterpolationDef::nodes_propagate,
@@ -175,8 +175,8 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
 			)pbdoc")
         .def_readwrite("do_binary_tables", &InterpolationDef::do_binary_tables,
                        R"pbdoc(
-				Should binary tables be used to store the data. 
-				This will increase performance, but are not readable for a 
+				Should binary tables be used to store the data.
+				This will increase performance, but are not readable for a
 				crosscheck by human. Default: xxx
 			)pbdoc")
         .def_readwrite("just_use_readonly_path",
@@ -227,48 +227,48 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
     py::class_<ContinuousRandomizer, std::shared_ptr<ContinuousRandomizer>>(
         m, "ContinuousRandomizer",
         R"pbdoc(
-        If :math:`v_\text{cut}` is large, the spectrum is not continously any 
-        more. Particles which has no stochastic loss crossing the medium has 
-        all the same energy :math:`E_\text{peak}` after propagating through 
+        If :math:`v_\text{cut}` is large, the spectrum is not continously any
+        more. Particles which has no stochastic loss crossing the medium has
+        all the same energy :math:`E_\text{peak}` after propagating through
         the medium.  This produce a gap of size of minimal stochastic loss.
         This effect can be reduced using continous randomization.
-        
+
         .. figure:: figures/mu_continuous.png
             :scale: 50%
             :align: center
 
             Propagate a muon with 100 TeV through 300 m Rock.
 
-        The average energy loss from continous energy losses, is 
-        estimated by the energy-integral. 
+        The average energy loss from continous energy losses, is
+        estimated by the energy-integral.
 
         .. math::
-        
+
             \int^{E_f}_{E_i} \frac{\sigma(E)}{-f(E)} d\text{E} = -\text{log}(\xi)
 
-        Since probability of a energy loss :math:`e_{lost} < e_{cut}` 
-        at distance is finite, it produce fluctuations in average 
+        Since probability of a energy loss :math:`e_{lost} < e_{cut}`
+        at distance is finite, it produce fluctuations in average
         energy losses.
 
-        This small losses can be added in form of a perturbation from 
+        This small losses can be added in form of a perturbation from
         average energy loss.
 
     )pbdoc")
         .def(py::init<const Utility&, const InterpolationDef>(),
              py::arg("utility"), py::arg("interpolation_def"),
              R"pbdoc(
-                    Initalize a continous randomization calculator. 
-                    This may take some minutes because for all parametrization 
-                    the continous randomization interpolation tables have to be 
+                    Initalize a continous randomization calculator.
+                    This may take some minutes because for all parametrization
+                    the continous randomization interpolation tables have to be
                     build.
 
                     Note:
                         .. math::
-                            
-                            \langle ( \Delta ( \Delta E ) )^2 \rangle = 
-                                \int^{e_\text{cut}}_{e_0} \frac{d\text{E}}{-f(E)} 
+
+                            \langle ( \Delta ( \Delta E ) )^2 \rangle =
+                                \int^{e_\text{cut}}_{e_0} \frac{d\text{E}}{-f(E)}
                                 \left( \int_0^{e_{cut}} e^2 p(e;E) d\text{e} \right)
-                    
+
                     Args:
                         interpolation_def (interpolation_def): specify the number of interpolation points for cont-integral
                         utility (utility): specify the parametrization and energy cuts
@@ -277,32 +277,32 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
              py::arg("initial_energy"), py::arg("final_energy"),
              py::arg("rand"),
              R"pbdoc(
-                    Calculates the stochastical smering of the distribution based on 
-                    the second momentum of the parametrizations, the final and intial 
+                    Calculates the stochastical smering of the distribution based on
+                    the second momentum of the parametrizations, the final and intial
                     energy.
-                    
+
                     Note:
-                        A normal distribution with uppere defined variance will be 
+                        A normal distribution with uppere defined variance will be
                         asumed. The cumulative distibution function has the form:
-                        
+
                         .. math::
-                            
+
                             \text{cdf}(E) = \frac{1}{2} \left(1 + \text{erf} \left(
                                 \frac{E}{ \sqrt{ 2 \sigma^2 } } \right) \right)
-                        
+
                         There will be sampled a deviation form mean energy :math:`a`
-                        between :math:`\text{cdf}(E_\text{i} - E_\text{f})` and 
-                        :math:`\text{cdf}(E_\text{mass} - E_\text{f})` and finaly the 
+                        between :math:`\text{cdf}(E_\text{i} - E_\text{f})` and
+                        :math:`\text{cdf}(E_\text{mass} - E_\text{f})` and finaly the
                         energy updated.
 
                         .. math::
 
                             E_\text{f} = \sigma \cdot a + E_\text{f}
-                    
-                    Args: 
-                        initial_energy (float): energy befor stochastical loss 
-                        final_energy (float): energy after stochastical loss 
-                        rand (float): random number between 0 and 1 
+
+                    Args:
+                        initial_energy (float): energy befor stochastical loss
+                        final_energy (float): energy after stochastical loss
+                        rand (float): random number between 0 and 1
 
                     Returns:
                         float: randomized final energy
@@ -323,20 +323,20 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
     py::class_<Sector::Definition, std::shared_ptr<Sector::Definition>>(
         m, "SectorDefinition",
         R"pbdoc(
-                Sector definition is a container that collects all important 
-                settings for propagation through a sector. There could for 
-                example specify the used cross sections or the energy cut 
+                Sector definition is a container that collects all important
+                settings for propagation through a sector. There could for
+                example specify the used cross sections or the energy cut
                 settings.
 
-                An example for multiple SectorDefinitions is the standard 
+                An example for multiple SectorDefinitions is the standard
                 implementation of propagation. Three sectors are generated,
-                which differ in the energy cut settings, to reduce computing 
-                power without a measurable loss of accuracy. Infront of the 
+                which differ in the energy cut settings, to reduce computing
+                power without a measurable loss of accuracy. Infront of the
                 detector energy cut will be like :math:`v_\text{cut} = 0.05`.
-                Inside the detector the energy cut :math:`e_\text{cut} = 500 
-                \text{MeV}` is chosen so that particles below the detector 
+                Inside the detector the energy cut :math:`e_\text{cut} = 500
+                \text{MeV}` is chosen so that particles below the detector
                 resolution are statistically sampled. Outside of the detector no
-                cuts are made to find a decay point of the particle in first 
+                cuts are made to find a decay point of the particle in first
                 approximation.
             )pbdoc")
         .def(py::init<>())
@@ -357,46 +357,46 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
         .def_readwrite("do_stochastic_loss_weighting",
                        &Sector::Definition::do_stochastic_loss_weighting,
                        R"pbdoc(
-                    Boolean value whether the probability of producing a 
-                    stochastic loss should be adjusted with a factor, 
+                    Boolean value whether the probability of producing a
+                    stochastic loss should be adjusted with a factor,
                     defaults to False.
                 )pbdoc")
         .def_readwrite("stochastic_loss_weighting",
                        &Sector::Definition::stochastic_loss_weighting,
                        R"pbdoc(
-                    Factor used to scale the probability of producing a 
+                    Factor used to scale the probability of producing a
                     stochastic loss, defaults to 1.0.
                 )pbdoc")
         .def_readwrite("stopping_decay", &Sector::Definition::stopping_decay,
                        R"pbdoc(
-                    
+
                 )pbdoc")
         .def_readwrite("do_continuous_randomization",
                        &Sector::Definition::do_continuous_randomization,
                        R"pbdoc(
-                    Boolean if continous randomization should be done if 
+                    Boolean if continous randomization should be done if
                     interpolation if is used, defaults to true.
                 )pbdoc")
         .def_readwrite("do_continuous_energy_loss_output",
                        &Sector::Definition::do_continuous_energy_loss_output,
                        R"pbdoc(
-                    
+
                 )pbdoc")
         .def_readwrite("do_exact_time_calculation",
                        &Sector::Definition::do_exact_time_calculation,
                        R"pbdoc(
-                    Boolean if particle speed could be approach by the speed 
-                    of light or should be calculated by solving the track 
+                    Boolean if particle speed could be approach by the speed
+                    of light or should be calculated by solving the track
                     integral, defaults to false.
 
-                    If the energy is in the order of the rest energy of the 
-                    particle, the assumption that the particle moves at the 
-                    speed of light becomes increasingly worse. Than it make 
+                    If the energy is in the order of the rest energy of the
+                    particle, the assumption that the particle moves at the
+                    speed of light becomes increasingly worse. Than it make
                     sense to calculate the time integral.
 
                     .. math::
-                            
-                            t_\text{f} = t_\text{i} + \int_{x_\text{i}}^{x_\text{f}} 
+
+                            t_\text{f} = t_\text{i} + \int_{x_\text{i}}^{x_\text{f}}
                                 \frac{ \text{dx} }{ v(x) }
                 )pbdoc")
         .def_readwrite("scattering_model",
@@ -413,7 +413,7 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
                 )pbdoc")
         .def_readwrite("particle_location", &Sector::Definition::location,
                        R"pbdoc(
-                    Definition of the relationship of the sectors to each 
+                    Definition of the relationship of the sectors to each
                     other of type :meth:`ParticleLocation`.
                 )pbdoc")
         .def_readwrite("crosssection_defs", &Sector::Definition::utility_def,
@@ -427,7 +427,7 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
     // //
 
     py::class_<Sector, std::shared_ptr<Sector>>(m, "Sector", R"pbdoc(
-            A sector is characterized by its homogeneous attitudes. 
+            A sector is characterized by its homogeneous attitudes.
             Within a sector there are no boundaries to consider.
 		)pbdoc")
         .def(py::init<Particle&, const Sector::Definition&>(),
@@ -438,7 +438,7 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
              py::arg("interpolation_def"))
         .def("propagate", &Sector::Propagate, py::arg("distance"),
              R"pbdoc(
-                Args: 
+                Args:
                     distance (float): Distance to propagate in cm.
 
                 Returns:
@@ -447,21 +447,21 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
         .def("CalculateEnergyTillStochastic",
              &Sector::CalculateEnergyTillStochastic, py::arg("initial_energy"),
              R"pbdoc(
-                Samples the energy up to the next stochastic loss. 
+                Samples the energy up to the next stochastic loss.
 
                 Args:
                     initial_energy (float): Energy in MeV.
 
                 Returns:
-                    tuple: (next stochastic energy, decay energy) 
+                    tuple: (next stochastic energy, decay energy)
 			)pbdoc")
         .def("MakeStochasticLoss", &Sector::MakeStochasticLoss,
              py::arg("particle_energy"),
              R"pbdoc(
                 Samples the stochastic loss.
-			
+
                 Args:
-                    particle_energy (float): Energy of the propagated 
+                    particle_energy (float): Energy of the propagated
                         particle.
 
                 Returns:
@@ -476,7 +476,7 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
         .def_property_readonly("particle", &Sector::GetParticle,
                                R"pbdoc(
 				Get the internal created particle to modify its properties
-				
+
 				Return:
 					Particle: propagated Particle
 			)pbdoc");
@@ -539,9 +539,9 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
                     Returns:
                         list(DynamicData): list of stochastic losses parameters
                         list(list): list of stochastic losses parameters
-                    
+
                     Example:
-                        Propagate 1000 particle with an inital energy of 100 
+                        Propagate 1000 particle with an inital energy of 100
                         Tev and save the losses in daughters.
 
                         >>> for i in range(int(1e3)):
@@ -551,32 +551,32 @@ PYBIND11_MODULE(pyPROPOSAL, m) {
                         >>>   mu.direction = pp.Vector3D(0, 0, -1)
                         >>>   daughters = prop.propagate()
 
-                    Further basic condition are set at the next point of 
+                    Further basic condition are set at the next point of
                     interaction during generation.
                     The aim is to introduce forced stochastic losses
-                    so that the particle can be propagated through homogeneous 
+                    so that the particle can be propagated through homogeneous
                     sectors.
                     A more percise description of propagation through a
                     homoegenous sector can be found in ???.
-                    
+
                     .. figure:: figures/sector.png
                         :height: 200px
                         :align: center
 
-                        If the next interaction point is outside the actuell 
+                        If the next interaction point is outside the actuell
                         sector, the particle is forced to an interaction at the
-                        sector boundary. Thus it can be assumed that the 
+                        sector boundary. Thus it can be assumed that the
                         particle is porpagated by a homogeneous medium.
 
-                    The propagated particle will be forced to interact in the 
-                    closest point to the dector center. 
-                    This will be stored in the closest_approach variable of 
+                    The propagated particle will be forced to interact in the
+                    closest point to the dector center.
+                    This will be stored in the closest_approach variable of
                     the propagated particle.
 
-                    The propagation terminate if the maximal distance is 
+                    The propagation terminate if the maximal distance is
                     reached.
-                    The energy loss of the particle (e_lost) in the detector 
-                    will be calculated and the produced secondary particles 
+                    The energy loss of the particle (e_lost) in the detector
+                    will be calculated and the produced secondary particles
                     returned.
                 )pbdoc")
         .def_property_readonly("particle", &Propagator::GetParticle,

--- a/private/python/scattering.cxx
+++ b/private/python/scattering.cxx
@@ -16,7 +16,35 @@ void init_scattering(py::module& m) {
     py::module m_sub = m.def_submodule("scattering");
 
     py::class_<Scattering, std::shared_ptr<Scattering>>(m_sub, "Scattering")
-        .def("scatter", &Scattering::Scatter)
+        .def("scatter", overload_cast_<double, double, double>()(&Scattering::Scatter),
+                py::arg("dr"), py::arg("e_i"), py::arg("e_f"),
+            R"pbdoc(
+                Calculate a random averaged scatterangle `u` alonge the given
+                displacement`dr` and the particle directions after distance
+                `n_i`.
+
+                Args:
+                    dr(double): displacement of particle
+                    ei(double): inital energy
+                    ef(double): final energy
+            )pbdoc")
+        .def("scatter", overload_cast_<double, double, double, double, double, double, double>()(&Scattering::Scatter),
+                py::arg("dr"), py::arg("e_i"), py::arg("e_f"), py::arg("rnd1"),
+                py::arg("rnd2"), py::arg("rnd3"), py::arg("rnd4"),
+            R"pbdoc(
+                Calculate a averaged scatterangle `u` alonge the given
+                displacement `dr`, the particle directions after distance `n_i`
+                and given random numbers.
+
+                Args:
+                    dr(double): displacement of particle
+                    ei(double): inital energy
+                    ef(double): final energy
+                    rnd1(double): random number (0,1)
+                    rnd2(double): random number (0,1)
+                    rnd3(double): random number (0,1)
+                    rnd4(double): random number (0,1)
+            )pbdoc")
         .def_property_readonly("particle", &Scattering::GetParticle);
 
     py::class_<ScatteringMoliere, std::shared_ptr<ScatteringMoliere>,
@@ -41,4 +69,28 @@ void init_scattering(py::module& m) {
         .value("Moliere", ScatteringFactory::Moliere)
         .value("Highland", ScatteringFactory::Highland)
         .value("NoScattering", ScatteringFactory::NoScattering);
+
+    py::class_<Directions, std::shared_ptr<Directions>>(m_sub, "Directions",
+        R"pbdoc(
+            Container of scatteringangles. It will be differntiated between the
+            averaged angle `u` while continous propagation and the angle after
+            continous propagation `n_\text{i}`.
+
+            For further explanations see Jan-Hendrik Köhne's dissertations at
+            page 46.
+        )pbdoc")
+        .def(py::init<Vector3D, Vector3D>(), py::arg("u"), py::arg("n_i"),
+        R"pbdoc(
+            Args:
+                u(Vector3D): averaged angle
+                n_i(Vector3D): angle after continous loss
+        )pbdoc")
+        .def_readwrite("u", &Directions::u_,
+        R"pbdoc(
+            averaged angle
+        )pbdoc")
+        .def_readwrite("n_i", &Directions::n_i_,
+        R"pbdoc(
+            angle after continous loss
+        )pbdoc");
 }

--- a/public/PROPOSAL/scattering/Scattering.h
+++ b/public/PROPOSAL/scattering/Scattering.h
@@ -51,6 +51,7 @@ public:
     virtual Scattering* clone(Particle&, const Utility&) const = 0; // virtual constructor idiom (used for deep copies)
 
     std::shared_ptr<std::pair<Vector3D, Vector3D>> Scatter(double dr, double ei, double ef);
+    std::shared_ptr<std::pair<Vector3D, Vector3D>> Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
 
     const Particle& GetParticle() const { return particle_; }
 
@@ -65,7 +66,8 @@ protected:
         double sx, sy, tx, ty;
     };
 
-    virtual RandomAngles CalculateRandomAngle(double dr, double ei, double ef) = 0;
+    RandomAngles CalculateRandomAngle(double dr, double ei, double ef);
+    virtual RandomAngles CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4) = 0;
 
     Particle& particle_;
 };

--- a/public/PROPOSAL/scattering/Scattering.h
+++ b/public/PROPOSAL/scattering/Scattering.h
@@ -39,6 +39,7 @@ class Utility;
 
 struct Directions : std::enable_shared_from_this<Directions>
 {
+    Directions() : u_(0,0,0), n_i_(0,0,0) {};
     Directions(Vector3D u, Vector3D n_i) : u_(u), n_i_(n_i) {};
 
     Vector3D u_;
@@ -59,8 +60,8 @@ public:
     virtual Scattering* clone(Particle&, const Utility&) const = 0; // virtual constructor idiom (used for deep copies)
 
 
-    std::shared_ptr<Directions> Scatter(double dr, double ei, double ef);
-    std::shared_ptr<Directions> Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
+    Directions Scatter(double dr, double ei, double ef);
+    Directions Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
 
     const Particle& GetParticle() const { return particle_; }
 
@@ -79,7 +80,6 @@ protected:
     virtual RandomAngles CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4) = 0;
 
     Particle& particle_;
-    Directions directions_;
 };
 
 } // namespace PROPOSAL

--- a/public/PROPOSAL/scattering/Scattering.h
+++ b/public/PROPOSAL/scattering/Scattering.h
@@ -30,12 +30,20 @@
 #pragma once
 #include <utility>
 #include <memory>
+#include "PROPOSAL/math/Vector3D.h"
 
 namespace PROPOSAL {
 
 class Particle;
 class Utility;
-class Vector3D;
+
+struct Directions : std::enable_shared_from_this<Directions>
+{
+    Directions(Vector3D u, Vector3D n_i) : u_(u), n_i_(n_i) {};
+
+    Vector3D u_;
+    Vector3D n_i_;
+};
 
 class Scattering
 {
@@ -50,8 +58,9 @@ public:
     virtual Scattering* clone() const                          = 0; // virtual constructor idiom (used for deep copies)
     virtual Scattering* clone(Particle&, const Utility&) const = 0; // virtual constructor idiom (used for deep copies)
 
-    std::shared_ptr<std::pair<Vector3D, Vector3D>> Scatter(double dr, double ei, double ef);
-    std::shared_ptr<std::pair<Vector3D, Vector3D>> Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
+
+    std::shared_ptr<Directions> Scatter(double dr, double ei, double ef);
+    std::shared_ptr<Directions> Scatter(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
 
     const Particle& GetParticle() const { return particle_; }
 
@@ -70,6 +79,7 @@ protected:
     virtual RandomAngles CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4) = 0;
 
     Particle& particle_;
+    Directions directions_;
 };
 
 } // namespace PROPOSAL

--- a/public/PROPOSAL/scattering/Scattering.h
+++ b/public/PROPOSAL/scattering/Scattering.h
@@ -29,6 +29,7 @@
 
 #pragma once
 #include <utility>
+#include <memory>
 
 namespace PROPOSAL {
 
@@ -49,7 +50,7 @@ public:
     virtual Scattering* clone() const                          = 0; // virtual constructor idiom (used for deep copies)
     virtual Scattering* clone(Particle&, const Utility&) const = 0; // virtual constructor idiom (used for deep copies)
 
-    std::pair<Vector3D, Vector3D> Scatter(double dr, double ei, double ef);
+    std::shared_ptr<std::pair<Vector3D, Vector3D>> Scatter(double dr, double ei, double ef);
 
     const Particle& GetParticle() const { return particle_; }
 

--- a/public/PROPOSAL/scattering/Scattering.h
+++ b/public/PROPOSAL/scattering/Scattering.h
@@ -28,11 +28,13 @@
 
 
 #pragma once
+#include <utility>
 
 namespace PROPOSAL {
 
 class Particle;
 class Utility;
+class Vector3D;
 
 class Scattering
 {
@@ -47,7 +49,7 @@ public:
     virtual Scattering* clone() const                          = 0; // virtual constructor idiom (used for deep copies)
     virtual Scattering* clone(Particle&, const Utility&) const = 0; // virtual constructor idiom (used for deep copies)
 
-    void Scatter(double dr, double ei, double ef);
+    std::pair<Vector3D, Vector3D> Scatter(double dr, double ei, double ef);
 
     const Particle& GetParticle() const { return particle_; }
 

--- a/public/PROPOSAL/scattering/ScatteringHighland.h
+++ b/public/PROPOSAL/scattering/ScatteringHighland.h
@@ -60,7 +60,7 @@ private:
 
     bool compare(const Scattering&) const;
 
-    RandomAngles CalculateRandomAngle(double dr, double ei, double ef);
+    RandomAngles CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
     double CalculateTheta0(double dr);
 
     const Medium* medium_;

--- a/public/PROPOSAL/scattering/ScatteringHighlandIntegral.h
+++ b/public/PROPOSAL/scattering/ScatteringHighlandIntegral.h
@@ -63,7 +63,7 @@ private:
 
     bool compare(const Scattering&) const;
 
-    RandomAngles CalculateRandomAngle(double dr, double ei, double ef);
+    RandomAngles CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
     long double CalculateTheta0(double dr, double ei, double ef);
 
     UtilityDecorator* scatter_;

--- a/public/PROPOSAL/scattering/ScatteringMoliere.h
+++ b/public/PROPOSAL/scattering/ScatteringMoliere.h
@@ -58,7 +58,7 @@ private:
 
     bool compare(const Scattering&) const;
 
-    RandomAngles CalculateRandomAngle(double dr, double ei, double ef);
+    RandomAngles CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
 
     const Medium* medium_;
 
@@ -89,6 +89,6 @@ private:
     //----------------------------------------------------------------------------//
     //----------------------------------------------------------------------------//
 
-    double GetRandom(double pre_factor);
+    double GetRandom(double pre_factor, double rnd);
 };
 } // namespace PROPOSAL

--- a/public/PROPOSAL/scattering/ScatteringNoScattering.h
+++ b/public/PROPOSAL/scattering/ScatteringNoScattering.h
@@ -60,7 +60,7 @@ private:
 
     bool compare(const Scattering&) const;
 
-    RandomAngles CalculateRandomAngle(double dr, double ei, double ef);
+    RandomAngles CalculateRandomAngle(double dr, double ei, double ef, double rnd1, double rnd2, double rnd3, double rnd4);
 
     const Medium* medium_;
 };

--- a/public/python/pyBindings.h
+++ b/public/python/pyBindings.h
@@ -14,3 +14,6 @@ std::string py_print(const T& t) {
     ss << t;
     return ss.str();
 }
+
+template <typename... Args>
+using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -200,9 +200,9 @@ TEST(Scattering, Scatter)
             particle.SetPosition(position_init);
             particle.SetDirection(direction_init);
 
-            std::pair<Vector3D, Vector3D> directions = scattering->Scatter(distance, energy_init, energy_final);
-            particle.SetPosition(particle.GetPosition() + distance * directions.first);
-            particle.SetDirection(directions.second);
+            std::shared_ptr<std::pair<Vector3D, Vector3D>> directions = scattering->Scatter(distance, energy_init, energy_final);
+            particle.SetPosition(particle.GetPosition() + distance * directions->first);
+            particle.SetDirection(directions->second);
 
             ASSERT_NEAR(particle.GetPosition().GetX(), x_f, std::abs(error * x_f));
             ASSERT_NEAR(particle.GetPosition().GetY(), y_f, std::abs(error * y_f));

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -200,9 +200,9 @@ TEST(Scattering, Scatter)
             particle.SetPosition(position_init);
             particle.SetDirection(direction_init);
 
-            std::shared_ptr<Directions> directions = scattering->Scatter(distance, energy_init, energy_final);
-            particle.SetPosition(particle.GetPosition() + distance * directions->u_);
-            particle.SetDirection(directions->n_i_);
+            Directions directions = scattering->Scatter(distance, energy_init, energy_final);
+            particle.SetPosition(particle.GetPosition() + distance * directions.u_);
+            particle.SetDirection(directions.n_i_);
 
             ASSERT_NEAR(particle.GetPosition().GetX(), x_f, std::abs(error * x_f));
             ASSERT_NEAR(particle.GetPosition().GetY(), y_f, std::abs(error * y_f));

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -200,7 +200,9 @@ TEST(Scattering, Scatter)
             particle.SetPosition(position_init);
             particle.SetDirection(direction_init);
 
-            scattering->Scatter(distance, energy_init, energy_final);
+            std::pair<Vector3D, Vector3D> directions = scattering->Scatter(distance, energy_init, energy_final);
+            particle.SetPosition(particle.GetPosition() + distance * directions.first);
+            particle.SetDirection(directions.second);
 
             ASSERT_NEAR(particle.GetPosition().GetX(), x_f, std::abs(error * x_f));
             ASSERT_NEAR(particle.GetPosition().GetY(), y_f, std::abs(error * y_f));

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -200,9 +200,9 @@ TEST(Scattering, Scatter)
             particle.SetPosition(position_init);
             particle.SetDirection(direction_init);
 
-            std::shared_ptr<std::pair<Vector3D, Vector3D>> directions = scattering->Scatter(distance, energy_init, energy_final);
-            particle.SetPosition(particle.GetPosition() + distance * directions->first);
-            particle.SetDirection(directions->second);
+            std::shared_ptr<Directions> directions = scattering->Scatter(distance, energy_init, energy_final);
+            particle.SetPosition(particle.GetPosition() + distance * directions->u_);
+            particle.SetDirection(directions->n_i_);
 
             ASSERT_NEAR(particle.GetPosition().GetX(), x_f, std::abs(error * x_f));
             ASSERT_NEAR(particle.GetPosition().GetY(), y_f, std::abs(error * y_f));


### PR DESCRIPTION
Scattering will now return a pair of averaged scattering direction
and the direction of the particle at the end of propagation step.
In "AdvanceParticle" scattering (direction change) and displacement will
from now on consider separately.

The testfile must be modified, since scattering no longer takes over
the displacement of the particle.