### PR TITLE
Make tests fail when files not found

### DIFF
--- a/tests/Annihilation_TEST.cxx
+++ b/tests/Annihilation_TEST.cxx
@@ -134,16 +134,12 @@ EXPECT_TRUE(AnniInterpol_A == AnniInterpol_B);
 
 
 
-TEST(Annihilation, Test_of_dNdx)
-{
-std::ifstream in;
-std::string filename = "bin/TestFiles/Anni_dNdx.txt";
-in.open(filename.c_str());
+TEST(Annihilation, Test_of_dNdx) {
 
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::string filename = "bin/TestFiles/Anni_dNdx.txt"; 
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
+
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -179,14 +175,9 @@ delete anni;
 
 TEST(Annihilation, Test_of_dNdx_rnd)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Anni_dNdx_rnd.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -226,14 +217,9 @@ delete anni;
 
 TEST(Annihilation, Test_Stochastic_Loss)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Anni_e.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -277,14 +263,9 @@ delete anni;
 
 TEST(Annihilation, Test_of_dNdx_Interpolant)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Anni_dNdx_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -323,14 +304,9 @@ delete anni;
 
 TEST(Annihilation, Test_of_dNdxrnd_interpol)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Anni_dNdx_rnd_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -372,14 +348,9 @@ delete anni;
 
 TEST(Annihilation, Test_of_e_interpol)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Anni_e_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);

--- a/tests/Bremsstrahlung_TEST.cxx
+++ b/tests/Bremsstrahlung_TEST.cxx
@@ -159,14 +159,9 @@ TEST(Assignment, Copyconstructor2)
 
 TEST(Bremsstrahlung, Test_of_dEdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_dEdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -212,14 +207,9 @@ TEST(Bremsstrahlung, Test_of_dEdx)
 
 TEST(Bremsstrahlung, Test_of_dNdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_dNdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -265,14 +255,9 @@ TEST(Bremsstrahlung, Test_of_dNdx)
 
 TEST(Bremsstrahlung, Test_of_dNdx_rnd)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_dNdx_rnd.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -321,14 +306,9 @@ TEST(Bremsstrahlung, Test_of_dNdx_rnd)
 
 TEST(Bremsstrahlung, Test_of_e)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_e.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -377,14 +357,9 @@ TEST(Bremsstrahlung, Test_of_e)
 
 TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_dEdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -431,14 +406,10 @@ TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
 
 TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_dNdx_interpol.txt";
-    in.open(filename.c_str());
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
 
     std::string particleName;
     std::string mediumName;
@@ -482,14 +453,10 @@ TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 
 TEST(Bremsstrahlung, Test_of_dNdx_rnd_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_dNdx_rnd_interpol.txt";
-    in.open(filename.c_str());
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -539,14 +506,10 @@ TEST(Bremsstrahlung, Test_of_dNdx_rnd_Interpolant)
 
 TEST(Bremsstrahlung, Test_of_e_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Brems_e_interpol.txt";
-    in.open(filename.c_str());
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
 
     char firstLine[256];
     in.getline(firstLine, 256);

--- a/tests/Compton_TEST.cxx
+++ b/tests/Compton_TEST.cxx
@@ -116,14 +116,9 @@ EXPECT_TRUE(Interpol_A == Interpol_B);
 
 TEST(Compton, Test_of_dEdx)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_dEdx.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -166,14 +161,9 @@ delete Compton;
 
 TEST(Compton, Test_of_dNdx)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_dNdx.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -216,14 +206,9 @@ delete Compton;
 
 TEST(Compton, Test_of_dNdx_rnd)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_dNdx_rnd.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -269,14 +254,9 @@ delete Compton;
 
 TEST(Compton, Test_of_e)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_e.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -322,14 +302,9 @@ delete Compton;
 
 TEST(Compton, Test_of_dEdx_Interpolant)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_dEdx_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -373,14 +348,9 @@ delete Compton;
 
 TEST(Compton, Test_of_dNdx_Interpolant)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_dNdx_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 std::string mediumName;
 double ecut;
@@ -420,14 +390,9 @@ delete Compton;
 
 TEST(Compton, Test_of_dNdx_rnd_Interpolant)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_dNdx_rnd_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -473,14 +438,9 @@ delete Compton;
 
 TEST(Compton, Test_of_e_Interpolant)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Compton_e_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);

--- a/tests/ContinuousRandomization_TEST.cxx
+++ b/tests/ContinuousRandomization_TEST.cxx
@@ -95,13 +95,10 @@ TEST_F(Test_Utilities, Copyconstructor2) {
 }
 
 TEST(ContinuousRandomization, Randomize_interpol) {
-    std::ifstream in;
     std::string filename = "bin/TestFiles/continous_randomization.txt";
-    in.open(filename.c_str());
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
-    if (!in.good()) {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
 
     char firstLine[256];
     in.getline(firstLine, 256);

--- a/tests/DecayChannel_TEST.cxx
+++ b/tests/DecayChannel_TEST.cxx
@@ -135,14 +135,9 @@ TEST(Assignment, Copyconstructor)
 }
 
 TEST(DecaySpectrum, MuMinus_Rest){
-    std::ifstream in;
     std::string filename = testfile_dir + "Decay_MuMinus_rest.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     int statistic = 1e6;
     int NUM_bins = 50;
@@ -336,14 +331,9 @@ TEST(DecaySpectrum, MuMinus_Rest){
 }
 
 TEST(DecaySpectrum, MuMinus_Energy){
-    std::ifstream in;
     std::string filename = testfile_dir + "Decay_MuMinus_energy.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     int statistic = 1e6;
     int NUM_bins = 50;
@@ -539,14 +529,9 @@ TEST(DecaySpectrum, MuMinus_Energy){
 }
 
 TEST(DecaySpectrum, TauMinus_Rest){
-    std::ifstream in;
     std::string filename = testfile_dir + "Decay_TauMinus_rest.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     int statistic = 1e6;
     int NUM_bins = 50;
@@ -741,14 +726,9 @@ TEST(DecaySpectrum, TauMinus_Rest){
 
 
 TEST(DecaySpectrum, TauMinus_energy){
-    std::ifstream in;
     std::string filename = testfile_dir + "Decay_TauMinus_energy.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     int statistic = 1e6;
     int NUM_bins = 50;

--- a/tests/Epairproduction_TEST.cxx
+++ b/tests/Epairproduction_TEST.cxx
@@ -177,14 +177,9 @@ TEST(Assignment, Copyconstructor2)
 
 TEST(Epairproduction, Test_of_dEdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_dEdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -225,14 +220,9 @@ TEST(Epairproduction, Test_of_dEdx)
 
 TEST(Epairproduction, Test_of_dNdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_dNdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -273,14 +263,9 @@ TEST(Epairproduction, Test_of_dNdx)
 
 TEST(Epairproduction, Test_of_dNdx_rnd)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_dNdx_rnd.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -325,14 +310,9 @@ TEST(Epairproduction, Test_of_dNdx_rnd)
 
 TEST(Epairproduction, Test_Stochastic_Loss)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_e.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -380,14 +360,9 @@ TEST(Epairproduction, Test_Stochastic_Loss)
 
 TEST(Epairproduction, Test_of_dEdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_dEdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -431,14 +406,9 @@ TEST(Epairproduction, Test_of_dEdx_Interpolant)
 
 TEST(Epairproduction, Test_of_dNdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_dNdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -482,14 +452,9 @@ TEST(Epairproduction, Test_of_dNdx_Interpolant)
 
 TEST(Epairproduction, Test_of_dNdxrnd_interpol)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_dNdx_rnd_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -536,14 +501,9 @@ TEST(Epairproduction, Test_of_dNdxrnd_interpol)
 
 TEST(Epairproduction, Test_of_e_interpol)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Epair_e_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);

--- a/tests/Ionization_TEST.cxx
+++ b/tests/Ionization_TEST.cxx
@@ -137,14 +137,9 @@ TEST(Assignment, Copyconstructor2)
 
 TEST(Ionization, Test_of_dEdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_dEdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -183,14 +178,9 @@ TEST(Ionization, Test_of_dEdx)
 
 TEST(Ionization, Test_of_dNdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_dNdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -229,14 +219,9 @@ TEST(Ionization, Test_of_dNdx)
 
 TEST(Ionization, Test_of_dNdx_rnd)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_dNdx_rnd.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -279,14 +264,9 @@ TEST(Ionization, Test_of_dNdx_rnd)
 
 TEST(Ionization, Test_Stochastic_Loss)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_e.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -329,14 +309,9 @@ TEST(Ionization, Test_Stochastic_Loss)
 
 TEST(Ionization, Test_of_dEdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_dEdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -378,14 +353,9 @@ TEST(Ionization, Test_of_dEdx_Interpolant)
 
 TEST(Ionization, Test_of_dNdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_dNdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -427,14 +397,9 @@ TEST(Ionization, Test_of_dNdx_Interpolant)
 
 TEST(Ionization, Test_of_dNdxrnd_interpol)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_dNdx_rnd_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);
@@ -480,14 +445,9 @@ TEST(Ionization, Test_of_dNdxrnd_interpol)
 
 TEST(Ionization, Test_of_e_interpol)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Ioniz_e_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     char firstLine[256];
     in.getline(firstLine, 256);

--- a/tests/Mupairproduction_TEST.cxx
+++ b/tests/Mupairproduction_TEST.cxx
@@ -172,14 +172,9 @@ EXPECT_TRUE(Interpol_A == Interpol_B);
 
 TEST(Mupairproduction, Test_of_dEdx)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_dEdx.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -218,14 +213,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_of_dNdx)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_dNdx.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -264,14 +254,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_of_dNdx_rnd)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_dNdx_rnd.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -314,14 +299,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_Stochastic_Loss)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_e.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -367,14 +347,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_Calculate_Rho)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_rho.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -429,14 +404,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_of_dEdx_Interpolant)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_dEdx_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -478,14 +448,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_of_dNdx_Interpolant)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_dNdx_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -527,14 +492,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_of_dNdxrnd_interpol)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_dNdx_rnd_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -579,14 +539,9 @@ delete mupair;
 
 TEST(Mupairproduction, Test_of_e_interpol)
 {
-std::ifstream in;
 std::string filename = testfile_dir + "Mupair_e_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);

--- a/tests/PhotoPair_TEST.cxx
+++ b/tests/PhotoPair_TEST.cxx
@@ -195,14 +195,9 @@ EXPECT_TRUE(PhotoAngle_E == PhotoAngle_F);
 
 TEST(PhotoPair, Test_of_dNdx)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/PhotoPair_dNdx.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -239,14 +234,9 @@ delete photopair;
 
 TEST(PhotoPair, Test_of_dNdx_rnd)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/PhotoPair_dNdx_rnd.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -287,14 +277,9 @@ delete photopair;
 
 TEST(PhotoPair, Test_of_dNdx_Interpolant)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/PhotoPair_dNdx_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -334,14 +319,9 @@ delete photopair;
 
 TEST(PhotoPair, Test_of_dNdxrnd_interpol)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/PhotoPair_dNdx_rnd_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);

--- a/tests/Photonuclear_TEST.cxx
+++ b/tests/Photonuclear_TEST.cxx
@@ -242,14 +242,9 @@ TEST(Assignment, Copyconstructor2)
 
 TEST(PhotoRealPhotonAssumption, Test_of_dEdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Real_dEdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -291,14 +286,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx)
 
 TEST(PhotoRealPhotonAssumption, Test_of_dNdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Real_dNdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -340,14 +330,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx)
 
 TEST(PhotoRealPhotonAssumption, Test_of_dNdx_rnd)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Real_dNdx_rnd.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -390,14 +375,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_rnd)
 
 TEST(PhotoRealPhotonAssumption, Test_of_e)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Real_e.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -440,14 +420,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_e)
 
 TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Real_dEdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -491,14 +466,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
 
 TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Real_dNdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -542,14 +512,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
 
 TEST(PhotoRealPhotonAssumption, Test_of_dNdx_rnd_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Real_dNdx_rnd_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -594,14 +559,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_rnd_Interpolant)
 
 TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_e_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -648,14 +608,9 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 
 TEST(PhotoQ2Integration, Test_of_dEdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_dEdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -697,14 +652,9 @@ TEST(PhotoQ2Integration, Test_of_dEdx)
 
 TEST(PhotoQ2Integration, Test_of_dNdx)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_dNdx.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -746,14 +696,9 @@ TEST(PhotoQ2Integration, Test_of_dNdx)
 
 TEST(PhotoQ2Integration, Test_of_dNdx_rnd)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_dNdx_rnd.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -796,14 +741,9 @@ TEST(PhotoQ2Integration, Test_of_dNdx_rnd)
 
 TEST(PhotoQ2Integration, Test_of_e)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_e.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -846,14 +786,9 @@ TEST(PhotoQ2Integration, Test_of_e)
 
 TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_dEdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -897,14 +832,9 @@ TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
 
 TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_dNdx_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -948,14 +878,9 @@ TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
 
 TEST(PhotoQ2Integration, Test_of_dNdx_rnd_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_dNdx_rnd_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;
@@ -1000,14 +925,9 @@ TEST(PhotoQ2Integration, Test_of_dNdx_rnd_Interpolant)
 
 TEST(PhotoQ2Integration, Test_of_e_Interpolant)
 {
-    std::ifstream in;
     std::string filename = testfile_dir + "Photo_Q2_e_interpol.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;

--- a/tests/Propagation_TEST.cxx
+++ b/tests/Propagation_TEST.cxx
@@ -178,14 +178,9 @@ TEST(Propagation, Test_nan)
 
 TEST(Propagation, particle_type)
 {
-    std::ifstream in;
     std::string filename = "bin/TestFiles/Propagator_propagation.txt";
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     // Just skip the header
     char firstLine[256];

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -130,15 +130,9 @@ TEST(Assignment, Copyconstructor2)
 
 TEST(Scattering, Scatter)
 {
-    std::ifstream in;
     std::string filename = "bin/TestFiles/Scattering_scatter.txt";
-
-    in.open(filename.c_str());
-
-    if (!in.good())
-    {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::string particleName;
     std::string mediumName;

--- a/tests/Sector_TEST.cxx
+++ b/tests/Sector_TEST.cxx
@@ -148,13 +148,9 @@ TEST(Assignment, Copyconstructor2)
 
 TEST(Sector, Continuous)
 {
-    std::ifstream in;
     std::string filename = "bin/TestFiles/Sector_ContinousLoss.txt";
-    in.open(filename.c_str());
-
-    if (!in.good()) {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::cout.precision(16);
     RandomGenerator::Get().SetSeed(1234);
@@ -206,13 +202,9 @@ TEST(Sector, Continuous)
 
 TEST(Sector, Stochastic)
 {
-    std::ifstream in;
     std::string filename = "bin/TestFiles/Sector_StochasticLoss.txt";
-    in.open(filename.c_str());
-
-    if (!in.good()) {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::cout.precision(16);
     RandomGenerator::Get().SetSeed(1234);
@@ -264,13 +256,9 @@ TEST(Sector, Stochastic)
 
 TEST(Sector, EnergyDisplacement)
 {
-    std::ifstream in;
     std::string filename = "bin/TestFiles/Sector_Energy_Distance.txt";
-    in.open(filename.c_str());
-
-    if (!in.good()) {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::cout.precision(16);
     RandomGenerator::Get().SetSeed(1234);
@@ -317,13 +305,9 @@ TEST(Sector, EnergyDisplacement)
 
 TEST(Sector, Propagate)
 {
-    std::ifstream in;
     std::string filename = "bin/TestFiles/Sector_Propagate.txt";
-    in.open(filename.c_str());
-
-    if (!in.good()) {
-        std::cerr << "File \"" << filename << "\" not found" << std::endl;
-    }
+	std::ifstream in{filename};
+	EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
     std::cout.precision(16);
     RandomGenerator::Get().SetSeed(1234);

--- a/tests/WeakInteraction_TEST.cxx
+++ b/tests/WeakInteraction_TEST.cxx
@@ -168,14 +168,9 @@ EXPECT_TRUE(WeakInterpol_A == WeakInterpol_B);
 
 TEST(WeakInteraction, Test_of_dNdx)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Weak_dNdx.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -211,14 +206,9 @@ delete weak;
 
 TEST(WeakInteraction, Test_of_dNdx_rnd)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Weak_dNdx_rnd.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -258,14 +248,9 @@ delete weak;
 
 TEST(WeakInteraction, Test_Stochastic_Loss)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Weak_e.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -309,14 +294,9 @@ delete weak;
 
 TEST(WeakInteraction, Test_of_dNdx_Interpolant)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Weak_dNdx_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -355,14 +335,9 @@ delete weak;
 
 TEST(WeakInteraction, Test_of_dNdxrnd_interpol)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Weak_dNdx_rnd_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);
@@ -404,14 +379,9 @@ delete weak;
 
 TEST(WeakInteraction, Test_of_e_interpol)
 {
-std::ifstream in;
 std::string filename = "bin/TestFiles/Weak_e_interpol.txt";
-in.open(filename.c_str());
-
-if (!in.good())
-{
-std::cerr << "File \"" << filename << "\" not found" << std::endl;
-}
+std::ifstream in{filename};
+EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 
 char firstLine[256];
 in.getline(firstLine, 256);


### PR DESCRIPTION
Some tests on travis #68 here passed although the input files were not found.

This provides a clear error with a nice error message  when the input files could not be found.