### PR TITLE
Fix interpolation pointers

### DIFF
--- a/private/PROPOSAL/crossection/AnnihilationInterpolant.cxx
+++ b/private/PROPOSAL/crossection/AnnihilationInterpolant.cxx
@@ -23,10 +23,10 @@ AnnihilationInterpolant::AnnihilationInterpolant(const Annihilation& param, cons
     gamma_def_ = &GammaDef::Get();
 }
 
-AnnihilationInterpolant::AnnihilationInterpolant(const AnnihilationInterpolant& annihilation)
+/*AnnihilationInterpolant::AnnihilationInterpolant(const AnnihilationInterpolant& annihilation)
         : CrossSectionInterpolant(annihilation), rndc_(annihilation.rndc_), gamma_def_(annihilation.gamma_def_)
 {
-}
+}*/
 
 AnnihilationInterpolant::~AnnihilationInterpolant() {}
 

--- a/private/PROPOSAL/crossection/BremsInterpolant.cxx
+++ b/private/PROPOSAL/crossection/BremsInterpolant.cxx
@@ -42,7 +42,7 @@ BremsInterpolant::BremsInterpolant(const Bremsstrahlung& param, std::shared_ptr<
         .SetLogSubst(true)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &brems, std::placeholders::_1));
 
-    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
+    builder_container.push_back(&builder1d);
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -64,11 +64,14 @@ BremsInterpolant::BremsInterpolant(const Bremsstrahlung& param, std::shared_ptr<
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedE2dxWithoutMultiplier, &brems, std::placeholders::_1));
 
-    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
+    builder_container_de2dx.push_back(&builder_de2dx);
 
-    Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
-    Helper::InitializeInterpolation(
-        "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    auto dedx_interpolant_vec = Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
+    dedx_interpolant_ = std::move(dedx_interpolant_vec.at(0));
+
+    auto de2dx_interpolant_vec = Helper::InitializeInterpolation(
+            "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    de2dx_interpolant_ = std::move(de2dx_interpolant_vec.at(0));
 }
 
 /*BremsInterpolant::BremsInterpolant(const BremsInterpolant& brems)

--- a/private/PROPOSAL/crossection/BremsInterpolant.cxx
+++ b/private/PROPOSAL/crossection/BremsInterpolant.cxx
@@ -42,7 +42,7 @@ BremsInterpolant::BremsInterpolant(const Bremsstrahlung& param, std::shared_ptr<
         .SetLogSubst(true)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &brems, std::placeholders::_1));
 
-    builder_container.push_back(std::make_pair(&builder1d, dedx_interpolant_));
+    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -64,17 +64,17 @@ BremsInterpolant::BremsInterpolant(const Bremsstrahlung& param, std::shared_ptr<
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedE2dxWithoutMultiplier, &brems, std::placeholders::_1));
 
-    builder_container_de2dx.push_back(std::make_pair(&builder_de2dx, de2dx_interpolant_));
+    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
 
     Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
     Helper::InitializeInterpolation(
         "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
 }
 
-BremsInterpolant::BremsInterpolant(const BremsInterpolant& brems)
+/*BremsInterpolant::BremsInterpolant(const BremsInterpolant& brems)
     : CrossSectionInterpolant(brems)
 {
-}
+}*/
 
 BremsInterpolant::~BremsInterpolant() {}
 

--- a/private/PROPOSAL/crossection/ComptonInterpolant.cxx
+++ b/private/PROPOSAL/crossection/ComptonInterpolant.cxx
@@ -45,7 +45,7 @@ ComptonInterpolant::ComptonInterpolant(const Compton& param, std::shared_ptr<con
             .SetLogSubst(true)
             .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &compton, std::placeholders::_1));
 
-    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
+    builder_container.push_back(&builder1d);
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -67,11 +67,14 @@ ComptonInterpolant::ComptonInterpolant(const Compton& param, std::shared_ptr<con
             .SetLogSubst(false)
             .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedE2dxWithoutMultiplier, &compton, std::placeholders::_1));
 
-    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
+    builder_container_de2dx.push_back(&builder_de2dx);
 
-    Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
-    Helper::InitializeInterpolation(
+    auto dedx_interpolant_vec = Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
+    dedx_interpolant_ = std::move(dedx_interpolant_vec.at(0));
+
+    auto de2dx_interpolant_vec = Helper::InitializeInterpolation(
             "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    de2dx_interpolant_ = std::move(de2dx_interpolant_vec.at(0));
 }
 
 /*ComptonInterpolant::ComptonInterpolant(const ComptonInterpolant& compton)
@@ -217,7 +220,6 @@ void ComptonInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
 
     Helper::InterpolantBuilderContainer builder_container1d(components_.size());
     Helper::InterpolantBuilderContainer builder_container2d(components_.size());
-    Helper::InterpolantBuilderContainer builder_return;
 
     Integral integral(IROMB, IMAXS, IPREC);
 
@@ -253,8 +255,7 @@ void ComptonInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
                         std::ref(integral),
                         i));
 
-        builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = std::move(dndx_interpolant_2d_[i]);
+        builder_container2d[i] = &builder2d[i];
 
         builder1d[i]
                 .SetMax(def.nodes_cross_section)
@@ -270,17 +271,10 @@ void ComptonInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
                 .SetLogSubst(false)
                 .SetFunction1D(std::bind(&CrossSectionInterpolant::FunctionToBuildDNdxInterpolant, this, std::placeholders::_1, i));
 
-        builder_container1d[i].first  = &builder1d[i];
-        builder_container1d[i].second = std::move(dndx_interpolant_1d_[i]);
+        builder_container1d[i]  = &builder1d[i];
     }
 
-    for(auto& interpolant2d: builder_container2d){
-        builder_return.push_back(std::move(interpolant2d));
-    }
 
-    for(auto& interpolant1d: builder_container1d){
-        builder_return.push_back(std::move(interpolant1d));
-    }
-
-    Helper::InitializeInterpolation("dNdx", builder_return, std::vector<Parametrization*>(1, parametrization_), def);
+    dndx_interpolant_2d_ = Helper::InitializeInterpolation("dNdx_diff", builder_container2d, std::vector<Parametrization*>(1, parametrization_), def);
+    dndx_interpolant_1d_ = Helper::InitializeInterpolation("dNdx", builder_container1d, std::vector<Parametrization*>(1, parametrization_), def);
 }

--- a/private/PROPOSAL/crossection/CrossSectionInterpolant.cxx
+++ b/private/PROPOSAL/crossection/CrossSectionInterpolant.cxx
@@ -23,8 +23,8 @@ CrossSectionInterpolant::CrossSectionInterpolant(const Parametrization& param, s
     : CrossSection(param, cuts)
     , dedx_interpolant_(nullptr)
     , de2dx_interpolant_(nullptr)
-    , dndx_interpolant_1d_(param.GetMedium()->GetNumComponents(), nullptr)
-    , dndx_interpolant_2d_(param.GetMedium()->GetNumComponents(), nullptr)
+    , dndx_interpolant_1d_(param.GetMedium()->GetNumComponents())
+    , dndx_interpolant_2d_(param.GetMedium()->GetNumComponents())
 {
 }
 
@@ -105,7 +105,7 @@ void CrossSectionInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
                 i));
 
         builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = dndx_interpolant_2d_[i];
+        builder_container2d[i].second = std::move(dndx_interpolant_2d_[i]);
 
         builder1d[i]
             .SetMax(def.nodes_cross_section)
@@ -125,13 +125,17 @@ void CrossSectionInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
         builder_container1d[i].second = std::move(dndx_interpolant_1d_[i]);
     }
 
-    builder_return.insert(builder_return.end(), builder_container2d.begin(), builder_container2d.end());
-    builder_return.insert(builder_return.end(), builder_container1d.begin(), builder_container1d.end());
-    // builder2d.insert(builder2d.end(), builder1d.begin(), builder1d.end());
+    for(auto& interpolant2d: builder_container2d){
+        builder_return.push_back(std::move(interpolant2d));
+    }
+
+    for(auto& interpolant1d: builder_container1d){
+        builder_return.push_back(std::move(interpolant1d));
+    }
 
     Helper::InitializeInterpolation("dNdx", builder_return, std::vector<Parametrization*>(1, parametrization_), def);
 }
-
+/*
 CrossSectionInterpolant::CrossSectionInterpolant(const CrossSectionInterpolant& cross_section)
     : CrossSection(cross_section)
 {
@@ -154,24 +158,24 @@ CrossSectionInterpolant::CrossSectionInterpolant(const CrossSectionInterpolant& 
     int num_components = cross_section.parametrization_->GetMedium()->GetNumComponents();
 
     dndx_interpolant_1d_.reserve(num_components);
-    for (auto interpolant: cross_section.dndx_interpolant_1d_)
+    for (auto& interpolant: cross_section.dndx_interpolant_1d_)
     {
         if (interpolant != nullptr)
         {
-            dndx_interpolant_1d_.push_back(interpolant);
+            dndx_interpolant_1d_.push_back(std::move(interpolant));
         }
     }
 
     dndx_interpolant_2d_.reserve(num_components);
-    for (auto interpolant: cross_section.dndx_interpolant_2d_)
+    for (auto& interpolant: cross_section.dndx_interpolant_2d_)
     {
         if (interpolant != nullptr)
         {
-            dndx_interpolant_2d_.push_back(interpolant);
+            dndx_interpolant_2d_.push_back(std::move(interpolant));
         }
     }
 }
-
+*/
 // ------------------------------------------------------------------------- //
 // Pulblic methods
 // ------------------------------------------------------------------------- //

--- a/private/PROPOSAL/crossection/CrossSectionInterpolant.cxx
+++ b/private/PROPOSAL/crossection/CrossSectionInterpolant.cxx
@@ -68,7 +68,6 @@ void CrossSectionInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
 
     Helper::InterpolantBuilderContainer builder_container1d(components_.size());
     Helper::InterpolantBuilderContainer builder_container2d(components_.size());
-    Helper::InterpolantBuilderContainer builder_return;
 
     Integral integral(IROMB, IMAXS, IPREC);
 
@@ -104,8 +103,7 @@ void CrossSectionInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
                 std::ref(integral),
                 i));
 
