### PR TITLE
Fix error missing substitution for rFlag case in EPairProduction

### DIFF
--- a/private/PROPOSAL/crossection/EpairIntegral.cxx
+++ b/private/PROPOSAL/crossection/EpairIntegral.cxx
@@ -106,5 +106,5 @@ double EpairIntegral::CalculatedEdxWithoutMultiplier(double energy)
 // ------------------------------------------------------------------------- //
 double EpairIntegral::FunctionToDEdxIntegralReverse(double energy, double v)
 {
-    return (1 - v) * parametrization_->DifferentialCrossSection(energy, v);
+    return (1 - v) * parametrization_->DifferentialCrossSection(energy, 1 - v);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 SET(RESOURCE_URL https://proposal.app.tu-dortmund.de/resources)
-SET(TEST_FILES TestFiles_2020-02-26.tar.gz)
+SET(TEST_FILES TestFiles_2020-10-21.tar.gz)
 add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/google/googletest" "extern/googletest" EXCLUDE_FROM_ALL)
 mark_as_advanced(
 	BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS


### PR DESCRIPTION
When calculating dEdx for EPairProduction, CalculatedEdx may run into a specific case called `rflag` where the integral for dEdx is split into two parts (one part is integrated from v_min to 0.8, the second from 0.8 to v_up).
For the second part, the substitution `v = 1-v` is used for numerical reasons. However, it seems that this substitution was missing for FunctionToDEdxIntegralReverse.
This caused wrong calculations of dEdx in very specific cases, for example when calculating only-continuous dEdx values for electrons for high energies.

This breaks some test files.