### PR TITLE
Added extra package pmboxdraw to Doxyfile.in

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -820,7 +820,7 @@ PAPER_TYPE             = a4wide
 # The EXTRA_PACKAGES tag can be to specify one or more names of LaTeX 
 # packages that should be included in the LaTeX output.
 
-EXTRA_PACKAGES         = 
+EXTRA_PACKAGES         = pmboxdraw
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for 
 # the generated latex document. The header should contain everything until 


### PR DESCRIPTION
The documentation uses Unicode box-drawing characters not set up for use with LaTeX. Using the package pmboxdraw solves this problem.