### PR TITLE
remove clang warnings in medium

### DIFF
--- a/private/Interface/python/medium.cxx
+++ b/private/Interface/python/medium.cxx
@@ -80,8 +80,6 @@ void init_medium(py::module& m) {
                                R"pbdoc(Ratio of atomic and mass number.)pbdoc")
         .def_property_readonly("ionization_potential", &Medium::GetI,
                                R"pbdoc(Ionization potential in [eV])pbdoc")
-        .def_property_readonly("refraction_index", &Medium::GetR,
-                               R"pbdoc(Refraction index of the medium.)pbdoc")
         .def_property_readonly(
             "radiation_length",
             (double (Medium::*)() const) & Medium::GetRadiationLength,

--- a/private/Interface/python/medium.cxx
+++ b/private/Interface/python/medium.cxx
@@ -24,9 +24,9 @@ void init_medium(py::module& m) {
 
     m_sub.doc() = R"pbdoc(
             A medium is a object which contains serveral physical constants
-            about the material. Media are constant objects and can not be 
-            modified once there are initalized, with the exception of their 
-            density distribution. There are several preimplemented media. 
+            about the material. Media are constant objects and can not be
+            modified once there are initalized, with the exception of their
+            density distribution. There are several preimplemented media.
 
             +------------+------+----------+------------------+--------------------+
             | Water      | Ice  | Salt     | CalciumCarbonate | StandardRock       |
@@ -40,26 +40,26 @@ void init_medium(py::module& m) {
             is the possibility to create inhomogen densities as listed below.
             Split densities are faster than multiple sectors and are therefore
             recommended when using different density profiles.
-            
+
             +---------------------+--------------------+-----------------+
             | Density_exponential | Density_polynomial | Density_splines |
             +---------------------+--------------------+-----------------+
 
             There is currently an issue in the calculation of the LPM effect.
-            The calculation of the LPM effect depends on the 
-            bremsstrahlungcrosssection which again depends on the depth. 
-            When generating the interpolation table, the depth is assumed to 
+            The calculation of the LPM effect depends on the
+            bremsstrahlungcrosssection which again depends on the depth.
+            When generating the interpolation table, the depth is assumed to
             be constant.
             )pbdoc";
 
     py::class_<Medium, std::shared_ptr<Medium>>(m_sub, "Medium", R"pbdoc(
 			Each Medium is a container of physical constants. There are several
-			preimplemented media. They can be scaled by a correction factor if 
-			a homogen density is used. Otherwise the density_correction take 
+			preimplemented media. They can be scaled by a correction factor if
+			a homogen density is used. Otherwise the density_correction take
 			care of scaling tasks.
 
             Example:
-				Creating a homogeneous air medium with a linear correction 
+				Creating a homogeneous air medium with a linear correction
 				factor.
 
 				>>> correction_factor = 0.9
@@ -70,7 +70,7 @@ void init_medium(py::module& m) {
         .def(py::init<
                  std::string, double, double, double, double, double, double,
                  double, double, double,
-                 const std::vector<std::shared_ptr<Components::Component>>&>(),
+                 const std::vector<Components::Component>&>(),
              py::arg("name"), py::arg("rho"), py::arg("I"), py::arg("C"),
              py::arg("a"), py::arg("m"), py::arg("X0"), py::arg("X1"),
              py::arg("d0"), py::arg("massDensity"), py::arg("components"))
@@ -105,7 +105,7 @@ void init_medium(py::module& m) {
             R"pbdoc(List of components preserved in the medium.)pbdoc")
         .def_property_readonly(
             "name", &Medium::GetName,
-            R"pbdoc(Internal name of the particle. Should be unique to prevent 
+            R"pbdoc(Internal name of the particle. Should be unique to prevent
 				undefined behaviour.)pbdoc")
         .def_property("density_distribution", &Medium::GetDensityDistribution,
                       &Medium::SetDensityDistribution,
@@ -129,24 +129,24 @@ void init_medium(py::module& m) {
 
     py::class_<Density_distr, std::shared_ptr<Density_distr>>(
         m_sub, "density_distribution", R"pbdoc(
-		Density dirstribution is a factor for the medium dependend of the place 
-		of the particle.  There has to be an axis :math:`\vec{a}` , a reference 
-		point :math:`\vec{r}_p` and a function :math:`\rho` to calculate the 
+		Density dirstribution is a factor for the medium dependend of the place
+		of the particle.  There has to be an axis :math:`\vec{a}` , a reference
+		point :math:`\vec{r}_p` and a function :math:`\rho` to calculate the
 		density correction.
-		
+
 		Note:
 			Partical locations :math:`\vec{x}` will be written in dependent of
-			propagated distance :math:`l` along particle direction 
+			propagated distance :math:`l` along particle direction
 			:math:`\vec{d}` since last interaction point :math:`\vec{x}_r` and.
 
 			.. math::
 
 				\vec{x} = \vec{x}_i + l \cdot \vec{d}
 
-		Density function will be evaluated at the projection of the particle 
- 		position onto the density axis. If corrected displacement is in the 
-		dector, it will be returned, otherwise a failure will be raised and 
-		catched by the sector class to propagate the particle continously to 
+		Density function will be evaluated at the projection of the particle
+ 		position onto the density axis. If corrected displacement is in the
+		dector, it will be returned, otherwise a failure will be raised and
+		catched by the sector class to propagate the particle continously to
 		the sector border.
 
             )pbdoc")
@@ -154,14 +154,14 @@ void init_medium(py::module& m) {
              py::arg("direction"), py::arg("displacement"),
              py::arg("distance_to_border"),
              R"pbdoc(
-			Calculate displacemet :math:`l` equivalent by inverting the equation 
-			below. The left hand side represent the displacement in reference 
+			Calculate displacemet :math:`l` equivalent by inverting the equation
+			below. The left hand side represent the displacement in reference
 			medium which will be translated with density correction.
 
 			.. math::
 				\int_{E_i}^{E_r} \frac{1}{f(E)} dE= \int^{\vec{x}_i + l}_{\vec{x}_i} \rho(\vec{a} \vec{x}) dx
-			
-			If inverting the integral is not possible the newton method will 
+
+			If inverting the integral is not possible the newton method will
 			be used. When the displacement equivalent is outside the sector an
 			error will be raised, because it imply undefined behaviour.
 
@@ -191,14 +191,14 @@ void init_medium(py::module& m) {
         .def("calculate", &Density_distr::Calculate, py::arg("xi"),
              py::arg("direction"), py::arg("displacement"),
              R"pbdoc(
-			The depth will be calculated. Therefore, the dense integral is 
-			solved from the last interaction point to the next interaction 
+			The depth will be calculated. Therefore, the dense integral is
+			solved from the last interaction point to the next interaction
 			point.
 
 			.. math::
 				\int^{\vec{x}_i + l \cdot \vec{d}}_{\vec{x}_i} \rho(\vec{a} \vec{x}) dx
-			
-			Is equivalent to the correction factor to consider density 
+
+			Is equivalent to the correction factor to consider density
 			distribution for this place.
 
 			Parameters:
@@ -207,7 +207,7 @@ void init_medium(py::module& m) {
 				displacement (float): distance since last stochastical loss
 
 			Return:
-				float: density correction 
+				float: density correction
             )pbdoc");
 
     py::class_<Density_homogeneous, Density_distr,

--- a/private/PROPOSAL/crossection/CrossSectionInterpolant.cxx
+++ b/private/PROPOSAL/crossection/CrossSectionInterpolant.cxx
@@ -208,7 +208,7 @@ double CrossSectionInterpolant::CalculatedNdx(double energy)
 
     sum_of_rates_ = 0;
 
-    const ComponentVec& components = parametrization_->GetMedium()->GetComponents();
+    const auto& components = parametrization_->GetMedium()->GetComponents();
     for (size_t i = 0; i < components.size(); ++i)
     {
         prob_for_component_[i] = std::max(dndx_interpolant_1d_[i]->Interpolate(energy), 0.);
@@ -232,7 +232,7 @@ double CrossSectionInterpolant::CalculatedNdx(double energy, double rnd)
 
     sum_of_rates_ = 0;
 
-    const ComponentVec& components = parametrization_->GetMedium()->GetComponents();
+    const auto& components = parametrization_->GetMedium()->GetComponents();
     for (size_t i = 0; i < components.size(); ++i)
     {
         prob_for_component_[i] = std::max(dndx_interpolant_1d_[i]->Interpolate(energy), 0.);

--- a/private/PROPOSAL/crossection/IonizIntegral.cxx
+++ b/private/PROPOSAL/crossection/IonizIntegral.cxx
@@ -133,7 +133,7 @@ double IonizIntegral::CalculateStochasticLoss(double energy, double rnd1)
 
     for (unsigned int i = 0; i < components_.size(); i++)
     {
-        rsum += components_[i]->GetAtomInMolecule() * components_[i]->GetNucCharge();
+        rsum += components_[i].GetAtomInMolecule() * components_[i].GetNucCharge();
 
         if (rsum > rnd)
         {

--- a/private/PROPOSAL/crossection/IonizInterpolant.cxx
+++ b/private/PROPOSAL/crossection/IonizInterpolant.cxx
@@ -233,7 +233,7 @@ double IonizInterpolant::CalculateStochasticLoss(double energy, double rnd1)
 
     for (unsigned int i = 0; i < components_.size(); i++)
     {
-        rsum += components_[i]->GetAtomInMolecule() * components_[i]->GetNucCharge();
+        rsum += components_[i].GetAtomInMolecule() * components_[i].GetNucCharge();
 
         if (rsum > rnd)
         {

--- a/private/PROPOSAL/crossection/parametrization/Bremsstrahlung.cxx
+++ b/private/PROPOSAL/crossection/parametrization/Bremsstrahlung.cxx
@@ -100,7 +100,7 @@ double Bremsstrahlung::DifferentialCrossSection(double energy, double v)
     result = CalculateParametrization(energy, v);
 
     aux = 2 * particle_def_.charge * particle_def_.charge * (ME / particle_def_.mass) * RE *
-          components_[component_index_]->GetNucCharge();
+          components_[component_index_].GetNucCharge();
     aux *= aux * (ALPHA / v) * result;
 
     if (lpm_)
@@ -108,7 +108,7 @@ double Bremsstrahlung::DifferentialCrossSection(double energy, double v)
         aux *= lpm(energy, v);
     }
 
-    return medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() * aux;
+    return medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() * aux;
 }
 
 // ------------------------------------------------------------------------- //
@@ -120,7 +120,7 @@ Parametrization::IntegralLimits Bremsstrahlung::GetIntegralLimits(double energy)
 
     // The limit is taken from the Petrukhin/Shestakov Parametrization
     limits.vMax =
-        1 - 0.75 * SQRTE * (particle_def_.mass / energy) * std::pow(components_[component_index_]->GetNucCharge(), 1. / 3);
+        1 - 0.75 * SQRTE * (particle_def_.mass / energy) * std::pow(components_[component_index_].GetNucCharge(), 1. / 3);
 
     if (limits.vMax < 0)
     {
@@ -182,10 +182,10 @@ double Bremsstrahlung::lpm(double energy, double v)
     const double G1  = 0.710390;
     const double G2  = 0.904912;
 
-    double Z3 = std::pow(components_[component_index_]->GetNucCharge(), -1. / 3);
+    double Z3 = std::pow(components_[component_index_].GetNucCharge(), -1. / 3);
 
-    double Dn = 1.54 * std::pow(components_[component_index_]->GetAtomicNum(), 0.27);
-    s1        = ME * Dn / (particle_def_.mass * Z3 * components_[component_index_]->GetLogConstant());
+    double Dn = 1.54 * std::pow(components_[component_index_].GetAtomicNum(), 0.27);
+    s1        = ME * Dn / (particle_def_.mass * Z3 * components_[component_index_].GetLogConstant());
     s1 *= s1 * SQRT2;
 
     // Calc xi(s') from Stanev, Vankow, Streitmatter, Ellsworth, Bowen
@@ -282,7 +282,7 @@ double BremsPetrukhinShestakov::CalculateParametrization(double energy, double v
     double result = 0;
     double Fd     = 0;
 
-    double Z3 = std::pow(components_[component_index_]->GetNucCharge(), -1. / 3);
+    double Z3 = std::pow(components_[component_index_].GetNucCharge(), -1. / 3);
     // least momentum transferred to the nucleus (eq. 2)
     double delta = particle_def_.mass * particle_def_.mass * v / (2 * energy * (1 - v));
 
@@ -295,7 +295,7 @@ double BremsPetrukhinShestakov::CalculateParametrization(double energy, double v
 
     // for nuclear charge greater 10, a correction for the nuclear form factor
     // is taken into account (eq.11)
-    if (components_[component_index_]->GetNucCharge() > 10)
+    if (components_[component_index_].GetNucCharge() > 10)
     {
         Fd *= (2. / 3) * Z3;
     }
@@ -320,11 +320,11 @@ double BremsKelnerKokoulinPetrukhin::CalculateParametrization(double energy, dou
     // least momentum transferred to the nucleus (eq. 7)
     double delta = particle_def_.mass * particle_def_.mass * v / (2 * energy * (1 - v));
 
-    double Z3 = std::pow(components_[component_index_]->GetNucCharge(), -1. / 3);
-    double Dn = 1.54 * std::pow(components_[component_index_]->GetAtomicNum(), 0.27);
+    double Z3 = std::pow(components_[component_index_].GetNucCharge(), -1. / 3);
+    double Dn = 1.54 * std::pow(components_[component_index_].GetAtomicNum(), 0.27);
     // elastic atomic form factor (eq. 14)
     double formfactor_atomic_elastic =
-        std::log(1 + ME / (delta * SQRTE * components_[component_index_]->GetLogConstant() * Z3));
+        std::log(1 + ME / (delta * SQRTE * components_[component_index_].GetLogConstant() * Z3));
     // elastic nuclear form factor (eq. 18)
     double formfactor_nuclear_elastic = std::log(Dn / (1 + delta * (Dn * SQRTE - 2) / particle_def_.mass));
 
@@ -338,10 +338,10 @@ double BremsKelnerKokoulinPetrukhin::CalculateParametrization(double energy, dou
         // inelastic atomic contribution (eq. 26)
         formfactor_atomic_inelastic =
             std::log(particle_def_.mass / (delta * (delta * particle_def_.mass / (ME * ME) + SQRTE))) -
-            std::log(1 + ME / (delta * SQRTE * components_[component_index_]->GetBPrime() * Z3 * Z3));
+            std::log(1 + ME / (delta * SQRTE * components_[component_index_].GetBPrime() * Z3 * Z3));
     }
 
-    if (components_[component_index_]->GetNucCharge() != 1)
+    if (components_[component_index_].GetNucCharge() != 1)
     {
         // inelastic nuclear contribution (eq. 28)
         formfactor_nuclear_inelastic = formfactor_nuclear_elastic;
@@ -355,7 +355,7 @@ double BremsKelnerKokoulinPetrukhin::CalculateParametrization(double energy, dou
     result = ((4. / 3) * (1 - v) + v * v) * (std::log(particle_def_.mass / delta) - 0.5 // eq.3
                                              - formfactor_atomic_elastic - formfactor_nuclear_elastic +
                                              (formfactor_nuclear_inelastic + formfactor_atomic_inelastic) /
-                                                 components_[component_index_]->GetNucCharge());
+                                                 components_[component_index_].GetNucCharge());
 
     return result;
 }
@@ -374,14 +374,14 @@ double BremsCompleteScreening::CalculateParametrization(double energy, double v)
     double result = 0;
     double Lr, fZ, Lp;
 
-    double Z3 = std::pow(components_[component_index_]->GetNucCharge(), -1. / 3);
+    double Z3 = std::pow(components_[component_index_].GetNucCharge(), -1. / 3);
 
-    aux = ALPHA * components_[component_index_]->GetNucCharge();
+    aux = ALPHA * components_[component_index_].GetNucCharge();
     aux *= aux;
     fZ = aux * (1 / (1 + aux) + 0.20206 + aux * (-0.0369 + aux * (0.0083 - 0.002 * aux)));
 
     // check rounding
-    switch ((int)(components_[component_index_]->GetNucCharge() + 0.5))
+    switch ((int)(components_[component_index_].GetNucCharge() + 0.5))
     {
         case 1:
         {
@@ -418,9 +418,9 @@ double BremsCompleteScreening::CalculateParametrization(double energy, double v)
         }
     }
 
-    result = ((4. / 3 * (1 - v) + v * v) * (components_[component_index_]->GetNucCharge() * (Lr - fZ) + Lp) +
-              1. / 9 * (1 - v) * (components_[component_index_]->GetNucCharge() + 1)) /
-             components_[component_index_]->GetNucCharge();
+    result = ((4. / 3 * (1 - v) + v * v) * (components_[component_index_].GetNucCharge() * (Lr - fZ) + Lp) +
+              1. / 9 * (1 - v) * (components_[component_index_].GetNucCharge() + 1)) /
+             components_[component_index_].GetNucCharge();
 
     return result;
 }
@@ -437,7 +437,7 @@ double BremsAndreevBezrukovBugaev::CalculateParametrization(double energy, doubl
 
     // least momentum transferred to the nucleus (eq. 2.2)
 
-    double nucl_Z = components_[component_index_]->GetNucCharge();
+    double nucl_Z = components_[component_index_].GetNucCharge();
 
     double Z3 = std::pow(nucl_Z, -1. / 3);
 
@@ -504,11 +504,11 @@ double BremsSandrockSoedingreksoRhode::CalculateParametrization(double energy, d
     static const double d[6] = {2134.19, 581.823, -2708.85, 4767.05, 1.52918, 0.361933};
 
 
-    double Z = components_[component_index_]->GetNucCharge();
+    double Z = components_[component_index_].GetNucCharge();
     double Z13 = std::pow(Z, -1. / 3);
-    double rad_log = components_[component_index_]->GetLogConstant();
-    double rad_log_inel = components_[component_index_]->GetBPrime();
-    double Dn = 1.54 * std::pow(components_[component_index_]->GetAtomicNum(), 0.27);
+    double rad_log = components_[component_index_].GetLogConstant();
+    double rad_log_inel = components_[component_index_].GetBPrime();
+    double Dn = 1.54 * std::pow(components_[component_index_].GetAtomicNum(), 0.27);
 
     double mu_qc = particle_def_.mass / (MMU * std::exp(1.) / Dn);
     double rho = std::sqrt(1.0 + 4.0*mu_qc*mu_qc);
@@ -624,7 +624,7 @@ double BremsElectronScreening::DifferentialCrossSection(double energy, double v)
         aux *= lpm(energy, v);
     }
 
-    return medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() * aux;
+    return medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() * aux;
 }
 
 double BremsElectronScreening::CalculateParametrization(double energy, double v)
@@ -633,8 +633,8 @@ double BremsElectronScreening::CalculateParametrization(double energy, double v)
     double aux    = 0;
     double result = 0;
 
-    double Z3 = std::pow(components_[component_index_]->GetNucCharge(), -1. / 3);
-    double logZ = std::log(components_[component_index_]->GetNucCharge());
+    double Z3 = std::pow(components_[component_index_].GetNucCharge(), -1. / 3);
+    double logZ = std::log(components_[component_index_].GetNucCharge());
 
     double delta = particle_def_.mass * particle_def_.mass * v / (2 * energy * (1 - v));
     double x = 136 * Z3 * 2 * delta / ME;
@@ -659,14 +659,14 @@ double BremsElectronScreening::CalculateParametrization(double energy, double v)
     double A_fac = interpolant_->InterpolateArray(logZ, energy);
 
 
-    aux = ALPHA * components_[component_index_]->GetNucCharge();
+    aux = ALPHA * components_[component_index_].GetNucCharge();
     aux *= aux;
     f_c = aux * (1 / (1 + aux) + 0.20206 + aux * (-0.0369 + aux * (0.0083 - 0.002 * aux)));
 
     // bremsstrahlung contribution with atomic electrons as target particles
     double Lr, Lp, xi;
 
-    switch ((int)(components_[component_index_]->GetNucCharge() + 0.5))
+    switch ((int)(components_[component_index_].GetNucCharge() + 0.5))
     {
         case 1:
         {
@@ -709,7 +709,7 @@ double BremsElectronScreening::CalculateParametrization(double energy, double v)
         f_c = 0;
     }
 
-    result = A_fac * components_[component_index_]->GetNucCharge() * (components_[component_index_]->GetNucCharge() + xi);
+    result = A_fac * components_[component_index_].GetNucCharge() * (components_[component_index_].GetNucCharge() + xi);
 
     aux = (2. - 2. * v + v*v) * (phi1 - 4./3 * logZ - 4 * f_c) - 2./3 * (1. - v) * (phi2 - 4./3 * logZ - 4 * f_c);
     result *=aux;

--- a/private/PROPOSAL/crossection/parametrization/Compton.cxx
+++ b/private/PROPOSAL/crossection/parametrization/Compton.cxx
@@ -146,5 +146,5 @@ double ComptonKleinNishina::DifferentialCrossSection(double energy, double v)
     aux = aux / energy; // we loose a factor E due to variable transformation from k' to v
 
     aux *= PI * std::pow(RE, 2.) * ME;
-    return medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() * components_[component_index_]->GetNucCharge() * aux;
+    return medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() * components_[component_index_].GetNucCharge() * aux;
 }

--- a/private/PROPOSAL/crossection/parametrization/EpairProduction.cxx
+++ b/private/PROPOSAL/crossection/parametrization/EpairProduction.cxx
@@ -86,7 +86,7 @@ Parametrization::IntegralLimits EpairProduction::GetIntegralLimits(double energy
     double aux = particle_def_.mass / energy;
 
     limits.vMin = 4 * ME / energy;
-    limits.vMax = 1 - 0.75 * SQRTE * aux * std::pow(components_[component_index_]->GetNucCharge(), 1. / 3);
+    limits.vMax = 1 - 0.75 * SQRTE * aux * std::pow(components_[component_index_].GetNucCharge(), 1. / 3);
 
     aux         = 1 - 6 * aux * aux;
     limits.vMax = std::min(limits.vMax, aux);
@@ -121,8 +121,8 @@ double EpairProduction::lpm(double energy, double v, double r2, double b, double
 
         for (auto component: medium_->GetComponents())
         {
-            sum += component->GetNucCharge() * component->GetNucCharge() *
-                   std::log(3.25 * component->GetLogConstant() * std::pow(component->GetNucCharge(), -1. / 3));
+            sum += component.GetNucCharge() * component.GetNucCharge() *
+                   std::log(3.25 * component.GetLogConstant() * std::pow(component.GetNucCharge(), -1. / 3));
         }
 
         // eq. 29
@@ -219,7 +219,7 @@ double EpairProductionRhoIntegral::DifferentialCrossSection(double energy, doubl
 
     aux = std::max(1 - rMax, COMPUTER_PRECISION);
 
-    return medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() *
+    return medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() *
            particle_def_.charge * particle_def_.charge *
            (integral_.Integrate(
                 1 - rMax, aux, std::bind(&EpairProductionRhoIntegral::FunctionToIntegral, this, energy, v, std::placeholders::_1), 2) +
@@ -269,8 +269,8 @@ double EpairKelnerKokoulinPetrukhin::FunctionToIntegral(double energy, double v,
     double g1, g2;
     double aux, aux1, aux2, r2;
     double diagram_e, diagram_mu, atomic_electron_contribution;
-    double medium_charge       = components_[component_index_]->GetNucCharge();
-    double medium_log_constant = components_[component_index_]->GetLogConstant();
+    double medium_charge       = components_[component_index_].GetNucCharge();
+    double medium_log_constant = components_[component_index_].GetLogConstant();
 
     r           = 1 - r; // only for integral optimization - do not forget to swap integration limits!
     r2          = r * r;
@@ -370,10 +370,10 @@ double EpairSandrockSoedingreksoRhode::FunctionToIntegral(double energy, double 
 {
     double m_in = particle_def_.mass;
 
-    double nucl_Z = components_[component_index_]->GetNucCharge();
-    double nucl_A = components_[component_index_]->GetAtomicNum();
+    double nucl_Z = components_[component_index_].GetNucCharge();
+    double nucl_A = components_[component_index_].GetAtomicNum();
 
-    double rad_log = components_[component_index_]->GetLogConstant();
+    double rad_log = components_[component_index_].GetLogConstant();
 
     double const_prefactor = 4.0 / (3.0 * PI) * nucl_Z * std::pow(ALPHA * RE, 2.0);
     double Z13             = std::pow(nucl_Z, -1.0 / 3.0);

--- a/private/PROPOSAL/crossection/parametrization/MupairProduction.cxx
+++ b/private/PROPOSAL/crossection/parametrization/MupairProduction.cxx
@@ -168,7 +168,7 @@ double MupairProductionRhoIntegral::DifferentialCrossSection(double energy, doub
         return 0;
     }
 
-    return medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() *
+    return medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() *
            particle_def_.charge * particle_def_.charge *
            (integral_.Integrate(
                    0, rMax, std::bind(&MupairProductionRhoIntegral::FunctionToIntegral, this, energy, v, std::placeholders::_1), 2));
@@ -214,9 +214,9 @@ double MupairKelnerKokoulinPetrukhin::FunctionToIntegral(double energy, double v
 
     double aux, aux1, aux2, r2, rMax, Z3, xi, beta, A_pow, r_mu;
     double phi, U, U_max, X, Y;
-    double medium_charge       = components_[component_index_]->GetNucCharge();
-    double atomic_weight       = components_[component_index_]->GetAtomInMolecule();
-    //double medium_log_constant = components_[component_index_]->GetLogConstant();
+    double medium_charge       = components_[component_index_].GetNucCharge();
+    double atomic_weight       = components_[component_index_].GetAtomInMolecule();
+    //double medium_log_constant = components_[component_index_].GetLogConstant();
     double medium_log_constant = 183; // According to the paper, B is set to 183
 
     r2          = r * r;

--- a/private/PROPOSAL/crossection/parametrization/PhotoPairProduction.cxx
+++ b/private/PROPOSAL/crossection/parametrization/PhotoPairProduction.cxx
@@ -104,8 +104,8 @@ double PhotoPairTsai::DifferentialCrossSection(double energy, double x)
     // see formula (3.9)
 
     double Phi1, Phi2, Psi1, Psi2;
-    double Z = components_[component_index_]->GetNucCharge();
-    double logZ = std::log(components_[component_index_]->GetNucCharge());
+    double Z = components_[component_index_].GetNucCharge();
+    double logZ = std::log(components_[component_index_].GetNucCharge());
     double eta;
     double k = energy;
     double delta = std::pow(ME, 2.) / ( 2. * k * x * (1. - x)); // (3.20);
@@ -177,7 +177,7 @@ double PhotoPairTsai::DifferentialCrossSection(double energy, double x)
     double p = std::sqrt( std::pow(x * k, 2.) - std::pow(ME, 2.) ); // electron momentum
     aux *= x * std::pow(k, 2.) / p; // conversion from differential cross section in electron momentum to x
 
-    return std::max(medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() * aux, 0.); //TODO what are the real factors here, those are just guesses
+    return std::max(medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() * aux, 0.); //TODO what are the real factors here, those are just guesses
 }
 
 
@@ -292,8 +292,8 @@ double PhotoAngleTsaiIntegral::FunctionToIntegral(double energy, double x, doubl
     double aux;
     double E = energy * x; // electron energy
     double l = E * E * theta * theta / (ME * ME);
-    double Z = components_[component_index_]->GetNucCharge();
-    double Z3 = std::pow(components_[component_index_]->GetNucCharge(), -1. / 3);
+    double Z = components_[component_index_].GetNucCharge();
+    double Z3 = std::pow(components_[component_index_].GetNucCharge(), -1. / 3);
     double G2 = Z * Z + Z;
     double tminprimesqrt = ( ME * ME * (1. + l) ) / (2. * energy * x * (1. - x));
 

--- a/private/PROPOSAL/crossection/parametrization/PhotoQ2Integration.cxx
+++ b/private/PROPOSAL/crossection/parametrization/PhotoQ2Integration.cxx
@@ -85,7 +85,7 @@ double PhotoQ2Integral::DifferentialCrossSection(double energy, double v)
         q2_min -= (aux * aux) / (2 * (1 - v));
     }
 
-    q2_max = 2 * components_[component_index_]->GetAverageNucleonWeight() * energy * (v - limits.vMin);
+    q2_max = 2 * components_[component_index_].GetAverageNucleonWeight() * energy * (v - limits.vMin);
 
     //  if(form==4) max=Math.min(max, 5.5e6);  // as requested in Butkevich and Mikheyev
     if (q2_min > q2_max)
@@ -96,7 +96,7 @@ double PhotoQ2Integral::DifferentialCrossSection(double energy, double v)
     aux = integral_.Integrate(
         q2_min, q2_max, std::bind(&PhotoQ2Integral::FunctionToQ2Integral, this, energy, v, std::placeholders::_1), 4);
 
-    aux *= medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() *
+    aux *= medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() *
            particle_def_.charge * particle_def_.charge;
 
     return aux;
@@ -146,9 +146,9 @@ Q2_PHOTO_PARAM_INTEGRAL_IMPL(RenoSarcevicSu)
 // ------------------------------------------------------------------------- //
 double PhotoAbramowiczLevinLevyMaor91::FunctionToQ2Integral(double energy, double v, double Q2)
 {
-    Components::Component* component = components_[component_index_];
+    Components::Component component = components_[component_index_];
 
-    double mass_nucleus = component->GetAverageNucleonWeight();
+    double mass_nucleus = component.GetAverageNucleonWeight();
 
     // Bjorken x = \frac{Q^2}{2pq}
     double bjorken_x = Q2 / (2 * mass_nucleus * v * energy);
@@ -248,8 +248,8 @@ double PhotoAbramowiczLevinLevyMaor91::FunctionToQ2Integral(double energy, doubl
     // eq. 3.11
     // F_{2, nucleus} = G(x) (Z + (A - Z)P(x)) F_{2, Proton}
     double structure_function_nucleus =
-        structure_function_proton * shadow_effect_->CalculateShadowEffect(*component, bjorken_x, v * energy) *
-        (component->GetNucCharge() + (component->GetAtomicNum() - component->GetNucCharge()) * relation_proton_neutron);
+        structure_function_proton * shadow_effect_->CalculateShadowEffect(component, bjorken_x, v * energy) *
+        (component.GetNucCharge() + (component.GetAtomicNum() - component.GetNucCharge()) * relation_proton_neutron);
 
     // differential cross section from Dutta et al.
     // Phys. Rev. D 63 (2001), 094020
@@ -274,9 +274,9 @@ double PhotoAbramowiczLevinLevyMaor91::FunctionToQ2Integral(double energy, doubl
 // ------------------------------------------------------------------------- //
 double PhotoAbramowiczLevinLevyMaor97::FunctionToQ2Integral(double energy, double v, double Q2)
 {
-    Components::Component* component = components_[component_index_];
+    Components::Component component = components_[component_index_];
 
-    double mass_nucleus = component->GetAverageNucleonWeight();
+    double mass_nucleus = component.GetAverageNucleonWeight();
 
     // Bjorken x = \frac{Q^2}{2pq}
     double bjorken_x = Q2 / (2 * mass_nucleus * v * energy);
@@ -376,8 +376,8 @@ double PhotoAbramowiczLevinLevyMaor97::FunctionToQ2Integral(double energy, doubl
     // eq. 3.11
     // F_{2, nucleus} = G(x) (Z + (A - Z)P(x)) F_{2, Proton}
     double structure_function_nucleus =
-        structure_function_proton * shadow_effect_->CalculateShadowEffect(*component, bjorken_x, v * energy) *
-        (component->GetNucCharge() + (component->GetAtomicNum() - component->GetNucCharge()) * relation_proton_neutron);
+        structure_function_proton * shadow_effect_->CalculateShadowEffect(component, bjorken_x, v * energy) *
+        (component.GetNucCharge() + (component.GetAtomicNum() - component.GetNucCharge()) * relation_proton_neutron);
 
     // differential cross section from Dutta et al.
     // Phys. Rev. D 63 (2001), 094020
@@ -405,9 +405,9 @@ double PhotoAbramowiczLevinLevyMaor97::FunctionToQ2Integral(double energy, doubl
 // ------------------------------------------------------------------------- //
 double PhotoButkevichMikhailov::FunctionToQ2Integral(double energy, double v, double Q2)
 {
-    Components::Component* component = components_[component_index_];
+    Components::Component component = components_[component_index_];
 
-    double mass_nucleus = component->GetAverageNucleonWeight();
+    double mass_nucleus = component.GetAverageNucleonWeight();
 
     // Bjorken x = \frac{Q^2}{2pq}
     double bjorken_x = Q2 / (2 * mass_nucleus * v * energy);
@@ -464,9 +464,9 @@ double PhotoButkevichMikhailov::FunctionToQ2Integral(double energy, double v, do
     double structure_function_neutron = F_neutron_singlet + F_neutron_non_singlet;
     // F_{2, nucleus} = G (Z F_{2, Proton} + (A-Z) F_{2, Neutron})
     double structure_function_nucleus =
-        shadow_effect_->CalculateShadowEffect(*component, bjorken_x, v * energy) *
-        (component->GetNucCharge() * structure_function_proton +
-         (component->GetAtomicNum() - component->GetNucCharge()) * structure_function_neutron);
+        shadow_effect_->CalculateShadowEffect(component, bjorken_x, v * energy) *
+        (component.GetNucCharge() * structure_function_proton +
+         (component.GetAtomicNum() - component.GetNucCharge()) * structure_function_neutron);
 
     // differential cross section from Dutta et al.
     // Phys. Rev. D 63 (2001), 094020
@@ -493,9 +493,9 @@ double PhotoButkevichMikhailov::FunctionToQ2Integral(double energy, double v, do
 // ------------------------------------------------------------------------- //
 double PhotoRenoSarcevicSu::FunctionToQ2Integral(double energy, double v, double Q2)
 {
-    Components::Component* component = components_[component_index_];
+    Components::Component component = components_[component_index_];
 
-    double mass_nucleus = component->GetAverageNucleonWeight();
+    double mass_nucleus = component.GetAverageNucleonWeight();
 
     // Bjorken x = \frac{Q^2}{2pq}
     double bjorken_x = Q2 / (2 * mass_nucleus * v * energy);
@@ -595,8 +595,8 @@ double PhotoRenoSarcevicSu::FunctionToQ2Integral(double energy, double v, double
     // eq. 3.11
     // F_{2, nucleus} = G(x) (Z + (A - Z)P(x)) F_{2, Proton}
     double structure_function_nucleus =
-        structure_function_proton * shadow_effect_->CalculateShadowEffect(*component, bjorken_x, v * energy) *
-        (component->GetNucCharge() + (component->GetAtomicNum() - component->GetNucCharge()) * relation_proton_neutron);
+        structure_function_proton * shadow_effect_->CalculateShadowEffect(component, bjorken_x, v * energy) *
+        (component.GetNucCharge() + (component.GetAtomicNum() - component.GetNucCharge()) * relation_proton_neutron);
 
     // --------------------------------------------------------------------- //
     // this is the only part, that differs from ALLM parametrization

--- a/private/PROPOSAL/crossection/parametrization/PhotoRealPhotonAssumption.cxx
+++ b/private/PROPOSAL/crossection/parametrization/PhotoRealPhotonAssumption.cxx
@@ -92,13 +92,13 @@ double PhotoRealPhotonAssumption::DifferentialCrossSection(double energy, double
     double kappa = 1 - 2 / v + 2 / (v * v);
 
     // calculate the shadowing factor
-    if (components_[component_index_]->GetNucCharge() == 1)
+    if (components_[component_index_].GetNucCharge() == 1)
     {
         G = 1;
     } else
     {
         // eq. 18
-        double tmp = 0.00282 * std::pow(components_[component_index_]->GetAtomicNum(), 1. / 3) * sgn;
+        double tmp = 0.00282 * std::pow(components_[component_index_].GetAtomicNum(), 1. / 3) * sgn;
         // eq. 3
         G = (3 / tmp) * (0.5 + ((1 + tmp) * std::exp(-tmp) - 1) / (tmp * tmp));
     }
@@ -116,14 +116,14 @@ double PhotoRealPhotonAssumption::DifferentialCrossSection(double energy, double
           ((kappa + 2 * aum / m2) * std::log(1 + m2 / t) - aux) +
           aux * (G * (m1 - 4 * t) / (m1 + t) + (m2 / t) * std::log(1 + t / m2));
 
-    aux *= ALPHA / (8 * PI) * components_[component_index_]->GetAtomicNum() * v * sgn * 1.e-30;
+    aux *= ALPHA / (8 * PI) * components_[component_index_].GetAtomicNum() * v * sgn * 1.e-30;
 
     // hard component by Bugaev, Montaruli, Shelpin, Sokalski
     // Astrop. Phys. 21 (2004), 491
     // in the appendix
-    aux += components_[component_index_]->GetAtomicNum() * 1.e-30 * hard_component_->CalculateHardComponent(energy, v);
+    aux += components_[component_index_].GetAtomicNum() * 1.e-30 * hard_component_->CalculateHardComponent(energy, v);
 
-    return medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() *
+    return medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() *
            particle_def_.charge * particle_def_.charge * aux;
 }
 
@@ -175,7 +175,7 @@ double PhotoZeus::CalculateParametrization(double nu)
 {
     double aux;
 
-    aux = nu * 2.e-3 * this->components_[this->component_index_]->GetAverageNucleonWeight();
+    aux = nu * 2.e-3 * this->components_[this->component_index_].GetAverageNucleonWeight();
     aux = 63.5 * std::pow(aux, 0.097) + 145 * std::pow(aux, -0.5);
 
     return aux;

--- a/private/PROPOSAL/crossection/parametrization/Photonuclear.cxx
+++ b/private/PROPOSAL/crossection/parametrization/Photonuclear.cxx
@@ -302,12 +302,12 @@ Parametrization::IntegralLimits Photonuclear::GetIntegralLimits(double energy)
 
     IntegralLimits limits;
 
-    limits.vMin = (MPI + MPI * MPI / (2 * components_[component_index_]->GetAverageNucleonWeight())) / energy;
+    limits.vMin = (MPI + MPI * MPI / (2 * components_[component_index_].GetAverageNucleonWeight())) / energy;
 
     if (particle_def_.mass < MPI)
     {
-        aux         = particle_def_.mass / components_[component_index_]->GetAverageNucleonWeight();
-        limits.vMax = 1 - components_[component_index_]->GetAverageNucleonWeight() * (1 + aux * aux) / (2 * energy);
+        aux         = particle_def_.mass / components_[component_index_].GetAverageNucleonWeight();
+        limits.vMax = 1 - components_[component_index_].GetAverageNucleonWeight() * (1 + aux * aux) / (2 * energy);
     } else
     {
         limits.vMax = 1;

--- a/private/PROPOSAL/crossection/parametrization/WeakInteraction.cxx
+++ b/private/PROPOSAL/crossection/parametrization/WeakInteraction.cxx
@@ -129,11 +129,11 @@ bool WeakCooperSarkarMertsch::compare(const Parametrization& parametrization) co
 
 double WeakCooperSarkarMertsch::DifferentialCrossSection(double energy, double v)
 {
-    double proton_contribution = components_[component_index_]->GetNucCharge() * interpolant_.at(0)->InterpolateArray(std::log10(energy), v);
-    double neutron_contribution =  (components_[component_index_]->GetAtomicNum() - components_[component_index_]->GetNucCharge()) * interpolant_.at(1)->InterpolateArray(std::log10(energy), v);
-    double mean_contribution = (proton_contribution + neutron_contribution) / (components_[component_index_]->GetAtomicNum());
+    double proton_contribution = components_[component_index_].GetNucCharge() * interpolant_.at(0)->InterpolateArray(std::log10(energy), v);
+    double neutron_contribution =  (components_[component_index_].GetAtomicNum() - components_[component_index_].GetNucCharge()) * interpolant_.at(1)->InterpolateArray(std::log10(energy), v);
+    double mean_contribution = (proton_contribution + neutron_contribution) / (components_[component_index_].GetAtomicNum());
 
-    return medium_->GetMolDensity() * components_[component_index_]->GetAtomInMolecule() * 1e-36 * std::max(0.0, mean_contribution); //factor 1e-36: conversion from pb to cm^2
+    return medium_->GetMolDensity() * components_[component_index_].GetAtomInMolecule() * 1e-36 * std::max(0.0, mean_contribution); //factor 1e-36: conversion from pb to cm^2
 }
 
 

--- a/private/PROPOSAL/medium/Medium.cxx
+++ b/private/PROPOSAL/medium/Medium.cxx
@@ -44,10 +44,10 @@ std::ostream& operator<<(std::ostream& os, Medium const& medium) {
        << std::endl;
     os << "radiation Length:\t\t" << medium.radiationLength_ << std::endl;
 
-    for (std::vector<Components::Component*>::const_iterator iter =
+    for (std::vector<Components::Component>::const_iterator iter =
              medium.components_.begin();
          iter != medium.components_.end(); ++iter) {
-        os << **iter << std::endl;
+        os << *iter << std::endl;
     }
 
     os << Helper::Centered(60, "");
@@ -70,7 +70,7 @@ Medium::Medium(std::string name,
                double X1,
                double d0,
                double massDensity,
-               std::vector<std::shared_ptr<Components::Component>> components)
+               std::vector<Components::Component> components)
     : name_(name),
       numComponents_(components.size()),
       sumCharge_(0),
@@ -88,13 +88,8 @@ Medium::Medium(std::string name,
       radiationLength_(0),
       MM_(0),
       sumNucleons_(0),
-      dens_distr_(new Density_homogeneous(rho)) {
-    // components_.reserve(numComponents_);
-    // for (int i = 0; i < numComponents_; ++i)
-    for (auto component : components) {
-        components_.push_back(component->clone());
-    }
-
+      dens_distr_(new Density_homogeneous(rho)),
+      components_(components) {
     init();
 }
 
@@ -116,24 +111,15 @@ Medium::Medium(const Medium& medium)
       radiationLength_(medium.radiationLength_),
       MM_(medium.MM_),
       sumNucleons_(medium.sumNucleons_),
-      dens_distr_(medium.dens_distr_->clone()) {
-    // Deep copy of components
-    components_.resize(numComponents_);
-    for (unsigned int i = 0; i < components_.size(); ++i) {
-        components_[i] = medium.components_[i]->clone();
-    }
+      dens_distr_(medium.dens_distr_->clone()),
+        components_(medium.components_)
+{
 }
 
 // ------------------------------------------------------------------------- //
 Medium::~Medium() {
-    for (std::vector<Components::Component*>::iterator iter =
-             components_.begin();
-         iter != components_.end(); ++iter) {
-        delete (*iter);
-    }
 
     delete dens_distr_;
-    components_.clear();
 }
 
 // ------------------------------------------------------------------------- //
@@ -186,12 +172,7 @@ Medium& Medium::operator=(const Medium& medium) {
         sumNucleons_ = medium.sumNucleons_;
         dens_distr_ = medium.dens_distr_->clone();
 
-        components_.clear();
-        components_.resize(numComponents_);
-
-        for (unsigned int i = 0; i < components_.size(); ++i) {
-            components_[i] = medium.components_[i]->clone();
-        }
+        components_ = medium.components_;
     }
 
     return *this;
@@ -238,7 +219,7 @@ bool Medium::operator==(const Medium& medium) const {
     else {
         bool Return = true;
         for (unsigned int i = 0; i < components_.size(); ++i) {
-            if (*components_[i] != *medium.components_[i]) {
+            if (components_[i] != medium.components_[i]) {
                 Return = false;
             }
         }
@@ -264,13 +245,13 @@ void Medium::init() {
     numComponents_ = components_.size();
     // massDensity_ *= rho_;
 
-    for (std::vector<Components::Component*>::iterator iter =
+    for (std::vector<Components::Component>::iterator iter =
              components_.begin();
          iter != components_.end(); ++iter) {
-        aux1 += (*iter)->GetAtomInMolecule() * (*iter)->GetNucCharge();
-        aux2 += (*iter)->GetAtomInMolecule() * (*iter)->GetAtomicNum();
-        aux3 += (*iter)->GetAtomInMolecule() * (*iter)->GetAtomicNum() *
-                (*iter)->GetAverageNucleonWeight();
+        aux1 += (iter)->GetAtomInMolecule() * (iter)->GetNucCharge();
+        aux2 += (iter)->GetAtomInMolecule() * (iter)->GetAtomicNum();
+        aux3 += (iter)->GetAtomInMolecule() * (iter)->GetAtomicNum() *
+                (iter)->GetAverageNucleonWeight();
     }
 
     sumCharge_ = aux1;
@@ -287,12 +268,12 @@ void Medium::init() {
     aux1 = 0;
     aux2 = 0;
 
-    for (std::vector<Components::Component*>::iterator iter =
+    for (std::vector<Components::Component>::iterator iter =
              components_.begin();
          iter != components_.end(); ++iter) {
-        aux1 += X0_inv((*iter)->GetNucCharge(), (*iter)->GetAtomicNum()) *
-                ((*iter)->GetAtomInMolecule() * (*iter)->GetAtomicNum());
-        aux2 += (*iter)->GetAtomInMolecule() * (*iter)->GetAtomicNum();
+        aux1 += X0_inv((iter)->GetNucCharge(), (iter)->GetAtomicNum()) *
+                ((iter)->GetAtomInMolecule() * (iter)->GetAtomicNum());
+        aux2 += (iter)->GetAtomInMolecule() * (iter)->GetAtomicNum();
     }
 
     radiationLength_ = aux2 / aux1;
@@ -311,17 +292,9 @@ double Medium::GetRadiationLength(const Vector3D& position) const {
 // Setter
 // ------------------------------------------------------------------------- //
 
-void Medium::SetComponents(
-    std::vector<std::shared_ptr<Components::Component>> components) {
-    for (auto component : components_) {
-        delete component;
-    }
+void Medium::SetComponents(std::vector<Components::Component> components) {
 
-    components_.clear();
-
-    for (auto component : components) {
-        components_.push_back(component->clone());
-    }
+    components_ = components ;
 
     init();  // Init further member according to these components
 }
@@ -398,8 +371,8 @@ Water::Water(double rho)
           2.8004,   // X1
           0,        // d0
           1.000,    // massDensitiy
-          {std::shared_ptr<Components::Component>(new Components::Hydrogen(2)),
-           std::shared_ptr<Components::Component>(new Components::Oxygen())}) {}
+          {Components::Hydrogen(2),
+           Components::Oxygen()}) {}
 
 Ice::Ice(double rho)
     : Medium(
@@ -413,8 +386,8 @@ Ice::Ice(double rho)
           2.8004,   // X1
           0,        // d0
           0.917,    // massDensitiy
-          {std::shared_ptr<Components::Component>(new Components::Hydrogen(2)),
-           std::shared_ptr<Components::Component>(new Components::Oxygen())}) {}
+          {Components::Hydrogen(2),
+           Components::Oxygen()}) {}
 
 Salt::Salt(double rho)
     : Medium("salt",
@@ -429,9 +402,7 @@ Salt::Salt(double rho)
              3.0,      // X1
              0,        // d0
              2.323,    // Solid halite density
-             {std::shared_ptr<Components::Component>(new Components::Sodium()),
-              std::shared_ptr<Components::Component>(
-                  new Components::Chlorine())}) {}
+             {Components::Sodium(), Components::Chlorine()}) {}
 
 CalciumCarbonate::CalciumCarbonate(double rho)
     : Medium(
@@ -445,9 +416,9 @@ CalciumCarbonate::CalciumCarbonate(double rho)
           3.0549,   // X1
           0,        // d0
           2.650,    // massDensity
-          {std::shared_ptr<Components::Component>(new Components::Calcium()),
-           std::shared_ptr<Components::Component>(new Components::Carbon()),
-           std::shared_ptr<Components::Component>(new Components::Oxygen(3))}) {
+          {Components::Calcium(),
+           Components::Carbon(),
+           Components::Oxygen(3)}) {
 }
 
 StandardRock::StandardRock(double rho)
@@ -461,8 +432,7 @@ StandardRock::StandardRock(double rho)
              3.0549,   // X1
              0,        // d0
              2.650,    // massDensity
-             {std::shared_ptr<Components::Component>(
-                 new Components::StandardRock())}) {}
+             {Components::StandardRock()}) {}
 
 FrejusRock::FrejusRock(double rho)
     : Medium("frejusrock",
@@ -475,8 +445,7 @@ FrejusRock::FrejusRock(double rho)
              3.196,   // X1
              0,       // d0
              2.740,   // massDensity
-             {std::shared_ptr<Components::Component>(
-                 new Components::FrejusRock())}) {}
+             {Components::FrejusRock()}) {}
 
 Iron::Iron(double rho)
     : Medium("iron",
@@ -489,7 +458,7 @@ Iron::Iron(double rho)
              3.1531,   // X1
              0.12,     // d0
              7.874,    // massDensity
-             {std::shared_ptr<Components::Component>(new Components::Iron())}) {
+             {Components::Iron()}) {
 }
 
 Hydrogen::Hydrogen(double rho)
@@ -503,8 +472,7 @@ Hydrogen::Hydrogen(double rho)
              1.8856,   // X1
              0,        // d0
              0.07080,  // massDensity
-             {std::shared_ptr<Components::Component>(
-                 new Components::Hydrogen())}) {}
+             {Components::Hydrogen()}) {}
 
 Lead::Lead(double rho)
     : Medium("lead",
@@ -517,7 +485,7 @@ Lead::Lead(double rho)
              3.8073,   // X1
              0.14,     // d0
              11.350,   // massDensity
-             {std::shared_ptr<Components::Component>(new Components::Lead())}) {
+             {Components::Lead()}) {
 }
 
 Copper::Copper(double rho)
@@ -532,7 +500,7 @@ Copper::Copper(double rho)
           3.2792,   // X1
           0.08,     // d0
           8.960,    // massDensity
-          {std::shared_ptr<Components::Component>(new Components::Copper())}) {}
+          {Components::Copper()}) {}
 
 Uranium::Uranium(double rho)
     : Medium(
@@ -546,14 +514,8 @@ Uranium::Uranium(double rho)
           3.3721,   // X1
           0.14,     // d0
           18.950,   // massDensity
-          {std::shared_ptr<Components::Component>(new Components::Uranium())}) {
+          {Components::Uranium()}) {
 }
-
-const double Air::fraction_N = 2 * 78.1;
-const double Air::fraction_O = 2 * 21.0;
-const double Air::fraction_Ar = 0.9;
-const double Air::fraction_sum =
-    Air::fraction_N + Air::fraction_O + Air::fraction_Ar;
 
 Air::Air(double rho)
     : Medium("air",
@@ -566,12 +528,9 @@ Air::Air(double rho)
              4.2759,    // X1
              0,         // d0
              1.205e-3,  // dry, 1 atm massDensity
-             {std::shared_ptr<Components::Component>(
-                  new Components::Nitrogen(fraction_N / fraction_sum)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Oxygen(fraction_O / fraction_sum)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Argon(fraction_Ar / fraction_sum))}) {}
+             {Components::Nitrogen(2 * 78.1),
+              Components::Oxygen(2 * 21.0),
+              Components::Argon(0.9)}) {}
 
 Paraffin::Paraffin(double rho)
     : Medium(
@@ -585,9 +544,8 @@ Paraffin::Paraffin(double rho)
           2.5084,   // X1
           0,        // d0
           0.93,     // massDensity
-          {std::shared_ptr<Components::Component>(new Components::Carbon(25.0)),
-           std::shared_ptr<Components::Component>(
-               new Components::Oxygen(52.0))}) {}
+          {Components::Carbon(25.0),
+           Components::Oxygen(52.0)}) {}
 
 AntaresWater::AntaresWater(double rho)
     : Medium("antareswater",
@@ -600,22 +558,14 @@ AntaresWater::AntaresWater(double rho)
              2.8004,   // X1
              0,        // d0
              1.03975,  // massDensity
-             {std::shared_ptr<Components::Component>(
-                  new Components::Hydrogen(2.0)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Oxygen(1.00884)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Sodium(0.00943)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Potassium(0.000209)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Magnesium(0.001087)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Calcium(0.000209)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Chlorine(0.01106)),
-              std::shared_ptr<Components::Component>(
-                  new Components::Sulfur(0.00582))}) {
+             {Components::Hydrogen(2.0),
+              Components::Oxygen(1.00884),
+              Components::Sodium(0.00943),
+              Components::Potassium(0.000209),
+              Components::Magnesium(0.001087),
+              Components::Calcium(0.000209),
+              Components::Chlorine(0.01106),
+              Components::Sulfur(0.00582)}) {
     /*
      * initialize ANTARES water
      * Sea water (Mediterranean Sea, ANTARES place)
@@ -665,14 +615,14 @@ CascadiaBasinWater::CascadiaBasinWater(double rho)
         0.,        // d0
         1.0400322, // massDensity
         {
-            std::make_shared<Components::Component>(Components::Hydrogen(2.0)),
-            std::make_shared<Components::Component>(Components::Oxygen(1.0021)),
-            std::make_shared<Components::Component>(Components::Sodium(8.7174e-3)),
-            std::make_shared<Components::Component>(Components::Magnesium(9.8180e-4)),
-            std::make_shared<Components::Component>(Components::Calcium(1.9113e-4)),
-            std::make_shared<Components::Component>(Components::Potassium(1.8975e-4)),
-            std::make_shared<Components::Component>(Components::Chlorine(1.0147e-2)),
-            std::make_shared<Components::Component>(Components::Sulfur(5.2487e-4))
+            Components::Hydrogen(2.0),
+            Components::Oxygen(1.0021),
+            Components::Sodium(8.7174e-3),
+            Components::Magnesium(9.8180e-4),
+            Components::Calcium(1.9113e-4),
+            Components::Potassium(1.8975e-4),
+            Components::Chlorine(1.0147e-2),
+            Components::Sulfur(5.2487e-4)
         })
 {}
 

--- a/private/PROPOSAL/medium/Medium.cxx
+++ b/private/PROPOSAL/medium/Medium.cxx
@@ -37,7 +37,6 @@ std::ostream& operator<<(std::ostream& os, Medium const& medium) {
     os << "sum of nucleons of all nuclei:\t\t\t" << medium.sumNucleons_
        << std::endl;
     os << "ionization potential [eV]:\t\t\t" << medium.I_ << std::endl;
-    os << "refraction index:\t\t\t\t" << medium.r_ << std::endl;
     os << "average all-component nucleon weight [MeV]:\t" << medium.MM_
        << std::endl;
     os << "sum of charges of all nuclei:\t\t\t" << medium.sumCharge_
@@ -82,7 +81,6 @@ Medium::Medium(std::string name,
       X0_(X0),
       X1_(X1),
       d0_(d0),
-      r_(0),
       massDensity_(massDensity),
       molDensity_(0),
       radiationLength_(0),
@@ -105,7 +103,6 @@ Medium::Medium(const Medium& medium)
       X0_(medium.X0_),
       X1_(medium.X1_),
       d0_(medium.d0_),
-      r_(medium.r_),
       massDensity_(medium.massDensity_),
       molDensity_(medium.molDensity_),
       radiationLength_(medium.radiationLength_),
@@ -141,7 +138,6 @@ void Medium::swap(Medium& medium) {
     swap(X0_, medium.X0_);
     swap(X1_, medium.X1_);
     swap(d0_, medium.d0_);
-    swap(r_, medium.r_);
     swap(massDensity_, medium.massDensity_);
     swap(molDensity_, medium.molDensity_);
     swap(radiationLength_, medium.radiationLength_);
@@ -202,8 +198,6 @@ bool Medium::operator==(const Medium& medium) const {
         return false;
     else if (d0_ != medium.d0_)
         return false;
-    else if (r_ != medium.r_)
-        return false;
     else if (massDensity_ != medium.massDensity_)
         return false;
     else if (molDensity_ != medium.molDensity_)
@@ -259,9 +253,6 @@ void Medium::init() {
     ZA_ = aux1 / aux2;
     molDensity_ = massDensity_ * NA / aux2;
     MM_ = aux3 / aux2;
-
-    // TODO: this is never used; is that art or deletable
-    r_ = 1.31;  // only for ice - change if needed (sea water: 1.35)
 
     // TODO: Compare to Bremsstrahlung::CalculateScatteringX0; just one (this or
     // the Brems-thing) is needed Calculation of the radiation length
@@ -329,10 +320,6 @@ void Medium::SetX1(double X1) {
 
 void Medium::SetD0(double d0) {
     d0_ = d0;
-}
-
-void Medium::SetR(double r) {
-    r_ = r;
 }
 
 void Medium::SetMassDensity(double massDensity) {

--- a/private/PROPOSAL/scattering/ScatteringMoliere.cxx
+++ b/private/PROPOSAL/scattering/ScatteringMoliere.cxx
@@ -125,10 +125,10 @@ ScatteringMoliere::ScatteringMoliere(const ParticleDef& particle_def, std::share
     double A_sum = 0.;
 
     for (int i = 0; i < numComp_; i++) {
-        Components::Component* component = medium_->GetComponents().at(i);
-        Zi_[i] = component->GetNucCharge();
-        ki[i] = component->GetAtomInMolecule();
-        Ai[i] = component->GetAtomicNum();
+        Components::Component component = medium_->GetComponents().at(i);
+        Zi_[i] = component.GetNucCharge();
+        ki[i] = component.GetAtomInMolecule();
+        Ai[i] = component.GetAtomicNum();
 
         A_sum += ki[i] * Ai[i];
     }

--- a/public/PROPOSAL/crossection/CrossSection.h
+++ b/public/PROPOSAL/crossection/CrossSection.h
@@ -86,7 +86,6 @@ public:
     Parametrization& GetParametrization() const { return *parametrization_; }
 
 protected:
-    typedef std::vector<Components::Component*> ComponentVec;
 
     virtual bool compare(const CrossSection&) const = 0;
 
@@ -108,7 +107,7 @@ protected:
                                              //!< interact with the particle (formerly h_)
     double sum_of_rates_;
 
-    const ComponentVec& components_;
+    const std::vector<Components::Component>& components_;
 
     double rnd_; //!< This random number will be stored in CalculateDNdx to avoid calculate dNdx a second time in
                  //! ClaculateSochasticLoss when it is already done

--- a/public/PROPOSAL/crossection/parametrization/Parametrization.h
+++ b/public/PROPOSAL/crossection/parametrization/Parametrization.h
@@ -98,7 +98,6 @@ public:
     void SetCurrentComponent(int index) { component_index_ = index; }
 
 protected:
-    typedef std::vector<Components::Component*> ComponentVec;
 
     virtual bool compare(const Parametrization&) const;
     virtual void print(std::ostream&) const {};
@@ -110,7 +109,7 @@ protected:
     const EnergyCutSettings cut_settings_;
 
     // const Components::Component* current_component_;
-    const ComponentVec& components_;
+    const std::vector<Components::Component>& components_;
     int component_index_;
 
     double multiplier_;

--- a/public/PROPOSAL/crossection/parametrization/PhotoPairProduction.h
+++ b/public/PROPOSAL/crossection/parametrization/PhotoPairProduction.h
@@ -132,10 +132,9 @@ namespace PROPOSAL {
     protected:
         virtual bool compare(const PhotoAngleDistribution&) const;
 
-        typedef std::vector<Components::Component*> ComponentVec;
         const ParticleDef particle_def_;
         std::shared_ptr<const Medium> medium_;
-        const ComponentVec& components_;
+        const std::vector<Components::Component>& components_;
         int component_index_;
     };
 

--- a/public/PROPOSAL/medium/Medium.h
+++ b/public/PROPOSAL/medium/Medium.h
@@ -64,7 +64,7 @@ class Medium {
            double X1,
            double d0,
            double massDensity,
-           std::vector<std::shared_ptr<Components::Component>>);
+           std::vector<Components::Component>);
     Medium(const Medium&);
 
     ///@brief Crush this Medium.
@@ -84,7 +84,7 @@ class Medium {
 
     // Getter
     int GetNumComponents() const { return numComponents_; }
-    const std::vector<Components::Component*>& GetComponents() const {
+    const std::vector<Components::Component>& GetComponents() const {
         return components_;
     }
     double GetSumCharge() const { return sumCharge_; }
@@ -123,7 +123,7 @@ class Medium {
     void SetMolDensity(double molDensity);
     void SetAverageNucleonWeight(std::vector<double> M);
     void SetComponents(
-        std::vector<std::shared_ptr<Components::Component>> components);
+        std::vector<Components::Component> components);
     void SetMM(double MM);
     void SetSumNucleons(double sumNucleons);
     void SetDensityDistribution(Density_distr& dens_distr);
@@ -137,7 +137,7 @@ class Medium {
     std::string name_;
 
     int numComponents_;                               ///< number of components
-    std::vector<Components::Component*> components_;  ///< Components of Medium
+    std::vector<Components::Component> components_;  ///< Components of Medium
 
     double sumCharge_;  ///< sum of charges of all nuclei
 

--- a/public/PROPOSAL/medium/Medium.h
+++ b/public/PROPOSAL/medium/Medium.h
@@ -40,12 +40,6 @@
        public:                                                                 \
         cls(double rho = 1.0);                                                 \
         cls(const Medium& medium) : Medium(medium) {}                          \
-                                                                               \
-        virtual Medium* clone() const { return new cls(*this); }               \
-        using Medium::create;\
-        std::shared_ptr<const Medium> create() {\
-            return std::make_shared<const Medium>(cls());    \
-        }                                                                      \
     };
 
 namespace PROPOSAL {
@@ -72,8 +66,6 @@ class Medium {
            double massDensity,
            std::vector<std::shared_ptr<Components::Component>>);
     Medium(const Medium&);
-    /* virtual Medium* clone() const { return new Medium(*this); }; */
-    virtual std::shared_ptr<const Medium> create() const { return std::shared_ptr<const Medium>(new Medium(*this)) ;};
 
     ///@brief Crush this Medium.
     virtual ~Medium();
@@ -189,12 +181,6 @@ class Air : public Medium {
     Air(double rho = 1.0);
     Air(const Medium& medium) : Medium(medium) {}
     virtual ~Air() {}
-
-    /* virtual Medium* clone() const { return new Air(*this); } */
-    using Medium::create;
-    std::shared_ptr<const Medium> create(double density_correction = 1.0) {
-        return std::make_shared<const Medium>(Air(density_correction));
-    }
 };
 
 // #<{(|

--- a/public/PROPOSAL/medium/Medium.h
+++ b/public/PROPOSAL/medium/Medium.h
@@ -96,7 +96,6 @@ class Medium {
     double GetX0() const { return X0_; }
     double GetX1() const { return X1_; }
     double GetD0() const { return d0_; }
-    double GetR() const { return r_; }
     double GetMassDensity() const { return massDensity_; }
     double GetCorrectedMassDensity(const Vector3D& xi) const { return massDensity_ * dens_distr_->Evaluate(xi); }
     double GetRadiationLength() const { return radiationLength_; }
@@ -118,7 +117,6 @@ class Medium {
     void SetX0(double X0);
     void SetX1(double X1);
     void SetD0(double d0);
-    void SetR(double r);
     void SetMassDensity(double massDensity);
     void SetMolDensity(double molDensity);
     void SetAverageNucleonWeight(std::vector<double> M);
@@ -137,7 +135,6 @@ class Medium {
     std::string name_;
 
     int numComponents_;                               ///< number of components
-    std::vector<Components::Component> components_;  ///< Components of Medium
 
     double sumCharge_;  ///< sum of charges of all nuclei
 
@@ -145,7 +142,6 @@ class Medium {
     double I_;                 ///< ionization potential [eV]
     double C_, a_;             ///< ionization formula constants
     double m_, X0_, X1_, d0_;  ///< ionization formula constants (continued)
-    double r_;                 ///< refraction index
 
     double massDensity_;      ///< mass density [g/cm3]
     double molDensity_;       ///< molecule density [number/cm3]
@@ -155,6 +151,7 @@ class Medium {
     double sumNucleons_;  ///< sum of nucleons of all nuclei
 
     Density_distr* dens_distr_;
+    std::vector<Components::Component> components_;  ///< Components of Medium
 };
 
 MEDIUM_DEF(Water)

--- a/public/PROPOSAL/medium/Medium.h
+++ b/public/PROPOSAL/medium/Medium.h
@@ -42,6 +42,7 @@
         cls(const Medium& medium) : Medium(medium) {}                          \
                                                                                \
         virtual Medium* clone() const { return new cls(*this); }               \
+        using Medium::create;\
         std::shared_ptr<const Medium> create() {\
             return std::make_shared<const Medium>(cls());    \
         }                                                                      \
@@ -190,6 +191,7 @@ class Air : public Medium {
     virtual ~Air() {}
 
     /* virtual Medium* clone() const { return new Air(*this); } */
+    using Medium::create;
     std::shared_ptr<const Medium> create(double density_correction = 1.0) {
         return std::make_shared<const Medium>(Air(density_correction));
     }

--- a/tests/Annihilation_TEST.cxx
+++ b/tests/Annihilation_TEST.cxx
@@ -43,7 +43,7 @@ ParticleDef getParticleDef(const std::string& name)
 TEST(Comparison, Comparison_equal_particle)
 {
 ParticleDef particle_def = EPlusDef::Get(); //particle
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 double multiplier   = 1.;
 
 Annihilation* Anni_A = new AnnihilationHeitler(particle_def, medium, multiplier);
@@ -76,8 +76,8 @@ TEST(Comparison, Comparison_not_equal)
 ParticleDef mu_def  = MuMinusDef::Get();
 ParticleDef e_minus_def = EMinusDef::Get();
 ParticleDef e_plus_def  = EPlusDef::Get();
-std::shared_ptr<const Medium> medium_1(Water().create());
-std::shared_ptr<const Medium> medium_2(Ice().create());
+auto medium_1 = std::make_shared<const Water>();
+auto medium_2 = std::make_shared<const Ice>();
 double multiplier_1 = 1.;
 double multiplier_2 = 2.;
 
@@ -114,7 +114,7 @@ EXPECT_TRUE(Integral_A != Integral_B);
 TEST(Assignment, Copyconstructor)
 {
 ParticleDef particle_def = EPlusDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 double multiplier = 1.;
 
 AnnihilationHeitler Anni_A(particle_def, medium, multiplier);
@@ -136,7 +136,7 @@ EXPECT_TRUE(AnniInterpol_A == AnniInterpol_B);
 
 TEST(Annihilation, Test_of_dNdx) {
 
-std::string filename = "bin/TestFiles/Anni_dNdx.txt"; 
+std::string filename = "bin/TestFiles/Anni_dNdx.txt";
 std::ifstream in{filename};
 EXPECT_TRUE(in.good()) << "Test resource file '" << filename << "' could not be opened";
 

--- a/tests/Bremsstrahlung_TEST.cxx
+++ b/tests/Bremsstrahlung_TEST.cxx
@@ -36,7 +36,7 @@ const std::string testfile_dir = "bin/TestFiles/";
 TEST(Comparison, Comparison_equal)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
     bool lpm          = true;
@@ -70,8 +70,8 @@ TEST(Comparison, Comparison_not_equal)
 {
     ParticleDef mu_def  = MuMinusDef::Get();
     ParticleDef tau_def = TauMinusDef::Get();
-    std::shared_ptr<const Medium> medium_1(Water().create());
-    std::shared_ptr<const Medium> medium_2(Ice().create());
+    auto medium_1 = std::make_shared<const Water>();
+    auto medium_2 = std::make_shared<const Ice>();
     EnergyCutSettings ecuts_1(500, -1);
     EnergyCutSettings ecuts_2(-1, 0.05);
     double multiplier_1 = 1.;
@@ -114,7 +114,7 @@ TEST(Comparison, Comparison_not_equal)
 TEST(Assignment, Copyconstructor)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
     bool lpm          = true;
@@ -136,7 +136,7 @@ TEST(Assignment, Copyconstructor)
 TEST(Assignment, Copyconstructor2)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
     bool lpm          = true;

--- a/tests/Compton_TEST.cxx
+++ b/tests/Compton_TEST.cxx
@@ -22,7 +22,7 @@ const std::string testfile_dir = "bin/TestFiles/";
 TEST(Comparison, Comparison_equal)
 {
 ParticleDef particle_def = GammaDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 EnergyCutSettings ecuts;
 double multiplier = 1.;
 
@@ -54,8 +54,8 @@ delete Interpol_B;
 TEST(Comparison, Comparison_not_equal)
 {
 ParticleDef gamma_def  = GammaDef::Get();
-std::shared_ptr<const Medium> medium_1(Water().create());
-std::shared_ptr<const Medium> medium_2(Ice().create());
+auto medium_1 = std::make_shared<const Water>();
+auto medium_2 = std::make_shared<const Ice>();
 EnergyCutSettings ecuts_1(500, -1);
 EnergyCutSettings ecuts_2(-1, 0.05);
 double multiplier_1 = 1.;
@@ -73,7 +73,7 @@ EXPECT_TRUE(Compton_A != Compton_C);
 TEST(Assignment, Copyconstructor)
 {
 ParticleDef particle_def = GammaDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 EnergyCutSettings ecuts;
 double multiplier = 1.;
 
@@ -94,7 +94,7 @@ EXPECT_TRUE(Interpol_A == Interpol_B);
 TEST(Assignment, Copyconstructor2)
 {
 ParticleDef particle_def = GammaDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 EnergyCutSettings ecuts;
 double multiplier = 1.;
 

--- a/tests/Epairproduction_TEST.cxx
+++ b/tests/Epairproduction_TEST.cxx
@@ -33,7 +33,7 @@ const std::string testfile_dir = "bin/TestFiles/";
 TEST(Comparison, Comparison_equal)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
     bool lpm          = true;
@@ -78,8 +78,8 @@ TEST(Comparison, Comparison_not_equal)
 {
     ParticleDef mu_def  = MuMinusDef::Get();
     ParticleDef tau_def = TauMinusDef::Get();
-    std::shared_ptr<const Medium> medium_1(Water().create());
-    std::shared_ptr<const Medium> medium_2(Ice().create());
+    auto medium_1 = std::make_shared<const Water>();
+    auto medium_2 = std::make_shared<const Ice>();
     EnergyCutSettings ecuts_1(500, -1);
     EnergyCutSettings ecuts_2(-1, 0.05);
     double multiplier_1 = 1.;
@@ -124,7 +124,7 @@ TEST(Comparison, Comparison_not_equal)
 TEST(Assignment, Copyconstructor)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
     bool lpm          = true;
@@ -150,7 +150,7 @@ TEST(Assignment, Copyconstructor)
 TEST(Assignment, Copyconstructor2)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
     bool lpm          = true;

--- a/tests/Integral_TEST.cxx
+++ b/tests/Integral_TEST.cxx
@@ -212,7 +212,7 @@ TEST(IntegralValue, IntegrateWithLogSubstitution)
 TEST(QUADPACK, RombergIntegrationFailure)
 {
     double precision = 1e-4;
-    IonizIntegral Ioniz_Int(IonizBetheBlochRossi(MuMinusDef::Get(), Ice().create(), EnergyCutSettings(), 1.0));
+    IonizIntegral Ioniz_Int(IonizBetheBlochRossi(MuMinusDef::Get(), std::make_shared<const Ice>(), EnergyCutSettings(), 1.0));
 
     // --------------------------------------------------------------------- //
     // Problematic energy for romberg integration

--- a/tests/Ionization_TEST.cxx
+++ b/tests/Ionization_TEST.cxx
@@ -33,7 +33,7 @@ const std::string testfile_dir = "bin/TestFiles/";
 TEST(Comparison, Comparison_equal)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    auto medium = std::shared_ptr<const Water>();
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
 
@@ -65,8 +65,8 @@ TEST(Comparison, Comparison_not_equal)
 {
     ParticleDef mu_def  = MuMinusDef::Get();
     ParticleDef tau_def = TauMinusDef::Get();
-    auto medium_1 = std::shared_ptr<const Water>();
-    auto medium_2 = std::shared_ptr<const Ice>();
+    auto medium_1 = std::make_shared<const Water>();
+    auto medium_2 = std::make_shared<const Ice>();
     EnergyCutSettings ecuts_1(500, -1);
     EnergyCutSettings ecuts_2(-1, 0.05);
     double multiplier_1 = 1.;

--- a/tests/Ionization_TEST.cxx
+++ b/tests/Ionization_TEST.cxx
@@ -33,7 +33,7 @@ const std::string testfile_dir = "bin/TestFiles/";
 TEST(Comparison, Comparison_equal)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());;
+    auto medium = std::shared_ptr<const Water>();
     EnergyCutSettings ecuts;
     double multiplier = 1.;
 
@@ -65,8 +65,8 @@ TEST(Comparison, Comparison_not_equal)
 {
     ParticleDef mu_def  = MuMinusDef::Get();
     ParticleDef tau_def = TauMinusDef::Get();
-    std::shared_ptr<const Medium> medium_1(Water().create());
-    std::shared_ptr<const Medium> medium_2(Ice().create());
+    auto medium_1 = std::shared_ptr<const Water>();
+    auto medium_2 = std::shared_ptr<const Ice>();
     EnergyCutSettings ecuts_1(500, -1);
     EnergyCutSettings ecuts_2(-1, 0.05);
     double multiplier_1 = 1.;
@@ -95,7 +95,7 @@ TEST(Comparison, Comparison_not_equal)
 TEST(Assignment, Copyconstructor)
 {
     ParticleDef mu_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());;
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts(500, -1);
     double multiplier = 1.;
 
@@ -116,7 +116,7 @@ TEST(Assignment, Copyconstructor2)
 {
 
     ParticleDef mu_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());;
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts(500, -1);
     double multiplier = 1.;
 

--- a/tests/Mupairproduction_TEST.cxx
+++ b/tests/Mupairproduction_TEST.cxx
@@ -33,7 +33,7 @@ const std::string testfile_dir = "bin/TestFiles/";
 TEST(Comparison, Comparison_equal)
 {
 ParticleDef particle_def = MuMinusDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 EnergyCutSettings ecuts;
 double multiplier   = 1.;
 
@@ -77,8 +77,8 @@ TEST(Comparison, Comparison_not_equal)
 {
 ParticleDef mu_def  = MuMinusDef::Get();
 ParticleDef tau_def = TauMinusDef::Get();
-std::shared_ptr<const Medium> medium_1(Water().create());
-std::shared_ptr<const Medium> medium_2(Ice().create());
+auto medium_1 = std::make_shared<const Water>();
+auto medium_2 = std::make_shared<const Ice>();
 EnergyCutSettings ecuts_1(500, -1);
 EnergyCutSettings ecuts_2(-1, 0.05);
 double multiplier_1 = 1.;
@@ -121,7 +121,7 @@ EXPECT_TRUE(Interpol_A != Interpol_B);
 TEST(Assignment, Copyconstructor)
 {
 ParticleDef particle_def = MuMinusDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 EnergyCutSettings ecuts;
 double multiplier = 1.;
 
@@ -146,7 +146,7 @@ EXPECT_TRUE(Interpol_A == Interpol_B);
 TEST(Assignment, Copyconstructor2)
 {
 ParticleDef particle_def = MuMinusDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 EnergyCutSettings ecuts;
 double multiplier = 1.;
 

--- a/tests/PhotoPair_TEST.cxx
+++ b/tests/PhotoPair_TEST.cxx
@@ -29,7 +29,7 @@ ParticleDef getParticleDef(const std::string& name)
 TEST(Comparison, Comparison_equal)
 {
 ParticleDef particle_def = GammaDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 double multiplier   = 1.;
 
 PhotoPairProduction* PhotoPair_A = new PhotoPairTsai(particle_def, medium, multiplier);
@@ -62,7 +62,7 @@ delete Interpol_B;
 TEST(Comparison, Comparison_equal_PhotoAngleDistribution)
 {
 ParticleDef particle_def = GammaDef::Get(); //particle
-std::shared_ptr<const Medium> medium(Water().create());;
+auto medium = std::make_shared<const Water>();
 
 PhotoAngleDistribution* PhotoAngle_A = new PhotoAngleNoDeflection(particle_def, medium);
 PhotoAngleNoDeflection* PhotoAngle_B = new PhotoAngleNoDeflection(particle_def, medium);
@@ -80,8 +80,8 @@ TEST(Comparison, Comparison_not_equal)
 {
 ParticleDef photon  = GammaDef::Get();
 ParticleDef mu_def  = MuMinusDef::Get(); //makes no physical sense but programmatically possible
-std::shared_ptr<const Medium> medium_1(Water().create());;
-std::shared_ptr<const Medium> medium_2(Ice().create());;
+auto medium_1 = std::make_shared<const Water>();
+auto medium_2 = std::make_shared<const Ice>();
 double multiplier_1 = 1.;
 double multiplier_2 = 2.;
 PhotoAngleNoDeflection const PhotoAngle_1(photon, medium_1);
@@ -127,8 +127,8 @@ TEST(Comparison, Comparison_not_equal_PhotoAngleDistribution)
 {
 ParticleDef photon  = GammaDef::Get();
 ParticleDef mu_def  = MuMinusDef::Get(); //makes no physical sense but programmatically possible
-std::shared_ptr<const Medium> medium_1(Water().create());
-std::shared_ptr<const Medium> medium_2(Ice().create());
+auto medium_1 = std::make_shared<const Water>();
+auto medium_2 = std::make_shared<const Ice>();
 
 PhotoAngleNoDeflection PhotoPair_A(photon, medium_1);
 PhotoAngleNoDeflection PhotoPair_B(photon, medium_2);
@@ -156,7 +156,7 @@ EXPECT_TRUE(*PhotoAngle_J != *PhotoAngle_K);
 TEST(Assignment, Copyconstructor)
 {
 ParticleDef particle_def = GammaDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 double multiplier = 1.;
 
 PhotoPairTsai PhotoPair_A(particle_def, medium, multiplier);
@@ -178,7 +178,7 @@ EXPECT_TRUE(PhotoPairInterpol_A == PhotoPairInterpol_B);
 TEST(Assignment, Copyconstructor_PhotoAngleDistribution)
 {
 ParticleDef particle_def = GammaDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());;
+auto medium = std::make_shared<const Water>();
 
 PhotoAngleNoDeflection PhotoAngle_A(particle_def, medium);
 PhotoAngleNoDeflection PhotoAngle_B = PhotoAngle_A;

--- a/tests/Photonuclear_TEST.cxx
+++ b/tests/Photonuclear_TEST.cxx
@@ -34,7 +34,7 @@ const std::string testfile_dir = "bin/TestFiles/";
 TEST(Comparison, Comparison_equal)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier   = 1.;
     bool hard_component = true;
@@ -92,8 +92,8 @@ TEST(Comparison, Comparison_not_equal)
 {
     ParticleDef mu_def  = MuMinusDef::Get();
     ParticleDef tau_def = TauMinusDef::Get();
-    std::shared_ptr<const Medium> medium_1(Water().create());
-    std::shared_ptr<const Medium> medium_2(Ice().create());
+    auto medium_1 = std::make_shared<const Water>();
+    auto medium_2 = std::make_shared<const Ice>();
     EnergyCutSettings ecuts_1(500, 0.05);
     EnergyCutSettings ecuts_2(-1, 0.05);
     double multiplier_1 = 1.;
@@ -169,7 +169,7 @@ TEST(Comparison, Comparison_not_equal)
 TEST(Assignment, Copyconstructor)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier   = 1.;
     bool hard_component = true;
@@ -205,7 +205,7 @@ TEST(Assignment, Copyconstructor)
 TEST(Assignment, Copyconstructor2)
 {
     ParticleDef particle_def = MuMinusDef::Get();
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     EnergyCutSettings ecuts;
     double multiplier   = 1.;
     bool hard_component = true;

--- a/tests/Propagation_TEST.cxx
+++ b/tests/Propagation_TEST.cxx
@@ -12,7 +12,7 @@ TEST(Comparison, Comparison_equal)
 {
     Sector::Definition sector_def;
     sector_def.location = Sector::ParticleLocation::InsideDetector;
-    sector_def.SetMedium(std::make_shared<Medium>(Water()));
+    auto medium = std::make_shared<const Water>();
     sector_def.SetGeometry(Sphere().create());
     sector_def.scattering_model            = ScatteringFactory::Moliere;
     sector_def.cut_settings                = EnergyCutSettings();

--- a/tests/Propagation_TEST.cxx
+++ b/tests/Propagation_TEST.cxx
@@ -12,7 +12,7 @@ TEST(Comparison, Comparison_equal)
 {
     Sector::Definition sector_def;
     sector_def.location = Sector::ParticleLocation::InsideDetector;
-    auto medium = std::make_shared<const Water>();
+    sector_def.SetMedium( std::make_shared<const Water>() );
     sector_def.SetGeometry(Sphere().create());
     sector_def.scattering_model            = ScatteringFactory::Moliere;
     sector_def.cut_settings                = EnergyCutSettings();

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -35,7 +35,7 @@ ParticleDef getParticleDef(const std::string& name)
 TEST(Comparison, Comparison_equal)
 {
     ParticleDef mu = MuMinusDef::Get();
-    std::shared_ptr<const Medium> water(Water(1.0).create());
+    auto water = std::make_shared<const Water>(1.0);
 
     Scattering* noScat1 = new ScatteringNoScattering(mu, water);
     ScatteringNoScattering noScat2(mu, water);
@@ -66,8 +66,8 @@ TEST(Comparison, Comparison_not_equal)
 {
     ParticleDef mu  = MuMinusDef::Get();
     ParticleDef tau = TauMinusDef::Get();
-    std::shared_ptr<const Medium> water(Water(1.0).create());
-    std::shared_ptr<const Medium> ice(Ice().create());
+    auto water = std::make_shared<const Water>(1.0);
+    auto ice = std::make_shared<const Ice>();
 
     ScatteringNoScattering noScat1(mu, water);
     ScatteringNoScattering noScat2(tau, water);
@@ -111,7 +111,7 @@ TEST(Comparison, Comparison_not_equal)
 TEST(Assignment, Copyconstructor)
 {
     ParticleDef mu = MuMinusDef::Get();
-    std::shared_ptr<const Medium> water(Water(1.0).create());
+    auto water = std::make_shared<const Water>(1.0);
 
     ScatteringMoliere moliere1(mu, water);
     ScatteringMoliere moliere2 = moliere1;
@@ -121,7 +121,7 @@ TEST(Assignment, Copyconstructor)
 TEST(Assignment, Copyconstructor2)
 {
     ParticleDef mu = MuMinusDef::Get();
-    std::shared_ptr<const Medium> water(Water(1.0).create());
+    auto water = std::make_shared<const Water>(1.0);
 
     ScatteringMoliere moliere1(mu, water);
     ScatteringMoliere moliere2(moliere1);

--- a/tests/Sector_TEST.cxx
+++ b/tests/Sector_TEST.cxx
@@ -23,7 +23,7 @@ ParticleDef getParticleDef(const std::string& name)
 TEST(Comparison, Comparison_equal)
 {
     ParticleDef mu_def = MuMinusDef::Get();
-    std::shared_ptr<Medium> medium(new Water);
+    auto medium  = std::make_shared<Water>();
     auto sphere = Sphere().create();
     EnergyCutSettings ecuts;
 
@@ -45,8 +45,8 @@ TEST(Comparison, Comparison_not_equal)
 {
     ParticleDef mu_def = MuMinusDef::Get();
     ParticleDef tau_def = TauMinusDef::Get();
-    std::shared_ptr<Medium> medium1(new Water);
-    std::shared_ptr<Medium> medium2(new Ice);
+    auto medium1 = std::make_shared<Water>();
+    auto medium2 = std::make_shared<Ice>();
     auto geometry1 = Sphere().create();
     auto geometry2 = Cylinder().create();
     EnergyCutSettings ecuts1(500, 0.05);
@@ -111,7 +111,7 @@ TEST(Comparison, Comparison_not_equal)
 TEST(Assignment, Copyconstructor)
 {
     ParticleDef mu_def = MuMinusDef::Get();
-    std::shared_ptr<Medium> water(new Water);
+    auto water = std::make_shared<Water>();
     auto geometry = Sphere(Vector3D(0, 0, 0), 1000, 0).create();
     EnergyCutSettings ecuts(500, 0.05);
 
@@ -130,7 +130,7 @@ TEST(Assignment, Copyconstructor)
 TEST(Assignment, Copyconstructor2)
 {
     ParticleDef mu = MuMinusDef::Get();
-    std::shared_ptr<Medium> water(new Water);
+    auto water = std::make_shared<Water>();
     auto geometry = Sphere(Vector3D(), 1000, 0).create();
     EnergyCutSettings ecuts(500, 0.05);
 

--- a/tests/Utility_TEST.cxx
+++ b/tests/Utility_TEST.cxx
@@ -7,7 +7,7 @@
 using namespace PROPOSAL;
 
 TEST(Comparison, Comparison_equal) {
-    auto water = std::make_shared<Medium>(Water(1.0));
+    auto water = std::make_shared<Water>(1.0);
     EnergyCutSettings ecuts;
     ParticleDef pDef(MuMinusDef::Get());
     Utility::Definition utility_defs;
@@ -19,8 +19,8 @@ TEST(Comparison, Comparison_equal) {
 }
 
 TEST(Comparison, Comparison_not_equal) {
-    auto water1 = std::make_shared<Medium>(Water(1.0));
-    auto water2 = std::make_shared<Medium>(Water(0.9));
+    auto water1 = std::make_shared<Water>(1.0);
+    auto water2 = std::make_shared<Water>(0.9);
 
     EnergyCutSettings ecuts1(500, 0.05);
     EnergyCutSettings ecuts2(200, 0.01);
@@ -41,13 +41,13 @@ TEST(Comparison, Comparison_not_equal) {
 }
 
 TEST(Copyconstructor, Copyconstructor) {
-    Utility A(MuMinusDef::Get(), std::make_shared<Medium>(Ice()), EnergyCutSettings(),
+    Utility A(MuMinusDef::Get(), std::make_shared<Ice>(), EnergyCutSettings(),
               Utility::Definition());
     Utility B(A);
 
     EXPECT_TRUE(A == B);
 
-    Utility C(MuMinusDef::Get(), std::make_shared<Medium>(Ice()), EnergyCutSettings(),
+    Utility C(MuMinusDef::Get(), std::make_shared<Ice>(), EnergyCutSettings(),
               Utility::Definition(), InterpolationDef());
     Utility D(C);
 
@@ -55,13 +55,13 @@ TEST(Copyconstructor, Copyconstructor) {
 }
 
 TEST(Copyconstructor, Copyconstructor2) {
-    Utility A(MuMinusDef::Get(), std::make_shared<Medium>(Ice()), EnergyCutSettings(),
+    Utility A(MuMinusDef::Get(), std::make_shared<Ice>(), EnergyCutSettings(),
               Utility::Definition());
     Utility B = A;
 
     EXPECT_TRUE(A == B);
 
-    Utility C(MuMinusDef::Get(), std::make_shared<Medium>(Ice()), EnergyCutSettings(),
+    Utility C(MuMinusDef::Get(), std::make_shared<Ice>(), EnergyCutSettings(),
               Utility::Definition(), InterpolationDef());
     Utility D = C;
 

--- a/tests/WeakInteraction_TEST.cxx
+++ b/tests/WeakInteraction_TEST.cxx
@@ -43,7 +43,7 @@ ParticleDef getParticleDef(const std::string& name)
 TEST(Comparison, Comparison_equal_particle)
 {
 ParticleDef particle_def = MuMinusDef::Get(); //particle
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 EnergyCutSettings ecuts;
 double multiplier   = 1.;
 
@@ -75,7 +75,7 @@ delete Interpol_B;
 TEST(Comparison, Comparison_equal_antiparticle)
 {
     ParticleDef particle_def = MuPlusDef::Get(); //antiparticle
-    std::shared_ptr<const Medium> medium(Water().create());
+    auto medium = std::make_shared<const Water>();
     double multiplier   = 1.;
 
     WeakInteraction* Weak_A = new WeakCooperSarkarMertsch(particle_def, medium, multiplier);
@@ -108,8 +108,8 @@ TEST(Comparison, Comparison_not_equal)
 ParticleDef mu_def  = MuMinusDef::Get();
 ParticleDef tau_def = TauMinusDef::Get();
 ParticleDef mu_plus_def  = MuPlusDef::Get();
-std::shared_ptr<const Medium> medium_1(Water().create());
-std::shared_ptr<const Medium> medium_2(Ice().create());
+auto medium_1 = std::make_shared<const Water>();
+auto medium_2 = std::make_shared<const Ice>();
 double multiplier_1 = 1.;
 double multiplier_2 = 2.;
 
@@ -146,7 +146,7 @@ EXPECT_TRUE(Integral_A != Integral_B);
 TEST(Assignment, Copyconstructor)
 {
 ParticleDef particle_def = MuMinusDef::Get();
-std::shared_ptr<const Medium> medium(Water().create());
+auto medium = std::make_shared<const Water>();
 double multiplier = 1.;
 
 WeakCooperSarkarMertsch Weak_A(particle_def, medium, multiplier);


### PR DESCRIPTION
with the latest PR the compile log is full of the clang warning
`warning: 'PROPOSAL::Salt::create' hides overloaded virtual function [-Woverloaded-virtual]`
for every Medium
used the solution suggested here
https://stackoverflow.com/questions/18515183