### PR TITLE
Add a missing conversion from meter to centimeter

### DIFF
--- a/private/PROPOSAL/Propagator.cxx
+++ b/private/PROPOSAL/Propagator.cxx
@@ -185,7 +185,7 @@ Propagator::Propagator(
     std::shared_ptr<const Medium> med;
     std::shared_ptr<const Geometry> geo;
     std::array<std::pair<std::string, Sector::ParticleLocation::Enum>, 3> cuts {
-        std::make_pair("cuts_before", Sector::ParticleLocation::InfrontDetector),
+        std::make_pair("cuts_infront", Sector::ParticleLocation::InfrontDetector),
         std::make_pair("cuts_inside", Sector::ParticleLocation::InsideDetector),
         std::make_pair("cuts_behind", Sector::ParticleLocation::BehindDetector)
     };

--- a/private/PROPOSAL/geometry/Sphere.cxx
+++ b/private/PROPOSAL/geometry/Sphere.cxx
@@ -47,8 +47,8 @@ Sphere::Sphere(const nlohmann::json& config)
         throw std::invalid_argument("Outer radius is not a number.");
 
     config["outer_radius"].get_to(radius_);
-    radius_ *= 100;
-    inner_radius_ = config.value("inner_radius", 0);
+    radius_ *= 100;//cm
+    inner_radius_ = config.value("inner_radius", 0)*100;//cm
 
     if(inner_radius_ < 0) throw std::logic_error("inner radius must be >= 0");
     if(radius_ < inner_radius_)

--- a/resources/config_docu.md
+++ b/resources/config_docu.md
@@ -18,15 +18,15 @@ An example for a configuration file can be found [here](config_docu.md).
 There is the option to set a `seed`, if the internal random number generator is used.
 The seed has no effect, if you use an external random number generator.
 
-If the Output of the Secondaries should not only include the stochastic energy losses (and the particles produced in an interaction or decay), but also the continuous energy losses, this can be set by the `continous_loss_output` parameter.
+If the Output of the Secondaries should not only include the stochastic energy losses (and the particles produced in an interaction or decay), but also the continuous energy losses, this can be set by the `do_continuous_energy_loss_output` parameter.
 
 When the Output should just contain the secondaries (energy losses or particles produced in an interaction or decay), that occurred inside the detector volume, and not the ones outside of the detector, this can be set with the `only_loss_inside_detector` parameter.
 
-| Keyword                     | Type    | Default   | Description |
-| --------------------------- | ------- | --------- | ----------- |
-| `seed`                      | Integer | `0`       | seed for the internal random number generator|
-| `continous_loss_output`     | Bool    | `False`   | Decides whether continuous losses should be emitted in the Output of Secondaries|
-| `only_loss_inside_detector` | Bool    | `False`   | Decides whether only secondaries created inside the detector should be included in the Output of Secondaries|
+| Keyword                            | Type    | Default   | Description |
+| ---------------------------------- | ------- | --------- | ----------- |
+| `seed`                             | Integer | `0`       | seed for the internal random number generator|
+| `do_continuous_energy_loss_output` | Bool    | `False`   | Decides whether continuous losses should be emitted in the Output of Secondaries|
+| `only_loss_inside_detector`        | Bool    | `False`   | Decides whether only secondaries created inside the detector should be included in the Output of Secondaries|
 
 ### Interpolation parameters ###
 The `interpolation` parameter is an own json-object.

--- a/resources/config_docu.md
+++ b/resources/config_docu.md
@@ -267,6 +267,7 @@ A density correction factor for the medium, specifying the density of the medium
 
 Every sector needs a geometry, described by an vector that defines its `origin` and a `shape`.
 All lengths PROPOSAL uses are in **centimeter**!
+(Unit of length in the setting below are in **meter**!)
 
 The following three shapes are available:
 - `"Sphere"`


### PR DESCRIPTION
There're three commits in this PR, which includes the following changes:
1. Add a missing conversion from meter to centimeter of inner_radius in Sphere.cxx
2. Add a note about the unit used by the config file in the [documentation](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/master/resources/config_docu.md)
3. Modify a config label from `continous_loss_output` to `do_continuous_energy_loss_output`, so that it can be properly read by the program.
4. Modify a label `cuts_before` to `cuts_infront` in the configuration parser in Propagator.cxx.