-        builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = std::move(dndx_interpolant_2d_[i]);
+        builder_container2d[i] = &builder2d[i];
 
         builder1d[i]
             .SetMax(def.nodes_cross_section)
@@ -121,19 +119,12 @@ void CrossSectionInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
             .SetLogSubst(false)
             .SetFunction1D(std::bind(&CrossSectionInterpolant::FunctionToBuildDNdxInterpolant, this, std::placeholders::_1, i));
 
-        builder_container1d[i].first  = &builder1d[i];
-        builder_container1d[i].second = std::move(dndx_interpolant_1d_[i]);
+        builder_container1d[i]  = &builder1d[i];
     }
 
-    for(auto& interpolant2d: builder_container2d){
-        builder_return.push_back(std::move(interpolant2d));
-    }
+    dndx_interpolant_2d_ = Helper::InitializeInterpolation("dNdx", builder_container2d, std::vector<Parametrization*>(1, parametrization_), def);
+    dndx_interpolant_1d_ = Helper::InitializeInterpolation("dNdx", builder_container1d, std::vector<Parametrization*>(1, parametrization_), def);
 
-    for(auto& interpolant1d: builder_container1d){
-        builder_return.push_back(std::move(interpolant1d));
-    }
-
-    Helper::InitializeInterpolation("dNdx", builder_return, std::vector<Parametrization*>(1, parametrization_), def);
 }
 /*
 CrossSectionInterpolant::CrossSectionInterpolant(const CrossSectionInterpolant& cross_section)

--- a/private/PROPOSAL/crossection/EpairInterpolant.cxx
+++ b/private/PROPOSAL/crossection/EpairInterpolant.cxx
@@ -42,7 +42,7 @@ EpairInterpolant::EpairInterpolant(const EpairProduction& param, std::shared_ptr
         .SetLogSubst(true)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &epair, std::placeholders::_1));
 
-    builder_container.push_back(std::make_pair(&builder1d, dedx_interpolant_));
+    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -64,17 +64,17 @@ EpairInterpolant::EpairInterpolant(const EpairProduction& param, std::shared_ptr
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&EpairIntegral::CalculatedE2dxWithoutMultiplier, &epair, std::placeholders::_1));
 
-    builder_container_de2dx.push_back(std::make_pair(&builder_de2dx, de2dx_interpolant_));
+    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
 
     Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
     Helper::InitializeInterpolation(
         "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
 }
 
-EpairInterpolant::EpairInterpolant(const EpairInterpolant& epair)
+/*EpairInterpolant::EpairInterpolant(const EpairInterpolant& epair)
     : CrossSectionInterpolant(epair)
 {
-}
+}*/
 
 EpairInterpolant::~EpairInterpolant() {}
 

--- a/private/PROPOSAL/crossection/EpairInterpolant.cxx
+++ b/private/PROPOSAL/crossection/EpairInterpolant.cxx
@@ -42,7 +42,7 @@ EpairInterpolant::EpairInterpolant(const EpairProduction& param, std::shared_ptr
         .SetLogSubst(true)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &epair, std::placeholders::_1));
 
-    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
+    builder_container.push_back(&builder1d);
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -64,11 +64,14 @@ EpairInterpolant::EpairInterpolant(const EpairProduction& param, std::shared_ptr
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&EpairIntegral::CalculatedE2dxWithoutMultiplier, &epair, std::placeholders::_1));
 
-    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
+    builder_container_de2dx.push_back(&builder_de2dx);
 
