### PR TITLE
Fix for import ParticleDef error for newer pyBindings Version.  #43

### DIFF
--- a/private/Interface/python/particle.cxx
+++ b/private/Interface/python/particle.cxx
@@ -5,11 +5,9 @@
 #include "PROPOSAL/Secondaries.h"
 #include "pyBindings.h"
 
-#define PARTICLE_DEF(module, cls)                                           \
-    py::class_<cls##Def, ParticleDef,                                       \
-               std::unique_ptr<cls##Def, py::nodelete>>(module, #cls "Def") \
-        .def_static("get", &cls##Def::Get,                                  \
-                    py::return_value_policy::reference);
+#define PARTICLE_DEF(module, cls)                                                    \
+    py::class_<cls##Def, ParticleDef, std::shared_ptr<cls##Def>>(module, #cls "Def") \
+        .def(py::init<>());                                                          \
 
 namespace py = pybind11;
 using namespace PROPOSAL;
@@ -90,7 +88,7 @@ void init_particle(py::module& m) {
                       R"pbdoc(
                 particle type of the weak partner particle
             )pbdoc")
-        // .def_readonly("harc_component_table",
+        // .def_readonly("hard_component_table",
         // &ParticleDef::hard_component_table)
         // .add_property("hard_component_table",
         // make_function(&get_hard_component, return_internal_reference<>()))

--- a/public/PROPOSAL/particle/ParticleDef.h
+++ b/public/PROPOSAL/particle/ParticleDef.h
@@ -45,7 +45,6 @@
             return instance;                                                                                           \
         }                                                                                                              \
                                                                                                                        \
-    private:                                                                                                           \
         cls##Def();                                                                                                    \
         ~cls##Def();                                                                                                   \
     };


### PR DESCRIPTION
Singelton is replaced by normal constructor.
Singletone was prone to mutex locks when parallel processing.
Casting between shared and unique pointer vice versa is not supported by pybind.