### PR TITLE
Fix bugs in Propagation

### DIFF
--- a/private/PROPOSAL/Sector.cxx
+++ b/private/PROPOSAL/Sector.cxx
@@ -528,6 +528,9 @@ std::shared_ptr<DynamicData> Sector::DoContinuous(
     double displacement
         = Displacement(p_condition, final_energy, sector_border);
 
+    if(std::abs(displacement - sector_border) < PARTICLE_POSITION_RESOLUTION)
+        displacement = sector_border;
+
     double dist = p_condition.GetPropagatedDistance() + displacement;
     double time = CalculateTime(p_condition, final_energy, displacement);
 

--- a/private/PROPOSAL/medium/MediumFactory.cxx
+++ b/private/PROPOSAL/medium/MediumFactory.cxx
@@ -17,12 +17,11 @@ std::shared_ptr<Medium> CreateMedium(Medium_Type type, double density_correction
     std::unique_ptr<Density_distr> density_distr(new Density_homogeneous(density_correction));
     auto searched_medium = Medium_Map.find(type);
     if (searched_medium != Medium_Map.end()) {
-        searched_medium->second->SetDensityDistribution(*density_distr);
-    } else {
-        throw std::invalid_argument("Medium not found.");
+        auto medium = std::make_shared<Medium>(*searched_medium->second);
+        medium->SetDensityDistribution(*density_distr);
+        return medium;
     }
-
-    return searched_medium->second;
+    throw std::invalid_argument("Medium not found.");
 }
 } // namespace PROPOSAL
 


### PR DESCRIPTION
Fixing two bugs in Propagation. First bugs caused the density of a created medium to be overwritten, the second bug caused PROPOSAL to freeze when the distance to the Sector border became too small.