-    Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
-    Helper::InitializeInterpolation(
+    auto dedx_interpolant_vec = Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
+    dedx_interpolant_ = std::move(dedx_interpolant_vec.at(0));
+
+    auto de2dx_interpolant_vec = Helper::InitializeInterpolation(
         "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    de2dx_interpolant_ = std::move(de2dx_interpolant_vec.at(0));
 }
 
 /*EpairInterpolant::EpairInterpolant(const EpairInterpolant& epair)

--- a/private/PROPOSAL/crossection/IonizInterpolant.cxx
+++ b/private/PROPOSAL/crossection/IonizInterpolant.cxx
@@ -26,7 +26,6 @@ IonizInterpolant::IonizInterpolant(const Ionization& param, std::shared_ptr<cons
     // Use overwritten dNdx interpolation
     InitdNdxInterpolation(def);
 
-    std::cout << "fuu" << std::endl;
     // --------------------------------------------------------------------- //
     // Builder for DEdx
     // --------------------------------------------------------------------- //
@@ -34,7 +33,6 @@ IonizInterpolant::IonizInterpolant(const Ionization& param, std::shared_ptr<cons
     Interpolant1DBuilder builder1d;
     Helper::InterpolantBuilderContainer builder_container;
 
-    std::cout << "bazz" << std::endl;
     IonizIntegral ioniz(param, cuts);
 
     builder1d.SetMax(def.nodes_cross_section)

--- a/private/PROPOSAL/crossection/IonizInterpolant.cxx
+++ b/private/PROPOSAL/crossection/IonizInterpolant.cxx
@@ -50,7 +50,7 @@ IonizInterpolant::IonizInterpolant(const Ionization& param, std::shared_ptr<cons
         .SetLogSubst(true)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &ioniz, std::placeholders::_1));
 
-    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
+    builder_container.push_back(&builder1d);
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -72,11 +72,14 @@ IonizInterpolant::IonizInterpolant(const Ionization& param, std::shared_ptr<cons
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&IonizIntegral::CalculatedE2dxWithoutMultiplier, &ioniz, std::placeholders::_1));
 
-    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
+    builder_container_de2dx.push_back(&builder_de2dx);
 
-    Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
-    Helper::InitializeInterpolation(
+    auto dedx_interpolant_vec = Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
+    dedx_interpolant_ = std::move(dedx_interpolant_vec.at(0));
+
+    auto de2dx_interpolant_vec = Helper::InitializeInterpolation(
         "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    de2dx_interpolant_ = std::move(de2dx_interpolant_vec.at(0));
 }
 
 /*IonizInterpolant::IonizInterpolant(const IonizInterpolant& ioniz)
@@ -98,7 +101,6 @@ void IonizInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
 
     Helper::InterpolantBuilderContainer builder_container1d(components_.size());
     Helper::InterpolantBuilderContainer builder_container2d(components_.size());
-    Helper::InterpolantBuilderContainer builder_return;
 
     Integral integral(IROMB, IMAXS, IPREC);
 
@@ -129,8 +131,7 @@ void IonizInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
             .SetFunction2D(std::bind(
                 &IonizInterpolant::FunctionToBuildDNdxInterpolant2D, this, std::placeholders::_1, std::placeholders::_2, std::ref(integral), i));
 
-        builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = std::move(dndx_interpolant_2d_[i]);
+        builder_container2d[i] = &builder2d[i];
 
         builder1d[i]
             .SetMax(def.nodes_cross_section)
@@ -146,20 +147,11 @@ void IonizInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
             .SetLogSubst(false)
             .SetFunction1D(std::bind(&IonizInterpolant::FunctionToBuildDNdxInterpolant, this, std::placeholders::_1, i));
 
-        builder_container1d[i].first  = &builder1d[i];
-        builder_container1d[i].second = std::move(dndx_interpolant_1d_[i]);
+        builder_container1d[i] = &builder1d[i];
     }
 
-    for(auto& interpolant2d: builder_container2d){
-        builder_return.push_back(std::move(interpolant2d));
-    }
-
-    for(auto& interpolant1d: builder_container1d){
-
-        builder_return.push_back(std::move(interpolant1d));
-    }
-
-    Helper::InitializeInterpolation("dNdx", builder_return, std::vector<Parametrization*>(1, parametrization_), def);
+    dndx_interpolant_2d_ = Helper::InitializeInterpolation("dNdx_diff", builder_container2d, std::vector<Parametrization*>(1, parametrization_), def);
+    dndx_interpolant_1d_ = Helper::InitializeInterpolation("dNdx", builder_container1d, std::vector<Parametrization*>(1, parametrization_), def);
 }
 
 // ----------------------------------------------------------------- //

--- a/private/PROPOSAL/crossection/MupairInterpolant.cxx
+++ b/private/PROPOSAL/crossection/MupairInterpolant.cxx
@@ -45,7 +45,7 @@ MupairInterpolant::MupairInterpolant(const MupairProduction& param, std::shared_
         .SetLogSubst(true)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &mupair, std::placeholders::_1));
 
-    builder_container.push_back(std::make_pair(&builder1d, dedx_interpolant_));
+    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -67,7 +67,7 @@ MupairInterpolant::MupairInterpolant(const MupairProduction& param, std::shared_
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&MupairIntegral::CalculatedE2dxWithoutMultiplier, &mupair, std::placeholders::_1));
 
-    builder_container_de2dx.push_back(std::make_pair(&builder_de2dx, de2dx_interpolant_));
+    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
 
     Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
     Helper::InitializeInterpolation(
@@ -77,12 +77,12 @@ MupairInterpolant::MupairInterpolant(const MupairProduction& param, std::shared_
     muplus_def_ = &MuPlusDef::Get();
 }
 
-MupairInterpolant::MupairInterpolant(const MupairInterpolant& mupair)
+/*MupairInterpolant::MupairInterpolant(const MupairInterpolant& mupair)
     : CrossSectionInterpolant(mupair)
     , muminus_def_(mupair.muminus_def_)
     , muplus_def_(mupair.muplus_def_)
 {
-}
+}*/
 
 MupairInterpolant::~MupairInterpolant() {}
 

--- a/private/PROPOSAL/crossection/MupairInterpolant.cxx
+++ b/private/PROPOSAL/crossection/MupairInterpolant.cxx
@@ -45,7 +45,7 @@ MupairInterpolant::MupairInterpolant(const MupairProduction& param, std::shared_
         .SetLogSubst(true)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &mupair, std::placeholders::_1));
 
-    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
+    builder_container.push_back(&builder1d);
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -67,11 +67,14 @@ MupairInterpolant::MupairInterpolant(const MupairProduction& param, std::shared_
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&MupairIntegral::CalculatedE2dxWithoutMultiplier, &mupair, std::placeholders::_1));
 
-    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
+    builder_container_de2dx.push_back(&builder_de2dx);
 
-    Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
-    Helper::InitializeInterpolation(
-        "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    auto dedx_interpolant_vec = Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
+    dedx_interpolant_ = std::move(dedx_interpolant_vec.at(0));
+
+    auto d2edx_interpolant_vec = Helper::InitializeInterpolation(
+            "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    de2dx_interpolant_ = std::move(d2edx_interpolant_vec.at(0));
 
     muminus_def_ = &MuMinusDef::Get();
     muplus_def_ = &MuPlusDef::Get();

--- a/private/PROPOSAL/crossection/PhotoInterpolant.cxx
+++ b/private/PROPOSAL/crossection/PhotoInterpolant.cxx
@@ -42,7 +42,7 @@ PhotoInterpolant::PhotoInterpolant(const Photonuclear& param, std::shared_ptr<co
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &photo, std::placeholders::_1));
 
-    builder_container.push_back(std::make_pair(&builder1d, dedx_interpolant_));
+    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -64,17 +64,17 @@ PhotoInterpolant::PhotoInterpolant(const Photonuclear& param, std::shared_ptr<co
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&PhotoIntegral::CalculatedE2dxWithoutMultiplier, &photo, std::placeholders::_1));
 
-    builder_container_de2dx.push_back(std::make_pair(&builder_de2dx, de2dx_interpolant_));
+    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
 
     Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
     Helper::InitializeInterpolation(
         "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
 }
 
-PhotoInterpolant::PhotoInterpolant(const PhotoInterpolant& photo)
+/*PhotoInterpolant::PhotoInterpolant(const PhotoInterpolant& photo)
     : CrossSectionInterpolant(photo)
 {
-}
+}*/
 
 PhotoInterpolant::~PhotoInterpolant() {}
 

--- a/private/PROPOSAL/crossection/PhotoInterpolant.cxx
+++ b/private/PROPOSAL/crossection/PhotoInterpolant.cxx
@@ -42,7 +42,7 @@ PhotoInterpolant::PhotoInterpolant(const Photonuclear& param, std::shared_ptr<co
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&CrossSectionIntegral::CalculatedEdxWithoutMultiplier, &photo, std::placeholders::_1));
 
-    builder_container.emplace_back(&builder1d, std::move(dedx_interpolant_));
+    builder_container.push_back(&builder1d);
 
     // --------------------------------------------------------------------- //
     // Builder for DE2dx
