### PR TITLE
fix: adapt pyenv for travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,14 +89,14 @@ matrix:
 
 
 before_install:
-  - PYENV_VERSION=1.2.20
-  - PYTHON_VERSION=3.7.8
-  - git fetch
-  - pushd /opt/pyenv
-  - git checkout v$PYENV_VERSION
-  - pyenv install -v $PYTHON_VERSION
 
 install:
+  - PYENV_VERSION=1.2.20
+  - PYTHON_VERSION=3.7.8
+  - pushd $(pyenv root)
+  - git fetch
+  - git checkout v$PYENV_VERSION
+  - pyenv install -v $PYTHON_VERSION
   - ci/install_cmake.sh
   - export PATH="$HOME/cmake/bin:$PATH"
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ install:
   - git fetch
   - git checkout v$PYENV_VERSION
   - pyenv install -v $PYTHON_VERSION
+  - popd
   - ci/install_cmake.sh
   - export PATH="$HOME/cmake/bin:$PATH"
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,12 @@ matrix:
 
 
 before_install:
-  - pyenv global system 3.7
+  - PYENV_VERSION=1.2.20
+  - PYTHON_VERSION=3.7.8
+  - git fetch
+  - pushd /opt/pyenv
+  - git checkout v$PYENV_VERSION
+  - pyenv install -v $PYTHON_VERSION
 
 install:
   - ci/install_cmake.sh
@@ -97,6 +102,7 @@ install:
   - cmake --version
 
 before_script:
+  - pyenv global $PYTHON_VERSION
   - mkdir build
   - cd build
   - cmake .. -DADD_PYTHON=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/proposal


### PR DESCRIPTION
The reason, why the build bots currently fail:
see https://travis-ci.community/t/pyenv-global-3-7-now-fails-on-xenial-it-was-working-3-days-ago/9430
or the fix https://github.com/vgc/vgc/commit/5e3270528563bc1ddea687f207ea612176883330