### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-tests/TestFiles.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmake_uninstall.cmake
 *.png
 *.pdf
 *.swp
+tests/TestFiles.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ before_install:
 install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade; brew install cmake; fi
 before_script:
+- curl https://proposal.app.tu-dortmund.de/resources/2020-02-26/TestFiles.tar.gz --output tests/TestFiles.tar.gz
 - mkdir build
 - cd build
 - cmake .. -DADD_TESTS=ON -DADD_PYTHON=OFF

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,8 +12,7 @@ release tar balls.
 ```
 $ apt install g++ \
   cmake \
-  doxygen \
-  git-lfs
+  doxygen
 ```
 
 ### Arch Linux
@@ -21,8 +20,7 @@ $ apt install g++ \
 ```
 $ pacman -S g++ \
   cmake \
-  doxygen \
-  git-lfs
+  doxygen
 ```
 
 ### RHEL / Centos
@@ -32,7 +30,7 @@ called `cmake3`.
 PROPOSAL needs cmake3.
 
 ```
-$ yum install g++ cmake3 doxygen git-lfs
+$ yum install g++ cmake3 doxygen
 ```
 
 ### MacOS
@@ -40,8 +38,7 @@ $ yum install g++ cmake3 doxygen git-lfs
 ```
 $ xcode-select --install
 $ brew install cmake \
-  doxygen \
-  git-lfs
+  doxygen
 ```
 
 ## Building PROPOSAL
@@ -54,11 +51,9 @@ $ brew install cmake \
 
   To use a specific version of PROPOSAL, use `git checkout vX.Y.Z` after cloning.
 
-  In case you want to perform the unit tests, you need install `git-lfs` first and do an extra pull to get the TestFiles.
-  This is only possible with a git checkout.
-
+  In case you want to perform the unit tests, you need to download the TestFiles.
   ```
-  $ git lfs pull
+  $ curl https://proposal.app.tu-dortmund.de/resources/2020-02-26/TestFiles.tar.gz --output tests/TestFiles.tar.gz
   ```
 
 1.  Move to the build directory and generate the Makefile with cmake:

--- a/tests/TestFiles.tar.gz
+++ b/tests/TestFiles.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a0dc90ae76c2e3d652e6c1be0a8472485f843883f12ceb77e787b56d8557379
-size 2553956


### PR DESCRIPTION
as the quota of git lfs is exceeded, every pull crashes