@@ -64,11 +64,14 @@ PhotoInterpolant::PhotoInterpolant(const Photonuclear& param, std::shared_ptr<co
         .SetLogSubst(false)
         .SetFunction1D(std::bind(&PhotoIntegral::CalculatedE2dxWithoutMultiplier, &photo, std::placeholders::_1));
 
-    builder_container_de2dx.emplace_back(&builder_de2dx, std::move(de2dx_interpolant_));
+    builder_container_de2dx.push_back(&builder_de2dx);
 
-    Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
-    Helper::InitializeInterpolation(
+    auto dedx_interpolant_vec = Helper::InitializeInterpolation("dEdx", builder_container, std::vector<Parametrization*>(1, parametrization_), def);
+    dedx_interpolant_ = std::move(dedx_interpolant_vec.at(0));
+
+    auto de2dx_interpolant_vec = Helper::InitializeInterpolation(
         "dE2dx", builder_container_de2dx, std::vector<Parametrization*>(1, parametrization_), def);
+    de2dx_interpolant_ = std::move(de2dx_interpolant_vec.at(0));
 }
 
 /*PhotoInterpolant::PhotoInterpolant(const PhotoInterpolant& photo)

--- a/private/PROPOSAL/crossection/PhotoPairInterpolant.cxx
+++ b/private/PROPOSAL/crossection/PhotoPairInterpolant.cxx
@@ -153,7 +153,6 @@ void PhotoPairInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
 
     Helper::InterpolantBuilderContainer builder_container1d(components_.size());
     Helper::InterpolantBuilderContainer builder_container2d(components_.size());
-    Helper::InterpolantBuilderContainer builder_return;
 
     Integral integral(IROMB, IMAXS, IPREC);
 
@@ -189,8 +188,7 @@ void PhotoPairInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
                         std::ref(integral),
                         i));
 
-        builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = std::move(dndx_interpolant_2d_[i]);
+        builder_container2d[i] = &builder2d[i];
 
         builder1d[i]
                 .SetMax(def.nodes_cross_section)
@@ -206,17 +204,10 @@ void PhotoPairInterpolant::InitdNdxInterpolation(const InterpolationDef& def)
                 .SetLogSubst(false)
                 .SetFunction1D(std::bind(&CrossSectionInterpolant::FunctionToBuildDNdxInterpolant, this, std::placeholders::_1, i));
 
-        builder_container1d[i].first  = &builder1d[i];
-        builder_container1d[i].second = std::move(dndx_interpolant_1d_[i]);
+        builder_container1d[i] = &builder1d[i];
     }
 
-    for(auto& interpolant2d: builder_container2d){
-        builder_return.push_back(std::move(interpolant2d));
-    }
 
-    for(auto& interpolant1d: builder_container1d){
-        builder_return.push_back(std::move(interpolant1d));
-    }
-
-    Helper::InitializeInterpolation("dNdx", builder_return, std::vector<Parametrization*>(1, parametrization_), def);
+    dndx_interpolant_2d_ = Helper::InitializeInterpolation("dNdx_diff", builder_container2d, std::vector<Parametrization*>(1, parametrization_), def);
+    dndx_interpolant_1d_ = Helper::InitializeInterpolation("dNdx", builder_container1d, std::vector<Parametrization*>(1, parametrization_), def);
 }

--- a/private/PROPOSAL/crossection/WeakInterpolant.cxx
+++ b/private/PROPOSAL/crossection/WeakInterpolant.cxx
@@ -20,10 +20,10 @@ WeakInterpolant::WeakInterpolant(const WeakInteraction& param, const Interpolati
     InitdNdxInterpolation(def);
 }
 
-WeakInterpolant::WeakInterpolant(const WeakInterpolant& param)
+/*WeakInterpolant::WeakInterpolant(const WeakInterpolant& param)
         : CrossSectionInterpolant(param)
 {
-}
+}*/
 
 WeakInterpolant::~WeakInterpolant() {}
 

--- a/private/PROPOSAL/crossection/parametrization/Ionization.cxx
+++ b/private/PROPOSAL/crossection/parametrization/Ionization.cxx
@@ -26,7 +26,7 @@ Ionization::Ionization(const ParticleDef& particle_def,
 }
 
 Ionization::Ionization(const Ionization& ioniz)
-    : Parametrization(ioniz)
+    : Parametrization(ioniz), cuts_(ioniz.cuts_)
 {
 }
 
@@ -133,15 +133,18 @@ double IonizBetheBlochRossi::FunctionToDEdxIntegral(double energy, double variab
     Parametrization::KinematicLimits limits = this->GetKinematicLimits(energy);
 
     // TODO(mario): Better way? Sat 2017/09/02
-
     // PDG eq. 33.10
     // with Spin 1/2 correction by Rossi
     double square_momentum   = (energy - particle_mass_) * (energy + particle_mass_);
     double particle_momentum = std::sqrt(std::max(square_momentum, 0.0));
     double beta              = particle_momentum / energy;
     double gamma             = energy / particle_mass_;
-    double v_up              = cuts_->GetCut(energy);
+    double v_up;
 
+    if(cuts_ == nullptr)
+        v_up = this->GetKinematicLimits(energy).vMax;
+    else
+        v_up = cuts_->GetCut(energy);
 
     aux    = beta * gamma / (1.e-6 * medium_->GetI());
     result = std::log(v_up * (2 * ME * energy)) + 2 * std::log(aux);
@@ -318,8 +321,13 @@ double IonizBergerSeltzerBhabha::FunctionToDEdxIntegral(double energy, double va
     Parametrization::KinematicLimits limits = this->GetKinematicLimits(energy);
 
     double fplus; // (2.269)
+    double v_up;
 
-    double v_up         = cuts_->GetCut(energy);
+    if(cuts_ == nullptr)
+        v_up = this->GetKinematicLimits(energy).vMax;
+    else
+        v_up = cuts_->GetCut(energy);
+
     double bigDelta     = std::min(limits.vMax * energy / ME, v_up * energy / ME); // (2.265)
     double gamma        = energy / ME; // (2.258)
     double betasquared  = 1. - 1. / (gamma * gamma); // (2.260)
@@ -433,7 +441,13 @@ double IonizBergerSeltzerMoller::FunctionToDEdxIntegral(double energy, double va
     Parametrization::KinematicLimits limits = this->GetKinematicLimits(energy);
 
     double fminus; // (2.268)
-    double v_up         = cuts_->GetCut(energy);
+    double v_up;
+
+    if(cuts_ == nullptr)
+        v_up = this->GetKinematicLimits(energy).vMax;
+    else
+        v_up = cuts_->GetCut(energy);
+
     double bigDelta     = std::min(limits.vMax * energy / ME, v_up * energy / ME); // (2.265)
     double gamma        = energy / ME; // (2.258)
     double betasquared  = 1. - 1. / (gamma * gamma); // (2.260)

--- a/private/PROPOSAL/math/InterpolantBuilder.cxx
+++ b/private/PROPOSAL/math/InterpolantBuilder.cxx
@@ -64,13 +64,8 @@ Interpolant1DBuilder::Interpolant1DBuilder(const Interpolant1DBuilder& builder)
 
 std::unique_ptr<Interpolant> Interpolant1DBuilder::build()
 {
-    std::cout << "Das tut weh, Maxi!" << std::endl;
-    std::unique_ptr<Interpolant> ptr (new Interpolant(
+    return std::unique_ptr<Interpolant> (new Interpolant(
             max, xmin, xmax, function1d, romberg, rational, relative, isLog, rombergY, rationalY, relativeY, logSubst));
-
-    std::cout << &ptr << std::endl;
-
-    return ptr;
 }
 
 // ------------------------------------------------------------------------- //

--- a/private/PROPOSAL/math/InterpolantBuilder.cxx
+++ b/private/PROPOSAL/math/InterpolantBuilder.cxx
@@ -1,7 +1,7 @@
 
 #include "PROPOSAL/math/InterpolantBuilder.h"
 #include "PROPOSAL/math/Interpolant.h"
-
+#include <iostream>
 using namespace PROPOSAL;
 
 // ------------------------------------------------------------------------- //
@@ -62,10 +62,15 @@ Interpolant1DBuilder::Interpolant1DBuilder(const Interpolant1DBuilder& builder)
 {
 }
 
-Interpolant* Interpolant1DBuilder::build()
+std::unique_ptr<Interpolant> Interpolant1DBuilder::build()
 {
-    return new Interpolant(
-        max, xmin, xmax, function1d, romberg, rational, relative, isLog, rombergY, rationalY, relativeY, logSubst);
+    std::cout << "Das tut weh, Maxi!" << std::endl;
+    std::unique_ptr<Interpolant> ptr (new Interpolant(
+            max, xmin, xmax, function1d, romberg, rational, relative, isLog, rombergY, rationalY, relativeY, logSubst));
+
+    std::cout << &ptr << std::endl;
+
+    return ptr;
 }
 
 // ------------------------------------------------------------------------- //
@@ -143,9 +148,9 @@ Interpolant2DBuilder_array_as::Interpolant2DBuilder_array_as(const Interpolant2D
 {
 }
 
-Interpolant* Interpolant2DBuilder::build()
+std::unique_ptr<Interpolant> Interpolant2DBuilder::build()
 {
-    return new Interpolant(max1,
+    return std::unique_ptr<Interpolant>(new Interpolant(max1,
                            x1min,
                            x1max,
                            max2,
@@ -163,12 +168,12 @@ Interpolant* Interpolant2DBuilder::build()
                            rombergY,
                            rationalY,
                            relativeY,
-                           logSubst);
+                           logSubst));
 }
 
-Interpolant* Interpolant2DBuilder_array_as::build()
+std::unique_ptr<Interpolant> Interpolant2DBuilder_array_as::build()
 {
-    return new Interpolant(x1,
+    return std::unique_ptr<Interpolant>(new Interpolant(x1,
             x2,
             y,
             romberg1,
@@ -176,6 +181,6 @@ Interpolant* Interpolant2DBuilder_array_as::build()
             relative1,
             romberg2,
             rational2,
-            relative2);
+            relative2));
 }
 

--- a/private/PROPOSAL/math/InterpolantBuilder.cxx
+++ b/private/PROPOSAL/math/InterpolantBuilder.cxx
@@ -1,7 +1,6 @@
 
 #include "PROPOSAL/math/InterpolantBuilder.h"
 #include "PROPOSAL/math/Interpolant.h"
-#include <iostream>
 using namespace PROPOSAL;
 
 // ------------------------------------------------------------------------- //

--- a/private/PROPOSAL/methods.cxx
+++ b/private/PROPOSAL/methods.cxx
@@ -404,7 +404,7 @@ namespace Helper {
                     for (InterpolantBuilderContainer::iterator builder_it
                          = builder_container.begin();
                          builder_it != builder_container.end(); ++builder_it) {
-                        builder_it->second.reset(builder_it->first->build());
+                        builder_it->second = builder_it->first->build();
                         builder_it->second->Save(output, binary_tables);
                     }
                 } else {
@@ -424,7 +424,7 @@ namespace Helper {
             for (InterpolantBuilderContainer::iterator builder_it
                  = builder_container.begin();
                  builder_it != builder_container.end(); ++builder_it) {
-                builder_it->second.reset(builder_it->first->build());
+                builder_it->second = builder_it->first->build();
             }
         }
 

--- a/private/PROPOSAL/methods.cxx
+++ b/private/PROPOSAL/methods.cxx
@@ -239,7 +239,7 @@ namespace Helper {
 
     // -------------------------------------------------------------------------
     // //
-    void InitializeInterpolation(const std::string name,
+    std::vector<std::unique_ptr<Interpolant>> InitializeInterpolation(const std::string name,
         InterpolantBuilderContainer& builder_container,
         const std::vector<Parametrization*>& parametrizations,
         const InterpolationDef interpolation_def)
@@ -250,6 +250,8 @@ namespace Helper {
         // // Create hash for the file name
         // ---------------------------------------------------------------------
         // //
+
+        std::vector<std::unique_ptr<Interpolant>> interpolants(builder_container.size());
 
         size_t hash_digest = 0;
         if (parametrizations.size() == 1) {
@@ -303,12 +305,11 @@ namespace Helper {
                     log_debug("%s tables will be read from file: %s",
                         name.c_str(), filename.str().c_str());
 
-                    for (InterpolantBuilderContainer::iterator builder_it
-                         = builder_container.begin();
-                         builder_it != builder_container.end(); ++builder_it) {
+                    for (auto interpolant = interpolants.begin();
+                         interpolant != interpolants.end(); ++interpolant) {
                         // TODO(mario): read check Tue 2017/09/05
-                        builder_it->second.reset(new Interpolant());
-                        builder_it->second->Load(input, binary_tables);
+                        interpolant->reset(new Interpolant());
+                        interpolant->get()->Load(input, binary_tables);
                     }
                     reading_worked = true;
                 }
@@ -329,7 +330,7 @@ namespace Helper {
 
         if (reading_worked) {
             log_debug("Initialize %s interpolation done.", name.c_str());
-            return;
+            return std::move(interpolants);
         }
 
         if (just_use_readonly_path) {
@@ -376,12 +377,11 @@ namespace Helper {
                     log_debug("%s tables will be read from file: %s",
                         name.c_str(), filename.str().c_str());
 
-                    for (InterpolantBuilderContainer::iterator builder_it
-                         = builder_container.begin();
-                         builder_it != builder_container.end(); ++builder_it) {
+                    for (auto interpolant = interpolants.begin();
+                         interpolant != interpolants.end(); ++interpolant) {
                         // TODO(mario): read check Tue 2017/09/05
-                        builder_it->second.reset(new Interpolant());
-                        builder_it->second->Load(input, binary_tables);
+                        interpolant->reset(new Interpolant());
+                        interpolant->get()->Load(input, binary_tables);
                     }
                 }
 
@@ -401,11 +401,9 @@ namespace Helper {
                 if (output.good()) {
                     output.precision(16);
 
-                    for (InterpolantBuilderContainer::iterator builder_it
-                         = builder_container.begin();
-                         builder_it != builder_container.end(); ++builder_it) {
-                        builder_it->second = builder_it->first->build();
-                        builder_it->second->Save(output, binary_tables);
+                    for (std::size_t i = 0; i < builder_container.size(); ++i) {
+                        interpolants.at(i) = builder_container.at(i)->build();
+                        interpolants.at(i)->Save(output, binary_tables);
                     }
                 } else {
                     storing_failed = true;
@@ -421,14 +419,13 @@ namespace Helper {
         if (pathname.empty() || storing_failed) {
             log_debug("%s tables will be stored in memomy!", name.c_str());
 
-            for (InterpolantBuilderContainer::iterator builder_it
-                 = builder_container.begin();
-                 builder_it != builder_container.end(); ++builder_it) {
-                builder_it->second = builder_it->first->build();
+            for (std::size_t i = 0; i < builder_container.size(); ++i) {
+                interpolants.at(i) = builder_container.at(i)->build();
             }
         }
 
         log_debug("Initialize %s interpolation done.", name.c_str());
+        return std::move(interpolants);
     }
 
 } // namespace Helper

--- a/private/PROPOSAL/methods.cxx
+++ b/private/PROPOSAL/methods.cxx
@@ -330,7 +330,7 @@ namespace Helper {
 
         if (reading_worked) {
             log_debug("Initialize %s interpolation done.", name.c_str());
-            return std::move(interpolants);
+            return interpolants;
         }
 
         if (just_use_readonly_path) {
@@ -425,7 +425,7 @@ namespace Helper {
         }
 
         log_debug("Initialize %s interpolation done.", name.c_str());
-        return std::move(interpolants);
+        return interpolants;
     }
 
 } // namespace Helper

--- a/private/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
+++ b/private/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
@@ -46,15 +46,16 @@ void UtilityInterpolant::InitInterpolation(const std::string& name,
 {
     Integral integral(IROMB, IMAXS, IPREC2);
 
-    std::vector<std::pair<std::shared_ptr<Interpolant>, std::function<double(double)>>>
+    std::vector<std::pair<std::unique_ptr<Interpolant>, std::function<double(double)>>>
         interpolants;
 
-    interpolants.push_back(std::make_pair(interpolant_,
+    interpolants.emplace_back(std::move(interpolant_),
         std::bind(&UtilityInterpolant::BuildInterpolant, this,
-            std::placeholders::_1, std::ref(utility), std::ref(integral))));
-    interpolants.push_back(std::make_pair(interpolant_diff_,
+            std::placeholders::_1, std::ref(utility), std::ref(integral)));
+
+    interpolants.emplace_back(std::move(interpolant_diff_),
         std::bind(&UtilityIntegral::FunctionToIntegral, &utility,
-            std::placeholders::_1)));
+            std::placeholders::_1));
 
     unsigned int number_of_interpolants = interpolants.size();
 
@@ -79,7 +80,7 @@ void UtilityInterpolant::InitInterpolation(const std::string& name,
             .SetFunction1D(interpolants[i].second);
 
         builder_container[i]
-            = std::make_pair(&builder_vec[i], interpolants[i].first);
+            = std::make_pair(&builder_vec[i], std::move(interpolants[i].first));
     }
 
     std::vector<Parametrization*> params(crosss.size(), NULL);

--- a/private/test/example.cxx
+++ b/private/test/example.cxx
@@ -1,6 +1,5 @@
 #include "PROPOSAL/PROPOSAL.h"
 #include <vector>
-#include <iostream>
 
 using namespace PROPOSAL;
 

--- a/private/test/example.cxx
+++ b/private/test/example.cxx
@@ -1,80 +1,26 @@
-
-#include <fstream>
-#include <iostream>
-
 #include "PROPOSAL/PROPOSAL.h"
+#include <vector>
+#include <iostream>
 
 using namespace PROPOSAL;
 
-int main(int argc, const char* argv[])
+int main(int argc, char* argv[])
 {
-    int statistics = 100;
 
-    std::cout << "c++ standard: " << __cplusplus << std::endl;
+    MuMinusDef muon;
+    std::vector<std::unique_ptr<CrossSection>> crosssections;
+    auto cut = std::make_shared<EnergyCutSettings>(500,0.05,true);
+    auto medium = std::make_shared<const FrejusRock>();
+    InterpolationDef inter_def;
 
-    if (argc >= 2)
-    {
-        int result;
-        std::istringstream ss(argv[1]);
-        ss.imbue(std::locale::classic());
-        ss >> result;
+    BremsKelnerKokoulinPetrukhin brems_param(muon, medium, 1.0, true);
 
-        statistics = result;
-        std::cout << "propagate " << statistics << " particles" << std::endl;
-    }
+    IonizBetheBlochRossi ioniz_param(muon, medium, cut, 1.0);
 
-    /**************************************************************************
-     *              One Propagator for each particle definition                *
-     **************************************************************************/
+    /*BremsInterpolant brems_integral(brems_param, cut, inter_def); */
+    IonizInterpolant brems_integral(ioniz_param, cut, inter_def);
+    /* auto dedx = brems_integral.CalculatedEdx(1.e9); */
+    /* std::cout << dedx << std::endl; */
 
-    ParticleDef mu_def = MuMinusDef::Get();
-    ParticleDef tau_def = TauMinusDef::Get();
-    Propagator prop_mu(mu_def, "resources/config_ice.json");
-    Propagator prop_tau(tau_def, "resources/config_ice.json");
-
-    // Therefor its needed to get the internal created particle first
-    DynamicData particle_mu(mu_def.particle_type);
-    DynamicData particle_tau(tau_def.particle_type);
-
-    particle_mu.SetEnergy(1e7); // [MeV]
-    particle_mu.SetPropagatedDistance(0);
-    particle_mu.SetPosition(Vector3D(0, 0, 100));
-    particle_mu.SetDirection(Vector3D(0, 0, -1));
-
-    particle_tau.SetEnergy(1e8); // [MeV]
-    particle_tau.SetPropagatedDistance(0);
-    particle_tau.SetPosition(Vector3D(0, 0, 0));
-    particle_tau.SetDirection(Vector3D(0, 0, -1));
-
-    Secondaries sec_mu_direct = prop_mu.Propagate(particle_mu);
-
-    /**************************************************************************
-     *                        Using propagator service                         *
-     **************************************************************************/
-
-    // Possibility to register propagator in a service
-    PropagatorService prop_service;
-    prop_service.RegisterPropagator(prop_mu);
-    prop_service.RegisterPropagator(prop_tau);
-
-    // Define Particles to propagate
-    DynamicData mu(mu_def.particle_type);
-    DynamicData tau(tau_def.particle_type);
-
-    // Set particle properties
-    mu.SetEnergy(1e8); // [MeV]
-    mu.SetPropagatedDistance(0);
-    mu.SetPosition(Vector3D(0, 0, 0));
-    mu.SetDirection(Vector3D(0, 0, -1));
-
-    tau.SetEnergy(1e8); // [MeV]
-    tau.SetPropagatedDistance(0);
-    tau.SetPosition(Vector3D(0, 0, 0));
-    tau.SetDirection(Vector3D(0, 0, -1));
-
-    // Use service to propagate different particle
-    Secondaries sec_mu_service  = prop_service.Propagate(mu_def, mu);
-    Secondaries sec_tau_service = prop_service.Propagate(tau_def, tau);
-
-    //Output::getInstance().ClearSecondaryVector();
+    return 0;
 }

--- a/private/test/example.cxx
+++ b/private/test/example.cxx
@@ -17,8 +17,8 @@ int main(int argc, char* argv[])
 
     IonizBetheBlochRossi ioniz_param(muon, medium, cut, 1.0);
 
-    /*BremsInterpolant brems_integral(brems_param, cut, inter_def); */
-    IonizInterpolant brems_integral(ioniz_param, cut, inter_def);
+    BremsInterpolant brems_interpol(brems_param, cut, inter_def);
+    IonizInterpolant ioniz_interpol(ioniz_param, cut, inter_def);
     /* auto dedx = brems_integral.CalculatedEdx(1.e9); */
     /* std::cout << dedx << std::endl; */
 

--- a/public/PROPOSAL/crossection/AnnihilationInterpolant.h
+++ b/public/PROPOSAL/crossection/AnnihilationInterpolant.h
@@ -39,10 +39,10 @@ namespace PROPOSAL {
     {
     public:
         AnnihilationInterpolant(const Annihilation&, const InterpolationDef&);
-        AnnihilationInterpolant(const AnnihilationInterpolant&);
+        //AnnihilationInterpolant(const AnnihilationInterpolant&);
         virtual ~AnnihilationInterpolant();
 
-        CrossSection* clone() const { return new AnnihilationInterpolant(*this); }
+        //CrossSection* clone() const { return new AnnihilationInterpolant(*this); }
 
         // ----------------------------------------------------------------- //
         // Public methods

--- a/public/PROPOSAL/crossection/BremsInterpolant.h
+++ b/public/PROPOSAL/crossection/BremsInterpolant.h
@@ -39,10 +39,10 @@ class BremsInterpolant : public CrossSectionInterpolant
 {
 public:
     BremsInterpolant(const Bremsstrahlung&, std::shared_ptr<const EnergyCutSettings>, const InterpolationDef&);
-    BremsInterpolant(const BremsInterpolant&);
+    //BremsInterpolant(const BremsInterpolant&);
     virtual ~BremsInterpolant();
 
-    CrossSection* clone() const { return new BremsInterpolant(*this); }
+    //CrossSection* clone() const { return new BremsInterpolant(*this); }
 
     // ----------------------------------------------------------------- //
     // Public methods

--- a/public/PROPOSAL/crossection/ComptonInterpolant.h
+++ b/public/PROPOSAL/crossection/ComptonInterpolant.h
@@ -39,10 +39,10 @@ namespace PROPOSAL {
     {
     public:
         ComptonInterpolant(const Compton&, std::shared_ptr<const EnergyCutSettings>, const InterpolationDef&);
-        ComptonInterpolant(const ComptonInterpolant&);
+        //ComptonInterpolant(const ComptonInterpolant&);
         virtual ~ComptonInterpolant();
 
-        CrossSection* clone() const { return new ComptonInterpolant(*this); }
+        //CrossSection* clone() const { return new ComptonInterpolant(*this); }
 
         // ----------------------------------------------------------------- //
         // Public methods

--- a/public/PROPOSAL/crossection/CrossSection.h
+++ b/public/PROPOSAL/crossection/CrossSection.h
@@ -55,7 +55,7 @@ public:
     bool operator==(const CrossSection& cross_section) const;
     bool operator!=(const CrossSection& cross_section) const;
 
-    virtual CrossSection* clone() const = 0;
+    //virtual CrossSection* clone() const = 0;
 
     friend std::ostream& operator<<(std::ostream&, CrossSection const&);
 

--- a/public/PROPOSAL/crossection/CrossSectionInterpolant.h
+++ b/public/PROPOSAL/crossection/CrossSectionInterpolant.h
@@ -41,9 +41,9 @@ class CrossSectionInterpolant : public CrossSection
 {
 public:
     CrossSectionInterpolant(const Parametrization&, std::shared_ptr<const EnergyCutSettings>);
-    CrossSectionInterpolant(const CrossSectionInterpolant&);
+    //CrossSectionInterpolant(const CrossSectionInterpolant&);
 
-    virtual CrossSection* clone() const = 0;
+    //virtual CrossSection* clone() const = 0;
 
     virtual double CalculatedEdx(double energy) = 0;
     virtual double CalculatedE2dx(double energy);
@@ -59,13 +59,13 @@ public:
 protected:
     virtual bool compare(const CrossSection&) const;
 
-    typedef std::vector<std::shared_ptr<Interpolant>> InterpolantVec;
+    typedef std::vector<std::unique_ptr<Interpolant>> InterpolantVec;
 
     virtual double CalculateStochasticLoss(double energy, double rnd1);
     virtual void InitdNdxInterpolation(const InterpolationDef& def);
 
-    std::shared_ptr<Interpolant> dedx_interpolant_ = nullptr;
-    std::shared_ptr<Interpolant> de2dx_interpolant_ = nullptr;
+    std::unique_ptr<Interpolant> dedx_interpolant_;
+    std::unique_ptr<Interpolant> de2dx_interpolant_;
     InterpolantVec dndx_interpolant_1d_; // Stochastic dNdx()
     InterpolantVec dndx_interpolant_2d_; // Stochastic dNdx()
 };

--- a/public/PROPOSAL/crossection/EpairInterpolant.h
+++ b/public/PROPOSAL/crossection/EpairInterpolant.h
@@ -39,10 +39,10 @@ class EpairInterpolant : public CrossSectionInterpolant
 {
 public:
     EpairInterpolant(const EpairProduction&, std::shared_ptr<const EnergyCutSettings>, const InterpolationDef&);
-    EpairInterpolant(const EpairInterpolant&);
+    //EpairInterpolant(const EpairInterpolant&);
     virtual ~EpairInterpolant();
 
-    CrossSection* clone() const { return new EpairInterpolant(*this); }
+    //CrossSection* clone() const { return new EpairInterpolant(*this); }
 
     // ----------------------------------------------------------------- //
     // Public methods

--- a/public/PROPOSAL/crossection/IonizInterpolant.h
+++ b/public/PROPOSAL/crossection/IonizInterpolant.h
@@ -39,10 +39,10 @@ class IonizInterpolant : public CrossSectionInterpolant
 {
 public:
     IonizInterpolant(const Ionization&, std::shared_ptr<const EnergyCutSettings>, const InterpolationDef&);
-    IonizInterpolant(const IonizInterpolant&);
+    //IonizInterpolant(const IonizInterpolant&);
     virtual ~IonizInterpolant();
 
-    CrossSection* clone() const { return new IonizInterpolant(*this); }
+    //CrossSection* clone() const { return new IonizInterpolant(*this); }
 
     // ----------------------------------------------------------------- //
     // Public methods

--- a/public/PROPOSAL/crossection/MupairInterpolant.h
+++ b/public/PROPOSAL/crossection/MupairInterpolant.h
@@ -39,10 +39,10 @@ class MupairInterpolant : public CrossSectionInterpolant
 {
 public:
     MupairInterpolant(const MupairProduction&, std::shared_ptr<const EnergyCutSettings>, const InterpolationDef&);
-    MupairInterpolant(const MupairInterpolant&);
+    //MupairInterpolant(const MupairInterpolant&);
     virtual ~MupairInterpolant();
 
-    CrossSection* clone() const { return new MupairInterpolant(*this); }
+    //CrossSection* clone() const { return new MupairInterpolant(*this); }
 
     // ----------------------------------------------------------------- //
     // Public methods

--- a/public/PROPOSAL/crossection/PhotoInterpolant.h
+++ b/public/PROPOSAL/crossection/PhotoInterpolant.h
@@ -39,10 +39,10 @@ class PhotoInterpolant : public CrossSectionInterpolant
 {
 public:
     PhotoInterpolant(const Photonuclear&, std::shared_ptr<const EnergyCutSettings>, const InterpolationDef&);
-    PhotoInterpolant(const PhotoInterpolant&);
+    //PhotoInterpolant(const PhotoInterpolant&);
     virtual ~PhotoInterpolant();
 
-    CrossSection* clone() const { return new PhotoInterpolant(*this); }
+    //CrossSection* clone() const { return new PhotoInterpolant(*this); }
 
     // ----------------------------------------------------------------- //
     // Public methods

--- a/public/PROPOSAL/crossection/PhotoPairInterpolant.h
+++ b/public/PROPOSAL/crossection/PhotoPairInterpolant.h
@@ -39,10 +39,10 @@ namespace PROPOSAL {
     {
     public:
         PhotoPairInterpolant(const PhotoPairProduction&, const PhotoAngleDistribution&, const InterpolationDef&);
-        PhotoPairInterpolant(const PhotoPairInterpolant&);
+        //PhotoPairInterpolant(const PhotoPairInterpolant&);
         virtual ~PhotoPairInterpolant();
 
-        CrossSection* clone() const { return new PhotoPairInterpolant(*this); }
+        //CrossSection* clone() const { return new PhotoPairInterpolant(*this); }
 
         // ----------------------------------------------------------------- //
         // Public methods

--- a/public/PROPOSAL/crossection/WeakInterpolant.h
+++ b/public/PROPOSAL/crossection/WeakInterpolant.h
@@ -39,10 +39,10 @@ namespace PROPOSAL {
     {
     public:
         WeakInterpolant(const WeakInteraction&, const InterpolationDef&);
-        WeakInterpolant(const WeakInterpolant&);
+        //WeakInterpolant(const WeakInterpolant&);
         virtual ~WeakInterpolant();
 
-        CrossSection* clone() const { return new WeakInterpolant(*this); }
+        //CrossSection* clone() const { return new WeakInterpolant(*this); }
 
         // ----------------------------------------------------------------- //
         // Public methods

--- a/public/PROPOSAL/crossection/parametrization/EpairProduction.h
+++ b/public/PROPOSAL/crossection/parametrization/EpairProduction.h
@@ -233,11 +233,10 @@ EpairProductionRhoInterpolant<Param>::EpairProductionRhoInterpolant(const Partic
             .SetLogSubst(false)
             .SetFunction2D(std::bind(&EpairProductionRhoInterpolant::FunctionToBuildPhotoInterpolant, this, std::placeholders::_1, std::placeholders::_2, i));
 
-        builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = std::move(interpolant_[i]);
+        builder_container2d[i]  = &builder2d[i];
     }
 
-    Helper::InitializeInterpolation("Epair", builder_container2d, std::vector<Parametrization*>(1, this), *def);
+    interpolant_ = Helper::InitializeInterpolation("Epair", builder_container2d, std::vector<Parametrization*>(1, this), *def);
 }
 
 template<class Param>

--- a/public/PROPOSAL/crossection/parametrization/MupairProduction.h
+++ b/public/PROPOSAL/crossection/parametrization/MupairProduction.h
@@ -143,7 +143,7 @@ template<class Param = MupairKelnerKokoulinPetrukhin>
 class MupairProductionRhoInterpolant : public Param
 {
 public:
-    typedef std::vector<std::shared_ptr<Interpolant>> InterpolantVec;
+    typedef std::vector<std::unique_ptr<Interpolant>> InterpolantVec;
 
 public:
     MupairProductionRhoInterpolant(const ParticleDef&,
@@ -176,7 +176,7 @@ MupairProductionRhoInterpolant<Param>::MupairProductionRhoInterpolant(const Part
                                               double multiplier,
                                               std::shared_ptr<const InterpolationDef> def)
     : Param(particle_def, medium, multiplier)
-    , interpolant_(this->medium_->GetNumComponents(), nullptr)
+    , interpolant_(this->medium_->GetNumComponents())
 {
     std::vector<Interpolant2DBuilder> builder2d(this->components_.size());
     Helper::InterpolantBuilderContainer builder_container2d(this->components_.size());
@@ -205,7 +205,7 @@ MupairProductionRhoInterpolant<Param>::MupairProductionRhoInterpolant(const Part
             .SetFunction2D(std::bind(&MupairProductionRhoInterpolant::FunctionToBuildPhotoInterpolant, this, std::placeholders::_1, std::placeholders::_2, i));
 
         builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = interpolant_[i];
+        builder_container2d[i].second = std::move(interpolant_[i]);
     }
 
     Helper::InitializeInterpolation("Mupair", builder_container2d, std::vector<Parametrization*>(1, this), *def);
@@ -220,7 +220,7 @@ MupairProductionRhoInterpolant<Param>::MupairProductionRhoInterpolant(const Mupa
 
     for (unsigned int i = 0; i < photo.interpolant_.size(); ++i)
     {
-        interpolant_[i] = photo.interpolant_[i];
+        interpolant_[i] = std::unique_ptr<Interpolant>(new Interpolant(*photo.interpolant_[i]));
     }
 }
 

--- a/public/PROPOSAL/crossection/parametrization/MupairProduction.h
+++ b/public/PROPOSAL/crossection/parametrization/MupairProduction.h
@@ -204,11 +204,10 @@ MupairProductionRhoInterpolant<Param>::MupairProductionRhoInterpolant(const Part
             .SetLogSubst(false)
             .SetFunction2D(std::bind(&MupairProductionRhoInterpolant::FunctionToBuildPhotoInterpolant, this, std::placeholders::_1, std::placeholders::_2, i));
 
-        builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = std::move(interpolant_[i]);
+        builder_container2d[i]  = &builder2d[i];
     }
 
-    Helper::InitializeInterpolation("Mupair", builder_container2d, std::vector<Parametrization*>(1, this), *def);
+    interpolant_ = Helper::InitializeInterpolation("Mupair", builder_container2d, std::vector<Parametrization*>(1, this), *def);
 }
 
 template<class Param>

--- a/public/PROPOSAL/crossection/parametrization/PhotoQ2Integration.h
+++ b/public/PROPOSAL/crossection/parametrization/PhotoQ2Integration.h
@@ -126,7 +126,7 @@ template<class Param = PhotoAbramowiczLevinLevyMaor97>
 class PhotoQ2Interpolant : public Param
 {
 public:
-    typedef std::vector<std::shared_ptr<Interpolant>> InterpolantVec;
+    typedef std::vector<std::unique_ptr<Interpolant>> InterpolantVec;
 
 public:
     PhotoQ2Interpolant(const ParticleDef&,
@@ -162,7 +162,7 @@ PhotoQ2Interpolant<Param>::PhotoQ2Interpolant(const ParticleDef& particle_def,
                                               const ShadowEffect& shadow_effect,
                                               std::shared_ptr<const InterpolationDef> def)
     : Param(particle_def, medium, multiplier, shadow_effect)
-    , interpolant_(this->medium_->GetNumComponents(), NULL)
+    , interpolant_(this->medium_->GetNumComponents())
 {
     std::vector<Interpolant2DBuilder> builder2d(this->components_.size());
     Helper::InterpolantBuilderContainer builder_container2d(this->components_.size());
@@ -191,7 +191,7 @@ PhotoQ2Interpolant<Param>::PhotoQ2Interpolant(const ParticleDef& particle_def,
             .SetFunction2D(std::bind(&PhotoQ2Interpolant::FunctionToBuildPhotoInterpolant, this, std::placeholders::_1, std::placeholders::_2, i));
 
         builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = interpolant_[i];
+        builder_container2d[i].second = std::move(interpolant_[i]);
     }
 
     Helper::InitializeInterpolation("Photo", builder_container2d, std::vector<Parametrization*>(1, this), *def);
@@ -206,7 +206,7 @@ PhotoQ2Interpolant<Param>::PhotoQ2Interpolant(const PhotoQ2Interpolant& photo)
 
     for (unsigned int i = 0; i < photo.interpolant_.size(); ++i)
     {
-        interpolant_[i] = photo.interpolant_[i];
+        interpolant_[i] = std::unique_ptr<Interpolant>(new Interpolant(*photo.interpolant_[i]));
     }
 }
 

--- a/public/PROPOSAL/crossection/parametrization/PhotoQ2Integration.h
+++ b/public/PROPOSAL/crossection/parametrization/PhotoQ2Integration.h
@@ -190,11 +190,10 @@ PhotoQ2Interpolant<Param>::PhotoQ2Interpolant(const ParticleDef& particle_def,
             .SetLogSubst(false)
             .SetFunction2D(std::bind(&PhotoQ2Interpolant::FunctionToBuildPhotoInterpolant, this, std::placeholders::_1, std::placeholders::_2, i));
 
-        builder_container2d[i].first  = &builder2d[i];
-        builder_container2d[i].second = std::move(interpolant_[i]);
+        builder_container2d[i]  = &builder2d[i];
     }
 
-    Helper::InitializeInterpolation("Photo", builder_container2d, std::vector<Parametrization*>(1, this), *def);
+    interpolant_ = Helper::InitializeInterpolation("Photo", builder_container2d, std::vector<Parametrization*>(1, this), *def);
 }
 
 template<class Param>

--- a/public/PROPOSAL/math/InterpolantBuilder.h
+++ b/public/PROPOSAL/math/InterpolantBuilder.h
@@ -62,7 +62,7 @@ public:
     InterpolantBuilder() {}
     virtual ~InterpolantBuilder() {}
 
-    virtual Interpolant* build() = 0;
+    virtual std::unique_ptr<Interpolant> build() = 0;
 };
 
 // ----------------------------------------------------------------------------
@@ -154,7 +154,7 @@ public:
     // 	return *this;
     // }
 
-    Interpolant* build();
+    std::unique_ptr<Interpolant> build();
 
 private:
     Function1D function1d;
@@ -296,7 +296,7 @@ public:
     // 	return *this;
     // }
 
-    Interpolant* build();
+    std::unique_ptr<Interpolant> build();
 
 private:
     Function2D function2d;
@@ -381,7 +381,7 @@ private:
         }
 
 
-        Interpolant* build();
+        std::unique_ptr<Interpolant> build();
 
     private:
 

--- a/public/PROPOSAL/methods.h
+++ b/public/PROPOSAL/methods.h
@@ -159,7 +159,7 @@ bool FileExist(const std::string path);
 // ----------------------------------------------------------------------------
 std::string Centered(int width, const std::string& str, char fill = '=');
 
-typedef std::vector<std::pair<InterpolantBuilder*, std::unique_ptr<Interpolant>> > InterpolantBuilderContainer;
+typedef std::vector<InterpolantBuilder*> InterpolantBuilderContainer;
 
 // ----------------------------------------------------------------------------
 /// @brief Helper for interpolation initialization
@@ -170,7 +170,7 @@ typedef std::vector<std::pair<InterpolantBuilder*, std::unique_ptr<Interpolant>>
 /// @param std::vector: vector of parametrizations used to create
 ///        the interpolation tables with
 // ----------------------------------------------------------------------------
-void InitializeInterpolation(const std::string name,
+std::vector<std::unique_ptr<Interpolant>> InitializeInterpolation(const std::string name,
                              InterpolantBuilderContainer&,
                              const std::vector<Parametrization*>&,
                              const InterpolationDef);

--- a/public/PROPOSAL/methods.h
+++ b/public/PROPOSAL/methods.h
@@ -159,16 +159,17 @@ bool FileExist(const std::string path);
 // ----------------------------------------------------------------------------
 std::string Centered(int width, const std::string& str, char fill = '=');
 
-typedef std::vector<InterpolantBuilder*> InterpolantBuilderContainer;
+using InterpolantBuilderContainer = std::vector<InterpolantBuilder*>;
 
 // ----------------------------------------------------------------------------
 /// @brief Helper for interpolation initialization
 ///
 /// @param name: subject of resulting file name
-/// @param InterpolantBuilderContainer:
-///        vector of builder, pointer to Interplant pairs
+/// @param InterpolantBuilderContainer: vector of interpolant builder
 /// @param std::vector: vector of parametrizations used to create
 ///        the interpolation tables with
+///
+/// @return vector of unique_ptr to created interpolants
 // ----------------------------------------------------------------------------
 std::vector<std::unique_ptr<Interpolant>> InitializeInterpolation(const std::string name,
                              InterpolantBuilderContainer&,

--- a/public/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.h
+++ b/public/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.h
@@ -67,8 +67,8 @@ protected:
     virtual void InitInterpolation(const std::string&, UtilityIntegral&, int number_of_sampling_points) = 0;
 
     double stored_result_;
-    std::shared_ptr<Interpolant> interpolant_;
-    std::shared_ptr<Interpolant> interpolant_diff_;
+    std::unique_ptr<Interpolant> interpolant_;
+    std::unique_ptr<Interpolant> interpolant_diff_;
     double low_;
 
     std::shared_ptr<InterpolationDef> interpolation_def_;


### PR DESCRIPTION
The Interpolation issue caused by undefined unique_ptr objects has been solved. Now, the InitializeInterpolation function returns a unique_ptr instead of accepting and resetting one (this led to an undefined behaviour)