### PR TITLE
WIP: Restructuring of Secondaries/Track, Losses and DynamicData

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,3 @@ install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/PROPOSALConfigVersion.cmake"
     DESTINATION lib/cmake/PROPOSAL
 )
-
-add_executable(example example.cxx)
-target_link_libraries(example PRIVATE PROPOSAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,3 +156,6 @@ install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/PROPOSALConfigVersion.cmake"
     DESTINATION lib/cmake/PROPOSAL
 )
+
+add_executable(example example.cxx)
+target_link_libraries(example PRIVATE PROPOSAL)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ using namespace PROPOSAL;
 int main(){
     ParticleDef mu_def = MuMinusDef::Get();
     Propagator prop(mu_def, "resources/configuration/config.json");
-    DynamicData mu(mu_def.particle_type);
+    ParticleState mu(mu_def.particle_type);
 
     mu.SetEnergy(9e6);
     mu.SetPosition(Vector3D(0, 0, 0))
@@ -216,7 +216,7 @@ prop = pp.Propagator(
 	  config_file="path/to/config.json"
 )
 
-mu = pp.particle.DynamicData(mu_def.particle_type)
+mu = pp.particle.ParticleState(mu_def.particle_type)
 
 mu.energy = 9e6
 mu.direction = pp.Vector3D(0, 0, -1)

--- a/examples/Propagator.ipynb
+++ b/examples/Propagator.ipynb
@@ -53,7 +53,7 @@
     "\n",
     "prop = pp.Propagator(args[\"particle_def\"], [(detector, utility, density_distr)])\n",
     "\n",
-    "initial_state = pp.particle.DynamicData(args[\"particle_def\"].particle_type)\n",
+    "initial_state = pp.particle.ParticleState(args[\"particle_def\"].particle_type)\n",
     "initial_state.energy = 1e8\n",
     "initial_state.direction = pp.Vector3D(1,0,0)"
    ]

--- a/include/PROPOSAL/Propagator.h
+++ b/include/PROPOSAL/Propagator.h
@@ -62,15 +62,15 @@ public:
     : Propagator(p_def, ParseConfig(config_file)) {}
     Propagator(ParticleDef const&, std::vector<Sector> sectors);
 
-    Secondaries Propagate(const DynamicData& initial_particle,
+    Secondaries Propagate(const ParticleState& initial_particle,
             double max_distance = 1e20, double min_energy = 0.);
     enum {GEOMETRY, UTILITY, DENSITY_DISTR};
 
 private:
-    InteractionType DoStochasticInteraction(DynamicData&, PropagationUtility&,
-            std::function<double()>);
-    int AdvanceParticle(DynamicData& p_cond, double E_f, double max_distance,
-                         std::function<double()> rnd, Sector& current_sector);
+    InteractionType DoStochasticInteraction(ParticleState&, PropagationUtility&,
+                                            std::function<double()>);
+    int AdvanceParticle(ParticleState& p_cond, double E_f, double max_distance,
+                        std::function<double()> rnd, Sector& current_sector);
     double CalculateDistanceToBorder(const Vector3D& particle_position,
             const Vector3D& particle_direction,
             const Geometry& current_geometry);

--- a/include/PROPOSAL/Propagator.h
+++ b/include/PROPOSAL/Propagator.h
@@ -67,7 +67,7 @@ public:
     enum {GEOMETRY, UTILITY, DENSITY_DISTR};
 
 private:
-    void DoStochasticInteraction(DynamicData&, PropagationUtility&,
+    InteractionType DoStochasticInteraction(DynamicData&, PropagationUtility&,
             std::function<double()>);
     int AdvanceParticle(DynamicData& p_cond, double E_f, double max_distance,
                          std::function<double()> rnd, Sector& current_sector);

--- a/include/PROPOSAL/Secondaries.h
+++ b/include/PROPOSAL/Secondaries.h
@@ -52,24 +52,24 @@ public:
     // Operational functions to fill and access track
     void reserve(size_t number_secondaries);
     void clear() { track_.clear(); types_.clear(); };
-    void push_back(const DynamicData& point, const InteractionType& type);
+    void push_back(const ParticleState& point, const InteractionType& type);
     void emplace_back(const ParticleType& particle_type, const Vector3D& position,
         const Vector3D& direction, const double& energy, const double& time,
         const double& distance, const InteractionType& interaction_type);
-    const DynamicData& back() const {return track_.back(); }
-    const DynamicData& operator[](std::size_t idx) { return track_[idx]; };
+    const ParticleState& back() const {return track_.back(); }
+    const ParticleState& operator[](std::size_t idx) { return track_[idx]; };
 
     // Track functions
     double GetELost(const Geometry&) const;
-    std::unique_ptr<DynamicData> GetEntryPoint(const Geometry&) const;
-    std::unique_ptr<DynamicData> GetExitPoint(const Geometry&) const;
-    std::unique_ptr<DynamicData> GetClosestApproachPoint(const Geometry&) const;
+    std::unique_ptr<ParticleState> GetEntryPoint(const Geometry&) const;
+    std::unique_ptr<ParticleState> GetExitPoint(const Geometry&) const;
+    std::unique_ptr<ParticleState> GetClosestApproachPoint(const Geometry&) const;
 
-    std::vector<DynamicData> GetTrack() const { return track_; };
-    std::vector<DynamicData> GetTrack(const Geometry&) const;
+    std::vector<ParticleState> GetTrack() const { return track_; };
+    std::vector<ParticleState> GetTrack(const Geometry&) const;
 
-    DynamicData GetStateForEnergy(double) const;
-    DynamicData GetStateForDistance(double) const;
+    ParticleState GetStateForEnergy(double) const;
+    ParticleState GetStateForDistance(double) const;
 
     std::vector<Vector3D> GetTrackPositions() const;
     std::vector<Vector3D> GetTrackDirections() const;
@@ -78,7 +78,7 @@ public:
     std::vector<double> GetTrackPropagatedDistances() const;
     std::vector<InteractionType> GetTrackTypes() const { return types_; };
     unsigned int GetTrackLength() const { return track_.size(); };
-    std::vector<DynamicData> GetDecayProducts() const;
+    std::vector<ParticleState> GetDecayProducts() const;
 
     // Loss functions
 
@@ -91,11 +91,11 @@ public:
     std::vector<ContinuousLoss> GetContinuousLosses(const Geometry&) const;
 
 private:
-    DynamicData RePropagateDistance(const DynamicData&, double) const;
-    DynamicData RePropagateEnergy(const DynamicData&, double, double) const;
+    ParticleState RePropagateDistance(const ParticleState&, double) const;
+    ParticleState RePropagateEnergy(const ParticleState&, double, double) const;
     Sector GetCurrentSector(const Vector3D&, const Vector3D&) const;
 
-    std::vector<DynamicData> track_;
+    std::vector<ParticleState> track_;
     std::vector<InteractionType> types_;
     std::shared_ptr<ParticleDef> primary_def_;
     std::vector<Sector> sectors_;

--- a/include/PROPOSAL/Secondaries.h
+++ b/include/PROPOSAL/Secondaries.h
@@ -68,6 +68,9 @@ public:
     std::vector<DynamicData> GetTrack() const { return track_; };
     std::vector<DynamicData> GetTrack(const Geometry&) const;
 
+    DynamicData GetStateForEnergy(double) const;
+    DynamicData GetStateForDistance(double) const;
+
     std::vector<Vector3D> GetTrackPositions() const;
     std::vector<Vector3D> GetTrackDirections() const;
     std::vector<double> GetTrackEnergies() const;
@@ -88,7 +91,8 @@ public:
     std::vector<ContinuousLoss> GetContinuousLosses(const Geometry&) const;
 
 private:
-    DynamicData RePropagate(const DynamicData&, const Vector3D&, double) const;
+    DynamicData RePropagateDistance(const DynamicData&, double) const;
+    DynamicData RePropagateEnergy(const DynamicData&, double, double) const;
     Sector GetCurrentSector(const Vector3D&, const Vector3D&) const;
 
     std::vector<DynamicData> track_;

--- a/include/PROPOSAL/Secondaries.h
+++ b/include/PROPOSAL/Secondaries.h
@@ -34,11 +34,11 @@
 #include "PROPOSAL/particle/Particle.h"
 #include "PROPOSAL/particle/ParticleDef.h"
 #include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/geometry/Geometry.h"
+#include "PROPOSAL/propagation_utility/PropagationUtility.h"
 
 namespace PROPOSAL {
 
-class Geometry;
-class PropagationUtility;
 class Density_distr;
 
 using Sector = std::tuple<std::shared_ptr<const Geometry>, PropagationUtility,
@@ -73,8 +73,9 @@ public:
     std::vector<double> GetTrackEnergies() const;
     std::vector<double> GetTrackTimes() const;
     std::vector<double> GetTrackPropagatedDistances() const;
-    std::vector<InteractionType> GetTypes() const { return types_; };
+    std::vector<InteractionType> GetTrackTypes() const { return types_; };
     unsigned int GetTrackLength() const { return track_.size(); };
+    std::vector<DynamicData> GetDecayProducts() const;
 
     // Loss functions
 
@@ -85,8 +86,6 @@ public:
 
     std::vector<ContinuousLoss> GetContinuousLosses() const;
     std::vector<ContinuousLoss> GetContinuousLosses(const Geometry&) const;
-
-    void DoDecay();
 
 private:
     DynamicData RePropagate(const DynamicData&, const Vector3D&, double) const;

--- a/include/PROPOSAL/Secondaries.h
+++ b/include/PROPOSAL/Secondaries.h
@@ -49,47 +49,51 @@ class Secondaries {
 public:
     Secondaries(std::shared_ptr<ParticleDef>, std::vector<Sector>);
 
+    // Operational functions to fill and access track
     void reserve(size_t number_secondaries);
-    void clear() { secondaries_.clear(); };
-
-    DynamicData& operator[](std::size_t idx) { return secondaries_[idx]; };
-    DynamicData& back() { return secondaries_.back(); };
-
-    void push_back(const DynamicData& continuous_loss);
-    void emplace_back(const ParticleType& type, const Vector3D& position,
+    void clear() { track_.clear(); types_.clear(); };
+    void push_back(const DynamicData& point, const InteractionType& type);
+    void emplace_back(const ParticleType& particle_type, const Vector3D& position,
         const Vector3D& direction, const double& energy, const double& time,
-        const double& distance);
+        const double& distance, const InteractionType& interaction_type);
+    const DynamicData& back() const {return track_.back(); }
+    const DynamicData& operator[](std::size_t idx) { return track_[idx]; };
 
-    void append(Secondaries& secondaries);
+    // Track functions
+    double GetELost(const Geometry&) const;
+    std::unique_ptr<DynamicData> GetEntryPoint(const Geometry&) const;
+    std::unique_ptr<DynamicData> GetExitPoint(const Geometry&) const;
+    std::unique_ptr<DynamicData> GetClosestApproachPoint(const Geometry&) const;
 
-    Secondaries Query(const int&) const;
-    Secondaries Query(const std::string&) const;
-    Secondaries Query(const Geometry& geometry) const;
+    std::vector<DynamicData> GetTrack() const { return track_; };
+    std::vector<DynamicData> GetTrack(const Geometry&) const;
+
+    std::vector<Vector3D> GetTrackPositions() const;
+    std::vector<Vector3D> GetTrackDirections() const;
+    std::vector<double> GetTrackEnergies() const;
+    std::vector<double> GetTrackTimes() const;
+    std::vector<double> GetTrackPropagatedDistances() const;
+    std::vector<InteractionType> GetTypes() const { return types_; };
+    unsigned int GetTrackLength() const { return track_.size(); };
+
+    // Loss functions
+
+    std::vector<StochasticLoss> GetStochasticLosses() const;
+    std::vector<StochasticLoss> GetStochasticLosses(const Geometry&) const;
+    std::vector<StochasticLoss> GetStochasticLosses(const InteractionType&) const;
+    std::vector<StochasticLoss> GetStochasticLosses(const std::string&) const;
+
+    std::vector<ContinuousLoss> GetContinuousLosses() const;
+    std::vector<ContinuousLoss> GetContinuousLosses(const Geometry&) const;
 
     void DoDecay();
-
-    std::vector<Vector3D> GetPosition() const;
-    std::vector<Vector3D> GetDirection() const;
-    std::vector<double> GetEnergy() const;
-    std::vector<double> GetTime() const;
-    std::vector<double> GetPropagatedDistance() const;
-    std::vector<DynamicData> GetSecondaries() const { return secondaries_; };
-    std::vector<DynamicData>& GetModifyableSecondaries()
-    {
-        return secondaries_;
-    };
-    unsigned int GetNumberOfParticles() const { return secondaries_.size(); };
-
-    double GetELost(const Geometry&) const;
-    std::unique_ptr<DynamicData> GetEntryPoint(const Geometry& geometry) const;
-    std::unique_ptr<DynamicData> GetExitPoint(const Geometry& geometry) const;
-    std::unique_ptr<DynamicData> GetClosestApproachPoint(const Geometry& geometry) const;
 
 private:
     DynamicData RePropagate(const DynamicData&, const Vector3D&, double) const;
     Sector GetCurrentSector(const Vector3D&, const Vector3D&) const;
 
-    std::vector<DynamicData> secondaries_;
+    std::vector<DynamicData> track_;
+    std::vector<InteractionType> types_;
     std::shared_ptr<ParticleDef> primary_def_;
     std::vector<Sector> sectors_;
 };

--- a/include/PROPOSAL/Secondaries.h
+++ b/include/PROPOSAL/Secondaries.h
@@ -56,10 +56,8 @@ public:
     DynamicData& back() { return secondaries_.back(); };
 
     void push_back(const DynamicData& continuous_loss);
-    void emplace_back(const int& type);
-    void emplace_back(const int& type, const Vector3D& position,
-        const Vector3D& direction, const double& energy,
-        const double& parent_particle_energy, const double& time,
+    void emplace_back(const ParticleType& type, const Vector3D& position,
+        const Vector3D& direction, const double& energy, const double& time,
         const double& distance);
 
     void append(Secondaries& secondaries);
@@ -73,7 +71,6 @@ public:
     std::vector<Vector3D> GetPosition() const;
     std::vector<Vector3D> GetDirection() const;
     std::vector<double> GetEnergy() const;
-    std::vector<double> GetParentParticleEnergy() const;
     std::vector<double> GetTime() const;
     std::vector<double> GetPropagatedDistance() const;
     std::vector<DynamicData> GetSecondaries() const { return secondaries_; };

--- a/include/PROPOSAL/crosssection/parametrization/Annihilation.h
+++ b/include/PROPOSAL/crosssection/parametrization/Annihilation.h
@@ -75,14 +75,16 @@ cross_t_ptr<P, M> create_annihi(P p_def, M medium, bool interpol) {
 
 template<typename P, typename M>
 static std::map<std::string, annih_func_ptr<P, M>> annih_map = {
-        {"AnnihilationHeitler", create_annihi<AnnihilationHeitler, P, M>}
+        {"annihilationheitler", create_annihi<AnnihilationHeitler, P, M>}
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_annihilation(P p_def, M medium, bool interpol,
                                     const std::string& param_name){
 
-    auto it = annih_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = annih_map<P, M>.find(name);
     if (it == annih_map<P, M>.end())
         throw std::logic_error("Unknown parametrization for annihilation");
 

--- a/include/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
+++ b/include/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
@@ -114,19 +114,20 @@ cross_t_ptr<P, M> create_brems(P p_def, M medium,std::shared_ptr<const
 
 template<typename P, typename M>
 static std::map<std::string, brems_func_ptr<P, M>> brems_map = {
-        {"KelnerKokoulinPetrukhin", create_brems<BremsKelnerKokoulinPetrukhin, P, M>},
-        {"PetrukhinShestakov", create_brems<BremsPetrukhinShestakov, P, M>},
-        {"CompleteScreening", create_brems<BremsCompleteScreening, P, M>},
-        {"AndreevBezrukovBugaev", create_brems<BremsAndreevBezrukovBugaev, P, M>},
-        {"SandrockSoedingreksoRhode", create_brems<BremsSandrockSoedingreksoRhode, P, M>},
-        {"ElectronScreening", create_brems<BremsElectronScreening, P, M>}
+        {"kelnerkokoulinpetrukhin", create_brems<BremsKelnerKokoulinPetrukhin, P, M>},
+        {"petrukhinshestakov", create_brems<BremsPetrukhinShestakov, P, M>},
+        {"completescreening", create_brems<BremsCompleteScreening, P, M>},
+        {"andreevbezrukovbugaev", create_brems<BremsAndreevBezrukovBugaev, P, M>},
+        {"sandrocksoedingreksorhode", create_brems<BremsSandrockSoedingreksoRhode, P, M>},
+        {"electronscreening", create_brems<BremsElectronScreening, P, M>}
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_bremsstrahlung(P p_def, M medium, std::shared_ptr<const
         EnergyCutSettings> cuts, bool interpol, bool lpm, std::string param_name){
-
-    auto it = brems_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = brems_map<P, M>.find(name);
     if (it == brems_map<P, M>.end())
         throw std::logic_error("Unknown parametrization for bremsstrahlung");
 

--- a/include/PROPOSAL/crosssection/parametrization/Compton.h
+++ b/include/PROPOSAL/crosssection/parametrization/Compton.h
@@ -86,14 +86,15 @@ namespace crosssection {
 
     template<typename P, typename M>
     static std::map<std::string, compt_func_ptr<P, M>> compt_map = {
-            {"KleinNishina", create_compt<ComptonKleinNishina, P, M>},
+            {"kleinnishina", create_compt<ComptonKleinNishina, P, M>},
     };
 
     template<typename P, typename M>
     cross_t_ptr<P, M> make_compton(P p_def, M medium, std::shared_ptr<const
     EnergyCutSettings> cuts, bool interpol, const std::string& param_name) {
-
-        auto it = compt_map<P, M>.find(param_name);
+        std::string name = param_name;
+        std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+        auto it = compt_map<P, M>.find(name);
         if (it == compt_map<P, M>.end())
             throw std::logic_error("Unknown parametrization for compton");
 

--- a/include/PROPOSAL/crosssection/parametrization/EpairProduction.h
+++ b/include/PROPOSAL/crosssection/parametrization/EpairProduction.h
@@ -124,16 +124,17 @@ cross_t_ptr<P, M> create_epair(P p_def, M medium,std::shared_ptr<const
 
 template<typename P, typename M>
 static std::map<std::string, epair_func_ptr<P, M>> epair_map = {
-        {"KelnerKokoulinPetrukhin", create_epair<EpairKelnerKokoulinPetrukhin, P, M>},
-        {"SandrockSoedingreksoRhode", create_epair<EpairSandrockSoedingreksoRhode, P, M>},
-        {"ForElectronPositron", create_epair<EpairForElectronPositron, P, M>},
+        {"kelnerkokoulinpetrukhin", create_epair<EpairKelnerKokoulinPetrukhin, P, M>},
+        {"sandrocksoedingreksorhode", create_epair<EpairSandrockSoedingreksoRhode, P, M>},
+        {"forelectronpositron", create_epair<EpairForElectronPositron, P, M>},
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_epairproduction(P p_def, M medium, std::shared_ptr<const
         EnergyCutSettings> cuts, bool interpol, bool lpm, const std::string& param_name){
-
-    auto it = epair_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = epair_map<P, M>.find(name);
     if (it == epair_map<P, M>.end())
         throw std::logic_error("Unknown parametrization for epairproduction");
 

--- a/include/PROPOSAL/crosssection/parametrization/Ionization.h
+++ b/include/PROPOSAL/crosssection/parametrization/Ionization.h
@@ -122,9 +122,9 @@ cross_t_ptr<P, M> create_ioniz(P p_def, M medium,std::shared_ptr<const
 
 template<typename P, typename M>
 static std::map<std::string, ioniz_func_ptr<P, M>> ioniz_map = {
-        {"BetheBlochRossi", create_ioniz<IonizBetheBlochRossi, P, M>},
-        {"BergerSeltzerBhabha", create_ioniz<IonizBergerSeltzerBhabha, P, M>},
-        {"BergerSeltzerMoller", create_ioniz<IonizBergerSeltzerMoller, P, M>}
+        {"betheblochrossi", create_ioniz<IonizBetheBlochRossi, P, M>},
+        {"bergerseltzerbhabha", create_ioniz<IonizBergerSeltzerBhabha, P, M>},
+        {"bergerseltzermoller", create_ioniz<IonizBergerSeltzerMoller, P, M>}
 };
 
 template<typename P, typename M>
@@ -140,8 +140,9 @@ cross_t_ptr<P, M> make_ionization(P p_def, M medium, std::shared_ptr<const
 template<typename P, typename M>
 cross_t_ptr<P, M> make_ionization(P p_def, M medium, std::shared_ptr<const
         EnergyCutSettings> cuts, bool interpol, const std::string& param_name){
-
-    auto it = ioniz_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = ioniz_map<P, M>.find(name);
     if (it == ioniz_map<P, M>.end())
         throw std::logic_error("Unknown parametrization for ionization");
 

--- a/include/PROPOSAL/crosssection/parametrization/MupairProduction.h
+++ b/include/PROPOSAL/crosssection/parametrization/MupairProduction.h
@@ -93,14 +93,15 @@ cross_t_ptr<P, M> create_mupair(P p_def, M medium,std::shared_ptr<const
 
 template<typename P, typename M>
 static std::map<std::string, mupair_func_ptr<P, M>> mupair_map = {
-        {"KelnerKokoulinPetrukhin", create_mupair<MupairKelnerKokoulinPetrukhin, P, M>},
+        {"kelnerkokoulinpetrukhin", create_mupair<MupairKelnerKokoulinPetrukhin, P, M>},
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_mupairproduction(P p_def, M medium, std::shared_ptr<const
         EnergyCutSettings> cuts, bool interpol, const std::string& param_name){
-
-    auto it = mupair_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = mupair_map<P, M>.find(name);
     if (it == mupair_map<P, M>.end())
         throw std::logic_error("Unknown parametrization for mupairproduction");
 

--- a/include/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
+++ b/include/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
@@ -107,14 +107,15 @@ cross_t_ptr<P, M> create_photopair(P p_def, M medium, bool interpol) {
 
 template<typename P, typename M>
 static std::map<std::string, photopair_func_ptr<P, M>> photopair_map = {
-        {"Tsai", create_photopair<PhotoPairTsai, P, M>}
+        {"tsai", create_photopair<PhotoPairTsai, P, M>}
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_photopairproduction(P p_def, M medium, bool interpol,
                                     const std::string& param_name){
-
-    auto it = photopair_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = photopair_map<P, M>.find(name);
     if (it == photopair_map<P, M>.end())
         throw std::logic_error("Unknown parametrization for photopairproduction");
 

--- a/include/PROPOSAL/crosssection/parametrization/PhotoQ2Integration.h
+++ b/include/PROPOSAL/crosssection/parametrization/PhotoQ2Integration.h
@@ -122,10 +122,10 @@ cross_t_ptr<P, M> create_photoQ2(P p_def, M medium,std::shared_ptr<const
 
 template<typename P, typename M>
 static std::map<std::string, photoQ2_func_ptr<P, M>> photoQ2_map = {
-        {"AbramowiczLevinLevyMaor91", create_photoQ2<PhotoAbramowiczLevinLevyMaor91, P, M>},
-        {"AbramowiczLevinLevyMaor97", create_photoQ2<PhotoAbramowiczLevinLevyMaor97, P, M>},
-        {"ButkevichMikheyev", create_photoQ2<PhotoButkevichMikheyev, P, M>},
-        {"RenoSarcevicSu", create_photoQ2<PhotoRenoSarcevicSu, P, M>}
+        {"abramowiczlevinlevymaor91", create_photoQ2<PhotoAbramowiczLevinLevyMaor91, P, M>},
+        {"abramowiczlevinlevymaor97", create_photoQ2<PhotoAbramowiczLevinLevyMaor97, P, M>},
+        {"butkevichmikheyev", create_photoQ2<PhotoButkevichMikheyev, P, M>},
+        {"renosarcevicsu", create_photoQ2<PhotoRenoSarcevicSu, P, M>}
 };
 
 using shadow_func_ptr = std::shared_ptr<ShadowEffect>(*)();
@@ -136,20 +136,23 @@ std::shared_ptr<ShadowEffect> create_shadow() {
 }
 
 static std::map<std::string, shadow_func_ptr> shadow_map = {
-        {"DuttaRenoSarcevicSeckel", create_shadow<ShadowDuttaRenoSarcevicSeckel>},
-        {"ButkevichMikheyev", create_shadow<ShadowButkevichMikheyev>},
+        {"duttarenosarcevicseckel", create_shadow<ShadowDuttaRenoSarcevicSeckel>},
+        {"butkevichmikheyev", create_shadow<ShadowButkevichMikheyev>},
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_photonuclearQ2(P p_def, M medium, std::shared_ptr<const
         EnergyCutSettings> cuts, bool interpol, const std::string& param_name,
         const std::string& shadow_name){
-
-    auto it = photoQ2_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = photoQ2_map<P, M>.find(name);
     if (it == photoQ2_map<P, M>.end())
         throw std::invalid_argument("Unknown parametrization for photonuclear");
 
-    auto it_shadow = shadow_map.find(shadow_name);
+    std::string name2 = shadow_name;
+    std::transform(shadow_name.begin(), shadow_name.end(), name2.begin(), ::tolower);
+    auto it_shadow = shadow_map.find(name2);
     if(it_shadow == shadow_map.end())
         throw std::logic_error("Shadow effect name unknown");
     return it->second(p_def, medium, cuts, it_shadow->second(), interpol);

--- a/include/PROPOSAL/crosssection/parametrization/PhotoRealPhotonAssumption.h
+++ b/include/PROPOSAL/crosssection/parametrization/PhotoRealPhotonAssumption.h
@@ -93,18 +93,19 @@ cross_t_ptr<P, M> create_photoreal(P p_def, M medium,std::shared_ptr<const
 
 template<typename P, typename M>
 static std::map<std::string, photoreal_func_ptr<P, M>> photoreal_map = {
-        {"Zeus", create_photoreal<PhotoZeus, P, M>},
-        {"BezrukovBugaev", create_photoreal<PhotoBezrukovBugaev, P, M>},
-        {"Kokoulin", create_photoreal<PhotoKokoulin, P, M>},
-        {"Rhode", create_photoreal<PhotoRhode, P, M>},
+        {"zeus", create_photoreal<PhotoZeus, P, M>},
+        {"bezrukovbugaev", create_photoreal<PhotoBezrukovBugaev, P, M>},
+        {"kokoulin", create_photoreal<PhotoKokoulin, P, M>},
+        {"rhode", create_photoreal<PhotoRhode, P, M>},
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_photonuclearreal(P p_def, M medium, std::shared_ptr<const
         EnergyCutSettings> cuts, bool interpol, const std::string& param_name,
         bool hard_component){
-
-    auto it = photoreal_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = photoreal_map<P, M>.find(name);
     if (it == photoreal_map<P, M>.end())
         throw std::invalid_argument("Unknown parametrization for photonuclear");
 

--- a/include/PROPOSAL/crosssection/parametrization/WeakInteraction.h
+++ b/include/PROPOSAL/crosssection/parametrization/WeakInteraction.h
@@ -84,14 +84,15 @@ cross_t_ptr<P, M> create_weak(P p_def, M medium, bool interpol) {
 
 template<typename P, typename M>
 static std::map<std::string, weak_func_ptr<P, M>> weak_map = {
-        {"CooperSarkarMertsch", create_weak<WeakCooperSarkarMertsch, P, M>}
+        {"coopersarkarmertsch", create_weak<WeakCooperSarkarMertsch, P, M>}
 };
 
 template<typename P, typename M>
 cross_t_ptr<P, M> make_weakinteraction(P p_def, M medium, bool interpol,
                                     const std::string& param_name){
-
-    auto it = weak_map<P, M>.find(param_name);
+    std::string name = param_name;
+    std::transform(param_name.begin(), param_name.end(), name.begin(), ::tolower);
+    auto it = weak_map<P, M>.find(name);
     if (it == weak_map<P, M>.end())
         throw std::logic_error("Unknown parametrization for weak interaction");
 

--- a/include/PROPOSAL/decay/DecayChannel.h
+++ b/include/PROPOSAL/decay/DecayChannel.h
@@ -35,7 +35,7 @@
 namespace PROPOSAL {
 
 class Vector3D;
-struct DynamicData;
+struct ParticleState;
 class Particle;
 struct ParticleDef;
 
@@ -58,7 +58,7 @@ public:
     // Public methods
     // --------------------------------------------------------------------- //
 
-    virtual std::vector<DynamicData> Decay(const ParticleDef&, const DynamicData&) = 0;
+    virtual std::vector<ParticleState> Decay(const ParticleDef&, const ParticleState&) = 0;
 
     // ----------------------------------------------------------------------------
     /// @brief Boost the particle along a direction
@@ -75,7 +75,7 @@ public:
     /// @param gamma = E/m
     /// @param betagamma = beta*gamma = p/m
     // ----------------------------------------------------------------------------
-    static void Boost(DynamicData&, const Vector3D& direction, double gamma, double betagamma);
+    static void Boost(ParticleState&, const Vector3D& direction, double gamma, double betagamma);
 
     // ----------------------------------------------------------------------------
     /// @brief Boost a set of particles along a direction
@@ -89,7 +89,7 @@ public:
     /// @param betagamma = beta*gamma = p/m
     // ----------------------------------------------------------------------------
     /* static void Boost(const DecayProducts&, const Vector3D& direction, double gamma, double betagamma); */
-    static void Boost(std::vector<DynamicData>&, const Vector3D& direction, double gamma, double betagamma);
+    static void Boost(std::vector<ParticleState>&, const Vector3D& direction, double gamma, double betagamma);
 
     // ----------------------------------------------------------------------------
     /// @brief Calculate the momentum in a two-body-phase-space decay

--- a/include/PROPOSAL/decay/DecayChannel.h
+++ b/include/PROPOSAL/decay/DecayChannel.h
@@ -35,7 +35,7 @@
 namespace PROPOSAL {
 
 class Vector3D;
-class DynamicData;
+struct DynamicData;
 class Particle;
 struct ParticleDef;
 

--- a/include/PROPOSAL/decay/LeptonicDecayChannel.h
+++ b/include/PROPOSAL/decay/LeptonicDecayChannel.h
@@ -44,7 +44,7 @@ public:
     // No copy and assignemnt -> done by clone
     DecayChannel* clone() const { return new LeptonicDecayChannelApprox(*this); }
 
-    std::vector<DynamicData> Decay(const ParticleDef&, const DynamicData&);
+    std::vector<ParticleState> Decay(const ParticleDef&, const ParticleState&);
 
     const std::string& GetName() const { return name_; }
 

--- a/include/PROPOSAL/decay/ManyBodyPhaseSpace.h
+++ b/include/PROPOSAL/decay/ManyBodyPhaseSpace.h
@@ -59,7 +59,7 @@ public:
     };
 
     typedef std::unordered_map<ParticleDef, PhaseSpaceParameters> ParameterMap;
-    typedef std::function<double(const DynamicData&, const std::vector<DynamicData>&)> MatrixElementFunction;
+    typedef std::function<double(const ParticleState&, const std::vector<ParticleState>&)> MatrixElementFunction;
     typedef std::function<void(PhaseSpaceParameters&, const ParticleDef&)> EstimateFunction;
 
 public:
@@ -79,7 +79,7 @@ public:
     ///
     /// @return Vector of particles, the decay products
     // ----------------------------------------------------------------------------
-    std::vector<DynamicData> Decay(const ParticleDef& p_def, const DynamicData& p_condition);
+    std::vector<ParticleState> Decay(const ParticleDef& p_def, const ParticleState& p_condition);
 
     // ----------------------------------------------------------------------------
     /// @brief Evalutate the matrix element of this channel
@@ -90,14 +90,14 @@ public:
     ///
     /// @return matrix element
     // ----------------------------------------------------------------------------
-    static double DefaultEvaluate(const DynamicData&, const std::vector<DynamicData>&);
+    static double DefaultEvaluate(const ParticleState&, const std::vector<ParticleState>&);
 
     // ----------------------------------------------------------------------------
     /// @brief Evalutate the matrix element of this channel
     ///
     /// @return matrix element
     // ----------------------------------------------------------------------------
-    double Evaluate(const DynamicData&, const std::vector<DynamicData>&);
+    double Evaluate(const ParticleState&, const std::vector<ParticleState>&);
 
     // ----------------------------------------------------------------------------
     /// @brief Sets the uniform flag
@@ -126,7 +126,7 @@ private:
     ///
     /// @return Vector of particles, the decay products
     // ----------------------------------------------------------------------------
-    void GenerateEvent(std::vector<DynamicData>& products, const PhaseSpaceKinematics& kinematics);
+    void GenerateEvent(std::vector<ParticleState>& products, const PhaseSpaceKinematics& kinematics);
 
     // ----------------------------------------------------------------------------
     /// @brief Calculate the normalization of the phase space density

--- a/include/PROPOSAL/decay/StableChannel.h
+++ b/include/PROPOSAL/decay/StableChannel.h
@@ -45,7 +45,7 @@ public:
     DecayChannel* clone() const { return new StableChannel(*this); }
 
 
-    std::vector<DynamicData> Decay(const ParticleDef&, const DynamicData&);
+    std::vector<ParticleState> Decay(const ParticleDef&, const ParticleState&);
 
     const std::string& GetName() const { return name_; }
 

--- a/include/PROPOSAL/decay/TwoBodyPhaseSpace.h
+++ b/include/PROPOSAL/decay/TwoBodyPhaseSpace.h
@@ -46,7 +46,7 @@ public:
     // No copy and assignemnt -> done by clone
     DecayChannel* clone() const { return new TwoBodyPhaseSpace(*this); }
 
-    std::vector<DynamicData> Decay(const ParticleDef& p_def, const DynamicData& p_condition);
+    std::vector<ParticleState> Decay(const ParticleDef& p_def, const ParticleState& p_condition);
 
     const std::string& GetName() const { return name_; }
 

--- a/include/PROPOSAL/particle/Particle.h
+++ b/include/PROPOSAL/particle/Particle.h
@@ -83,17 +83,17 @@ static const std::unordered_map<InteractionType, std::string,
 
 namespace PROPOSAL {
 
-struct DynamicData {
+struct ParticleState {
 public:
-    DynamicData();
-    DynamicData(const Vector3D&, const Vector3D&, const double&,
-                const double&, const double&);
-    DynamicData(const ParticleType&, const Vector3D&, const Vector3D&, const double&,
-                const double&, const double&);
-    virtual ~DynamicData() = default;
-    bool operator==(const DynamicData&) const;
-    bool operator!=(const DynamicData&) const;
-    friend std::ostream& operator<<(std::ostream&, DynamicData const&);
+    ParticleState();
+    ParticleState(const Vector3D&, const Vector3D&, const double&,
+                  const double&, const double&);
+    ParticleState(const ParticleType&, const Vector3D&, const Vector3D&, const double&,
+                  const double&, const double&);
+    virtual ~ParticleState() = default;
+    bool operator==(const ParticleState&) const;
+    bool operator!=(const ParticleState&) const;
+    friend std::ostream& operator<<(std::ostream&, ParticleState const&);
 
     int type;
     Vector3D position;  //!< position coordinates [cm]

--- a/include/PROPOSAL/particle/Particle.h
+++ b/include/PROPOSAL/particle/Particle.h
@@ -91,7 +91,8 @@ public:
     DynamicData(const ParticleType&, const Vector3D&, const Vector3D&, const double&,
                 const double&, const double&);
     virtual ~DynamicData() = default;
-
+    bool operator==(const DynamicData&) const;
+    bool operator!=(const DynamicData&) const;
     friend std::ostream& operator<<(std::ostream&, DynamicData const&);
 
     int type;

--- a/include/PROPOSAL/scattering/ScatteringFactory.h
+++ b/include/PROPOSAL/scattering/ScatteringFactory.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -61,7 +62,10 @@ unique_ptr<Scattering> make_scattering(std::string const& name,
     ParticleDef const& p_def, Medium const& medium,
     Cross&& cross = nullptr, bool interpolate = true)
 {
-    auto it = ScatteringTable.find(name);
+    std::string name_lower = name;
+    std::transform(name.begin(), name.end(), name_lower.begin(), ::tolower);
+
+    auto it = ScatteringTable.find(name_lower);
     if (it != ScatteringTable.end()) {
         switch (it->second) {
         case ScatteringType::HighlandIntegral:

--- a/include/PROPOSAL/secondaries/Parametrization.h
+++ b/include/PROPOSAL/secondaries/Parametrization.h
@@ -17,8 +17,8 @@ namespace secondaries {
 
         virtual size_t RequiredRandomNumbers() const noexcept = 0;
         virtual InteractionType GetInteractionType() const noexcept = 0;
-        virtual vector<DynamicData> CalculateSecondaries(StochasticLoss,
-                                    const Component&, vector<double> &rnd) = 0;
+        virtual vector<ParticleState> CalculateSecondaries(StochasticLoss,
+                                                           const Component&, vector<double> &rnd) = 0;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/Parametrization.h
+++ b/include/PROPOSAL/secondaries/Parametrization.h
@@ -17,10 +17,8 @@ namespace secondaries {
 
         virtual size_t RequiredRandomNumbers() const noexcept = 0;
         virtual InteractionType GetInteractionType() const noexcept = 0;
-        virtual vector<Loss::secondary_t> CalculateSecondaries(
-            double primary_energy, Loss::secondary_t, const Component&,
-            vector<double> rnd)
-            = 0;
+        virtual vector<DynamicData> CalculateSecondaries(StochasticLoss,
+                                    const Component&, vector<double> &rnd) = 0;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/SecondariesCalculator.h
+++ b/include/PROPOSAL/secondaries/SecondariesCalculator.h
@@ -66,7 +66,8 @@ public:
     //! Calculates the secondary particle for a given loss. Initial particle is
     //! treated as a loss and returned as the first particle of the secondaries.
     //!
-    std::vector<Loss::secondary_t> CalculateSecondaries(double, Loss::secondary_t, Component const&, std::vector<double>);
+    std::vector<DynamicData> CalculateSecondaries(StochasticLoss, Component const&,
+                                                  std::vector<double>&);
 };
 
 //!

--- a/include/PROPOSAL/secondaries/SecondariesCalculator.h
+++ b/include/PROPOSAL/secondaries/SecondariesCalculator.h
@@ -66,8 +66,8 @@ public:
     //! Calculates the secondary particle for a given loss. Initial particle is
     //! treated as a loss and returned as the first particle of the secondaries.
     //!
-    std::vector<DynamicData> CalculateSecondaries(StochasticLoss, Component const&,
-                                                  std::vector<double>&);
+    std::vector<ParticleState> CalculateSecondaries(StochasticLoss, Component const&,
+                                                    std::vector<double>&);
 };
 
 //!

--- a/include/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.h
+++ b/include/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.h
@@ -35,8 +35,8 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept { return n_rnd; }
-        vector<DynamicData> CalculateSecondaries(StochasticLoss,
-                                                 const Component&, vector<double>&);
+        vector<ParticleState> CalculateSecondaries(StochasticLoss,
+                                                   const Component&, vector<double>&);
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.h
+++ b/include/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.h
@@ -35,8 +35,8 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept { return n_rnd; }
-        vector<Loss::secondary_t> CalculateSecondaries(
-            double, Loss::secondary_t, const Component&, vector<double>);
+        vector<DynamicData> CalculateSecondaries(StochasticLoss,
+                                                 const Component&, vector<double>&);
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.h
+++ b/include/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.h
@@ -18,8 +18,8 @@ namespace secondaries {
         NaivBremsstrahlung(ParticleDef p, Medium) :primary_lepton_type(p.particle_type) {};
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
-                                                 vector<double>&);
+        vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
+                                                   vector<double>&);
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.h
+++ b/include/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.h
@@ -18,8 +18,8 @@ namespace secondaries {
         NaivBremsstrahlung(ParticleDef p, Medium) :primary_lepton_type(p.particle_type) {};
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<Loss::secondary_t> CalculateSecondaries(
-            double, Loss::secondary_t, const Component&, vector<double>);
+        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
+                                                 vector<double>&);
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/compton/NaivCompton.h
+++ b/include/PROPOSAL/secondaries/compton/NaivCompton.h
@@ -24,8 +24,8 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept { return n_rnd; }
-        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
-                                                 vector<double>&);
+        vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
+                                                   vector<double>&);
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/compton/NaivCompton.h
+++ b/include/PROPOSAL/secondaries/compton/NaivCompton.h
@@ -18,14 +18,14 @@ namespace secondaries {
         static constexpr int n_rnd = 1;
 
         double CalculateRho(double, double) final;
-        enum { GAMMA, ELECTRON };
+        enum { GAMMA, EMINUS };
         tuple<Vector3D, Vector3D> CalculateDirections(
             Vector3D, double, double, double) final;
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept { return n_rnd; }
-        vector<Loss::secondary_t> CalculateSecondaries(
-            double, Loss::secondary_t, const Component&, vector<double>);
+        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
+                                                 vector<double>&);
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.h
+++ b/include/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.h
@@ -33,8 +33,8 @@ namespace PROPOSAL {
             //TODO: set lpm to true when possible
 
             size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-            vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
-                                                     vector<double>&) final;
+            vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
+                                                       vector<double>&) final;
         };
     } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.h
+++ b/include/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.h
@@ -20,9 +20,9 @@ namespace PROPOSAL {
             crosssection::EpairKelnerKokoulinPetrukhin param;
             Integral integral;
             ParticleDef p_def;
-            static constexpr int n_rnd = 2;
+            static constexpr int n_rnd = 3;
 
-            double CalculateRho(double, double, const Component&, double);
+            double CalculateRho(double, double, const Component&, double, double);
             tuple<Vector3D, Vector3D> CalculateDirections(
                     Vector3D, double, double, double);
             tuple<double, double> CalculateEnergy(double, double);
@@ -33,8 +33,8 @@ namespace PROPOSAL {
             //TODO: set lpm to true when possible
 
             size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-            vector<Loss::secondary_t> CalculateSecondaries(
-                    double, Loss::secondary_t, const Component&, vector<double>) final;
+            vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
+                                                     vector<double>&) final;
         };
     } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/epairproduction/NaivEpairProduction.h
+++ b/include/PROPOSAL/secondaries/epairproduction/NaivEpairProduction.h
@@ -24,9 +24,9 @@ namespace secondaries {
 
         NaivEpairProduction(ParticleDef, Medium){};
 
-        vector<Loss::secondary_t> CalculateSecondaries(
-            double, Loss::secondary_t, const Component&, vector<double>) {
-            auto sec = vector<Loss::secondary_t>{};
+        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
+                                                 vector<double>&) {
+            auto sec = vector<DynamicData>{};
             return sec;
         };
     };

--- a/include/PROPOSAL/secondaries/epairproduction/NaivEpairProduction.h
+++ b/include/PROPOSAL/secondaries/epairproduction/NaivEpairProduction.h
@@ -24,9 +24,9 @@ namespace secondaries {
 
         NaivEpairProduction(ParticleDef, Medium){};
 
-        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
-                                                 vector<double>&) {
-            auto sec = vector<DynamicData>{};
+        vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
+                                                   vector<double>&) {
+            auto sec = vector<ParticleState>{};
             return sec;
         };
     };

--- a/include/PROPOSAL/secondaries/ionization/NaivIonization.h
+++ b/include/PROPOSAL/secondaries/ionization/NaivIonization.h
@@ -28,8 +28,8 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<Loss::secondary_t> CalculateSecondaries(
-            double, Loss::secondary_t, const Component&, vector<double>) final;
+        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
+                                                 vector<double>&) final;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/ionization/NaivIonization.h
+++ b/include/PROPOSAL/secondaries/ionization/NaivIonization.h
@@ -28,8 +28,8 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
-                                                 vector<double>&) final;
+        vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
+                                                   vector<double>&) final;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.h
+++ b/include/PROPOSAL/secondaries/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.h
@@ -37,7 +37,7 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<DynamicData> CalculateSecondaries(
+        vector<ParticleState> CalculateSecondaries(
                 StochasticLoss, const Component&, vector<double>&) final;
     };
 } // namespace secondaries

--- a/include/PROPOSAL/secondaries/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.h
+++ b/include/PROPOSAL/secondaries/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.h
@@ -22,7 +22,7 @@ namespace secondaries {
         Integral integral;
         ParticleDef p_def;
 
-        static constexpr int n_rnd = 2;
+        static constexpr int n_rnd = 3;
 
     public:
         KelnerKokoulinPetrukhinMupairProduction(
@@ -31,14 +31,14 @@ namespace secondaries {
         {
         }
 
-        double CalculateRho(double, double, const Component&, double) final;
+        double CalculateRho(double, double, const Component&, double, double) final;
         tuple<Vector3D, Vector3D> CalculateDirections(
             Vector3D, double, double, double) final;
         tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<Loss::secondary_t> CalculateSecondaries(
-            double, Loss::secondary_t, const Component&, vector<double>) final;
+        vector<DynamicData> CalculateSecondaries(
+                StochasticLoss, const Component&, vector<double>&) final;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/mupairproduction/MupairProduction.h
+++ b/include/PROPOSAL/secondaries/mupairproduction/MupairProduction.h
@@ -15,8 +15,8 @@ namespace secondaries {
         static constexpr InteractionType type = PROPOSAL::InteractionType::MuPair;
         InteractionType GetInteractionType() const noexcept { return type; };
 
-        virtual double CalculateRho(double, double, const Component&, double)
-            = 0;
+        virtual double CalculateRho(double, double, const Component&, double,
+                                    double) = 0;
         virtual tuple<Vector3D, Vector3D> CalculateDirections(
             Vector3D, double, double, double)
             = 0;

--- a/include/PROPOSAL/secondaries/photonuclear/Photonuclear.h
+++ b/include/PROPOSAL/secondaries/photonuclear/Photonuclear.h
@@ -20,15 +20,18 @@ namespace secondaries {
             = PROPOSAL::InteractionType::Photonuclear;
         InteractionType GetInteractionType() const noexcept { return type; }
 
-        vector<Loss::secondary_t> CalculateSecondaries(double primary_energy,
-            Loss::secondary_t loss, const Component&, vector<double>)
+        vector<DynamicData> CalculateSecondaries(StochasticLoss loss, const Component&,
+                                                 vector<double>&)
         {
             std::cout << "a hadronic interaction modell must be called."
                       << std::endl;
+            //TODO: Treatment for hadronic interactions
+            /*
             std::get<Loss::TYPE>(loss) = primary_particle_type;
             std::get<Loss::ENERGY>(loss)
                 = primary_energy - std::get<Loss::ENERGY>(loss);
-            return std::vector<Loss::secondary_t>{loss};
+            */
+            return std::vector<DynamicData>{};
         };
     };
 } // namespace secondaries

--- a/include/PROPOSAL/secondaries/photonuclear/Photonuclear.h
+++ b/include/PROPOSAL/secondaries/photonuclear/Photonuclear.h
@@ -20,8 +20,8 @@ namespace secondaries {
             = PROPOSAL::InteractionType::Photonuclear;
         InteractionType GetInteractionType() const noexcept { return type; }
 
-        vector<DynamicData> CalculateSecondaries(StochasticLoss loss, const Component&,
-                                                 vector<double>&)
+        vector<ParticleState> CalculateSecondaries(StochasticLoss loss, const Component&,
+                                                   vector<double>&)
         {
             std::cout << "a hadronic interaction modell must be called."
                       << std::endl;
@@ -31,7 +31,7 @@ namespace secondaries {
             std::get<Loss::ENERGY>(loss)
                 = primary_energy - std::get<Loss::ENERGY>(loss);
             */
-            return std::vector<DynamicData>{};
+            return std::vector<ParticleState>{};
         };
     };
 } // namespace secondaries

--- a/include/PROPOSAL/secondaries/photopairproduction/PhotoTsai.h
+++ b/include/PROPOSAL/secondaries/photopairproduction/PhotoTsai.h
@@ -39,8 +39,8 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double, double) override;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
-                                                 vector<double>&) final;
+        vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
+                                                   vector<double>&) final;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/photopairproduction/PhotoTsai.h
+++ b/include/PROPOSAL/secondaries/photopairproduction/PhotoTsai.h
@@ -39,8 +39,8 @@ namespace secondaries {
         tuple<double, double> CalculateEnergy(double, double, double) override;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
-        vector<Loss::secondary_t> CalculateSecondaries(
-            double, Loss::secondary_t, const Component&, vector<double>) final;
+        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
+                                                 vector<double>&) final;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.h
+++ b/include/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.h
@@ -20,8 +20,8 @@ namespace secondaries {
             : weak_partner_type(p.weak_partner) {}
 
         size_t RequiredRandomNumbers() const noexcept override { return n_rnd; }
-        vector<Loss::secondary_t> CalculateSecondaries(double,
-            Loss::secondary_t, const Component&, vector<double>) override;
+        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
+                                                 vector<double>&) override;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/include/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.h
+++ b/include/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.h
@@ -20,8 +20,8 @@ namespace secondaries {
             : weak_partner_type(p.weak_partner) {}
 
         size_t RequiredRandomNumbers() const noexcept override { return n_rnd; }
-        vector<DynamicData> CalculateSecondaries(StochasticLoss, const Component&,
-                                                 vector<double>&) override;
+        vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
+                                                   vector<double>&) override;
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/interface/python/decay.cxx
+++ b/interface/python/decay.cxx
@@ -20,8 +20,8 @@ void init_decay(py::module& m) {
         .def("__eq__", &DecayChannel::operator==)
         .def("__ne__", &DecayChannel::operator!=)
         .def("decay", &DecayChannel::Decay, "Decay the given particle")
-        .def_static("boost", overload_cast_<DynamicData&, const Vector3D&, double, double>()(&DecayChannel::Boost))
-        .def_static("boost", overload_cast_<std::vector<DynamicData>&, const Vector3D&, double, double>()(&DecayChannel::Boost));
+        .def_static("boost", overload_cast_<ParticleState&, const Vector3D&, double, double>()(&DecayChannel::Boost))
+        .def_static("boost", overload_cast_<std::vector<ParticleState>&, const Vector3D&, double, double>()(&DecayChannel::Boost));
 
     py::class_<LeptonicDecayChannelApprox,
                std::shared_ptr<LeptonicDecayChannelApprox>, DecayChannel>(

--- a/interface/python/particle.cxx
+++ b/interface/python/particle.cxx
@@ -208,77 +208,104 @@ void init_particle(py::module& m) {
 
     py::class_<DynamicData, std::shared_ptr<DynamicData>>(m_sub, "DynamicData",
                                                           R"pbdoc(
-                Interaction will be stored in form of Dynamic Data.
-                It is used as an array with all important values for
-                secondary particles. Secondary particles are not propagated.
+                Dynamic data objects store information about particle states,
+                for example the intial particle state for the propagator,
+                specific states during propagation or secondary particles.
             )pbdoc")
-        .def(py::init<const int&>())
+        .def(py::init<const Vector3D&, const Vector3D&, const double&, const double&, const double&>(),
+                py::arg("position"), py::arg("direction"), py::arg("energy"),
+                py::arg("time"), py::arg("propagated_distance"))
+        .def(py::init<const ParticleType&, const Vector3D&, const Vector3D&, const double&, const double&, const double&>(),
+             py::arg("particle_type"), py::arg("position"), py::arg("direction"),
+             py::arg("energy"), py::arg("time"), py::arg("propagated_distance"))
         .def(py::init<const DynamicData&>())
         .def("__str__", &py_print<DynamicData>)
-        .def_property_readonly("type", &DynamicData::GetType,
+        .def_readwrite("type", &DynamicData::type,
                                R"pbdoc(
-                Type of Dynamic Data. Can be an Interaction Type
-                or a Particle Type.
+                Type of Dynamic Data. Describes the ParticleType of instance.
             )pbdoc")
         .def_property_readonly("name", &DynamicData::GetName,
                                R"pbdoc(
-                Name of Particle or interaction.
+                Name of Particle of instance.
             )pbdoc")
-        .def_property("position", &DynamicData::GetPosition,
-                      &DynamicData::SetPosition,
+        .def_readwrite("position", &DynamicData::position,
                       R"pbdoc(
-                Place of Interaction.
+                Position of particle (in cm).
             )pbdoc")
-        .def_property("direction", &DynamicData::GetDirection,
-                      &DynamicData::SetDirection,
+        .def_readwrite("direction", &DynamicData::direction,
                       R"pbdoc(
-                Direction of particle after interaction.
+                Direction of particle.
             )pbdoc")
-        .def_property("energy", &DynamicData::GetEnergy,
-                      &DynamicData::SetEnergy,
+        .def_readwrite("energy", &DynamicData::energy,
                       R"pbdoc(
-                Energy of secondary particle.
+                Energy of particle in MeV.
             )pbdoc")
         .def_property("momentum", &DynamicData::GetMomentum,
                       &DynamicData::SetMomentum,
                       R"pbdoc(
-                Momentum of primary particle in MeV
+                Momentum of particle in MeV
             )pbdoc")
-        .def_property("parent_particle_energy",
-                      &DynamicData::GetParentParticleEnergy,
-                      &DynamicData::SetParentParticleEnergy,
+        .def_readwrite("time", &DynamicData::time,
                       R"pbdoc(
-                Energy of primary particle after interaction.
+                Time (in sec) since beginning of propagation the particle.
             )pbdoc")
-        .def_property("time", &DynamicData::GetTime, &DynamicData::SetTime,
-                      R"pbdoc(
-                Time since beginning of propagation the primary particle.
-            )pbdoc")
-        .def_property("propagated_distance",
-                      &DynamicData::GetPropagatedDistance,
-                      &DynamicData::SetPropagatedDistance,
+        .def_readwrite("propagated_distance", &DynamicData::propagated_distance,
                       R"pbdoc(
                 Propagated distance of primary particle.
             )pbdoc");
 
-    /* py::class_<std::vector<DynamicData>>(m, "Secondaries"); */
+    py::class_<Loss, std::shared_ptr<Loss>>(m_sub, "Loss", R"pbdoc(
+                Loss objects are the base class for energy losses (stochastic
+                and continuous losses) in PROPOSAL. They are defined by their
+                type and energy. More specific information are stored in the
+                derived classes.
+            )pbdoc")
+            .def(py::init<const int&, const double&>(),
+                    py::arg("type"), py::arg("loss_energy"))
+            .def_readwrite("type", &Loss::type)
+            .def_readwrite("loss_energy", &Loss::loss_energy);
 
-    /* py::class_<Secondaries, std::shared_ptr<Secondaries>>(m_sub, "Secondaries", */
-    /*         R"pbdoc(List of secondaries)pbdoc"); */
-    /*     .def("Query", overload_cast_<const int&>()(&Secondaries::Query, py::const_), py::arg("Interaction")) */
-    /*     .def("Query", overload_cast_<const std::string&>()(&Secondaries::Query, py::const_), py::arg("Interaction")) */
-    /*     .def("decay", &Secondaries::DoDecay) */
-    /*     .def_property_readonly("particles", &Secondaries::GetSecondaries) */
-    /*     .def_property_readonly("number_of_particles", &Secondaries::GetNumberOfParticles) */
-    /*     .def_property_readonly("position", &Secondaries::GetPosition) */
-    /*     .def_property_readonly("direction", &Secondaries::GetDirection) */
-    /*     .def_property_readonly("parent_particle_energy", &Secondaries::GetParentParticleEnergy) */
-    /*     .def_property_readonly("energy", &Secondaries::GetEnergy) */
-    /*     .def_property_readonly("time", &Secondaries::GetTime) */
-    /*     .def_property_readonly("propagated_distance", &Secondaries::GetPropagatedDistance) */
-    /*     .def_property_readonly("entry_point", &Secondaries::GetEntryPoint) */
-    /*     .def_property_readonly("exit_point", &Secondaries::GetExitPoint) */
-    /*     .def_property_readonly("closest_approach_point", &Secondaries::GetClosestApproachPoint); */
+    py::class_<StochasticLoss, Loss, std::shared_ptr<StochasticLoss>>(m_sub, "StochasticLoss")
+            .def(py::init<const int&, const double&, const Vector3D&, const Vector3D&, const double&, const double&, const double &>(),
+                 py::arg("type"), py::arg("loss_energy"), py::arg("position"),
+                 py::arg("direction"), py::arg("time"),
+                 py::arg("propagated_distance"),
+                 py::arg("parent_particle_energy"))
+            .def_readwrite("position", &StochasticLoss::position)
+            .def_readwrite("direction", &StochasticLoss::direction)
+            .def_readwrite("time", &StochasticLoss::time)
+            .def_readwrite("propagated_distance", &StochasticLoss::propagated_distance)
+            .def_readwrite("parent_particle_energy", &StochasticLoss::parent_particle_energy);
+
+    py::class_<ContinuousLoss, Loss, std::shared_ptr<ContinuousLoss>>(m_sub, "ContinuousLoss")
+            .def(py::init<const std::pair<double, double>&, const std::pair<Vector3D, Vector3D>&, const std::pair<Vector3D, Vector3D>&, const std::pair<double, double>&>(),
+                    py::arg("energies"), py::arg("positions"), py::arg("directions"), py::arg("times"))
+            .def_readwrite("energies", &ContinuousLoss::energies)
+            .def_readwrite("positions", &ContinuousLoss::positions)
+            .def_readwrite("directions", &ContinuousLoss::directions)
+            .def_readwrite("times", &ContinuousLoss::times);
+
+    py::class_<Secondaries, std::shared_ptr<Secondaries>>(m_sub, "Secondaries", R"pbdoc(Output of Propagator.)pbdoc")
+            .def("ELost", &Secondaries::GetELost)
+            .def("entry_point", &Secondaries::GetEntryPoint)
+            .def("exit_point", &Secondaries::GetExitPoint)
+            .def("closest_approach_point", &Secondaries::GetClosestApproachPoint)
+            .def("track", overload_cast_<>()(&Secondaries::GetTrack, py::const_))
+            .def("track", overload_cast_<const Geometry&>()(&Secondaries::GetTrack, py::const_))
+            .def("track_positions", &Secondaries::GetTrackPositions)
+            .def("track_directions", &Secondaries::GetTrackDirections)
+            .def("track_energies", &Secondaries::GetTrackEnergies)
+            .def("track_times", &Secondaries::GetTrackTimes)
+            .def("track_propagated_distances", &Secondaries::GetTrackPropagatedDistances)
+            .def("track_types", &Secondaries::GetTrackTypes)
+            .def("track_length", &Secondaries::GetTrackLength)
+            .def("stochastic_losses", overload_cast_<>()(&Secondaries::GetStochasticLosses, py::const_))
+            .def("stochastic_losses", overload_cast_<const Geometry&>()(&Secondaries::GetStochasticLosses, py::const_))
+            .def("stochastic_losses", overload_cast_<const InteractionType&>()(&Secondaries::GetStochasticLosses, py::const_))
+            .def("stochastic_losses", overload_cast_<const std::string&>()(&Secondaries::GetStochasticLosses, py::const_))
+            .def("continuous_losses", overload_cast_<>()(&Secondaries::GetContinuousLosses, py::const_))
+            .def("continuous_losses", overload_cast_<const Geometry&>()(&Secondaries::GetContinuousLosses, py::const_))
+            .def("decay_products", &Secondaries::GetDecayProducts);
 
     py::enum_<InteractionType>(m_sub, "Interaction_Type")
         .value("particle", InteractionType::Particle)

--- a/interface/python/particle.cxx
+++ b/interface/python/particle.cxx
@@ -293,6 +293,8 @@ void init_particle(py::module& m) {
             .def("closest_approach_point", &Secondaries::GetClosestApproachPoint)
             .def("track", overload_cast_<>()(&Secondaries::GetTrack, py::const_))
             .def("track", overload_cast_<const Geometry&>()(&Secondaries::GetTrack, py::const_))
+            .def("get_state_for_energy", &Secondaries::GetStateForEnergy)
+            .def("get_state_for_distance", &Secondaries::GetStateForDistance)
             .def("track_positions", &Secondaries::GetTrackPositions)
             .def("track_directions", &Secondaries::GetTrackDirections)
             .def("track_energies", &Secondaries::GetTrackEnergies)

--- a/interface/python/particle.cxx
+++ b/interface/python/particle.cxx
@@ -215,6 +215,7 @@ void init_particle(py::module& m) {
         .def(py::init<const Vector3D&, const Vector3D&, const double&, const double&, const double&>(),
                 py::arg("position"), py::arg("direction"), py::arg("energy"),
                 py::arg("time"), py::arg("propagated_distance"))
+        .def(py::init<>())
         .def(py::init<const ParticleType&, const Vector3D&, const Vector3D&, const double&, const double&, const double&>(),
              py::arg("particle_type"), py::arg("position"), py::arg("direction"),
              py::arg("energy"), py::arg("time"), py::arg("propagated_distance"))

--- a/interface/python/particle.cxx
+++ b/interface/python/particle.cxx
@@ -206,8 +206,8 @@ void init_particle(py::module& m) {
     PARTICLE_DEF(m_sub, SMPMinus)
     PARTICLE_DEF(m_sub, SMPPlus)
 
-    py::class_<DynamicData, std::shared_ptr<DynamicData>>(m_sub, "DynamicData",
-                                                          R"pbdoc(
+    py::class_<ParticleState, std::shared_ptr<ParticleState>>(m_sub, "ParticleState",
+                                                              R"pbdoc(
                 Dynamic data objects store information about particle states,
                 for example the intial particle state for the propagator,
                 specific states during propagation or secondary particles.
@@ -219,38 +219,38 @@ void init_particle(py::module& m) {
         .def(py::init<const ParticleType&, const Vector3D&, const Vector3D&, const double&, const double&, const double&>(),
              py::arg("particle_type"), py::arg("position"), py::arg("direction"),
              py::arg("energy"), py::arg("time"), py::arg("propagated_distance"))
-        .def(py::init<const DynamicData&>())
-        .def("__str__", &py_print<DynamicData>)
-        .def_readwrite("type", &DynamicData::type,
+        .def(py::init<const ParticleState&>())
+        .def("__str__", &py_print<ParticleState>)
+        .def_readwrite("type", &ParticleState::type,
                                R"pbdoc(
                 Type of Dynamic Data. Describes the ParticleType of instance.
             )pbdoc")
-        .def_property_readonly("name", &DynamicData::GetName,
+        .def_property_readonly("name", &ParticleState::GetName,
                                R"pbdoc(
                 Name of Particle of instance.
             )pbdoc")
-        .def_readwrite("position", &DynamicData::position,
+        .def_readwrite("position", &ParticleState::position,
                       R"pbdoc(
                 Position of particle (in cm).
             )pbdoc")
-        .def_readwrite("direction", &DynamicData::direction,
+        .def_readwrite("direction", &ParticleState::direction,
                       R"pbdoc(
                 Direction of particle.
             )pbdoc")
-        .def_readwrite("energy", &DynamicData::energy,
+        .def_readwrite("energy", &ParticleState::energy,
                       R"pbdoc(
                 Energy of particle in MeV.
             )pbdoc")
-        .def_property("momentum", &DynamicData::GetMomentum,
-                      &DynamicData::SetMomentum,
+        .def_property("momentum", &ParticleState::GetMomentum,
+                      &ParticleState::SetMomentum,
                       R"pbdoc(
                 Momentum of particle in MeV
             )pbdoc")
-        .def_readwrite("time", &DynamicData::time,
+        .def_readwrite("time", &ParticleState::time,
                       R"pbdoc(
                 Time (in sec) since beginning of propagation the particle.
             )pbdoc")
-        .def_readwrite("propagated_distance", &DynamicData::propagated_distance,
+        .def_readwrite("propagated_distance", &ParticleState::propagated_distance,
                       R"pbdoc(
                 Propagated distance of primary particle.
             )pbdoc");

--- a/interface/python/pybindings.cxx
+++ b/interface/python/pybindings.cxx
@@ -281,7 +281,6 @@ PYBIND11_MODULE(proposal, m)
         .def("energy_randomize", &PropagationUtility::EnergyRandomize)
         .def("energy_distance", &PropagationUtility::EnergyDistance)
         .def("length_continuous", &PropagationUtility::LengthContinuous)
-        .def("length_continuous", &PropagationUtility::LengthContinuous)
         .def("directions_scatter", &PropagationUtility::DirectionsScatter);
 
 
@@ -306,136 +305,6 @@ PYBIND11_MODULE(proposal, m)
         /*         )pbdoc") */
 
 
-    /* py::enum_<Sector::ParticleLocation::Enum>(m, "ParticleLocation") */
-    /*     .value("infront_detector", Sector::ParticleLocation::InfrontDetector) */
-    /*     .value("inside_detector", Sector::ParticleLocation::InsideDetector) */
-    /*     .value("behind_detector", Sector::ParticleLocation::BehindDetector); */
-
-    /* py::class_<Sector::Definition, std::shared_ptr<Sector::Definition>>(m, */
-    /*     "SectorDefinition", */
-    /*     R"pbdoc( */
-    /*             Sector definition is a container that collects all important */
-    /*             settings for propagation through a sector. There could for */
-    /*             example specify the used cross sections or the energy cut */
-    /*             settings. */
-
-    /*             An example for multiple SectorDefinitions is the standard */
-    /*             implementation of propagation. Three sectors are generated, */
-    /*             which differ in the energy cut settings, to reduce computing */
-    /*             power without a measurable loss of accuracy. Infront of the */
-    /*             detector energy cut will be like :math:`v_\text{cut} = 0.05`. */
-    /*             Inside the detector the energy cut :math:`e_\text{cut} = 500 */
-    /*             \text{MeV}` is chosen so that particles below the detector */
-    /*             resolution are statistically sampled. Outside of the detector no */
-    /*             cuts are made to find a decay point of the particle in first */
-    /*             approximation. */
-    /*         )pbdoc") */
-    /*     .def(py::init<>()) */
-    /*     .def("__str__", &py_print<Sector::Definition>) */
-    /*     .def_readwrite("cut_settings", &Sector::Definition::cut_settings, */
-    /*         R"pbdoc( */
-    /*                 Definition of the :meth:`EnergyCutSettings` */
-    /*             )pbdoc") */
-    /*     .def_property("medium", &Sector::Definition::GetMedium, */
-    /*         &Sector::Definition::SetMedium, */
-    /*         R"pbdoc( */
-    /*                 Definition of the :meth:`~proposal.medium.Medium` */
-    /*             )pbdoc") */
-    /*     .def_property("geometry", &Sector::Definition::GetGeometry, */
-    /*         &Sector::Definition::SetGeometry, */
-    /*         R"pbdoc( */
-    /*                 Definiton of the :meth:`~proposal.geometry.Geometry` */
-    /*             )pbdoc") */
-    /*     .def_readwrite("do_stochastic_loss_weighting", */
-    /*         &Sector::Definition::do_stochastic_loss_weighting, */
-    /*         R"pbdoc( */
-    /*                 Boolean value whether the probability of producing a */
-    /*                 stochastic loss should be adjusted with a factor, */
-    /*                 defaults to False. */
-    /*             )pbdoc") */
-    /*     .def_readwrite("stochastic_loss_weighting", */
-    /*         &Sector::Definition::stochastic_loss_weighting, */
-    /*         R"pbdoc( */
-    /*                 Factor used to scale the probability of producing a */
-    /*                 stochastic loss, defaults to 1.0. */
-    /*             )pbdoc") */
-    /*     .def_readwrite("stopping_decay", &Sector::Definition::stopping_decay, */
-    /*         R"pbdoc( */
-
-    /*             )pbdoc") */
-    /*     .def_readwrite("do_continuous_randomization", */
-    /*         &Sector::Definition::do_continuous_randomization, */
-    /*         R"pbdoc( */
-    /*                 Boolean if continous randomization should be done if */
-    /*                 interpolation if is used, defaults to true. */
-    /*             )pbdoc") */
-    /*     .def_readwrite("do_continuous_energy_loss_output", */
-    /*         &Sector::Definition::do_continuous_energy_loss_output, */
-    /*         R"pbdoc( */
-
-    /*             )pbdoc") */
-    /*     .def_readwrite("do_exact_time_calculation", */
-    /*         &Sector::Definition::do_exact_time_calculation, */
-    /*         R"pbdoc( */
-    /*                 Boolean if particle speed could be approach by the speed */
-    /*                 of light or should be calculated by solving the track */
-    /*                 integral, defaults to false. */
-
-    /*                 If the energy is in the order of the rest energy of the */
-    /*                 particle, the assumption that the particle moves at the */
-    /*                 speed of light becomes increasingly worse. Than it make */
-    /*                 sense to calculate the time integral. */
-
-    /*                 .. math:: */
-
-    /*                         t_\text{f} = t_\text{i} + \int_{x_\text{i}}^{x_\text{f}} */
-    /*                             \frac{ \text{dx} }{ v(x) } */
-    /*             )pbdoc") */
-    /*     .def_readwrite("scattering_model", */
-    /*         &Sector::Definition::scattering_model, */
-    /*         R"pbdoc( */
-    /*                 Definition of the scattering modell of type :meth:`~proposal.scattering.ScatteringModel` */
-    /*                 or deactivate scattering. */
-
-    /*                 Example: */
-    /*                     Deactivating scattering can be achieved with: */
-
-    /*                     >>> sec = proposal.SectorDefinition() */
-    /*                     >>> sec.scattering_model = proposal.scattering.ScatteringModel.NoScattering */
-    /*             )pbdoc") */
-    /*     .def_readwrite("particle_location", &Sector::Definition::location, */
-    /*         R"pbdoc( */
-    /*                 Definition of the relationship of the sectors to each */
-    /*                 other of type :meth:`ParticleLocation`. */
-    /*             )pbdoc") */
-    /*     .def_readwrite("crosssection_defs", &Sector::Definition::utility_def, */
-    /*         R"pbdoc( */
-    /*                 Definition of the crosssection of type :meth:`~proposal.UtilityDefinition` */
-    /*             )pbdoc"); */
-
-    /* py::class_<Sector, std::shared_ptr<Sector>>(m, "Sector", R"pbdoc( */
-    /*         A sector is characterized by its homogeneous attitudes. */
-    /*         Within a sector there are no boundaries to consider. */
-    /*     )pbdoc") */
-    /*     .def(py::init<ParticleDef&, const Sector::Definition&>(), */
-    /*         py::arg("particle_def"), py::arg("sector_definition")) */
-    /*     .def(py::init<ParticleDef&, const Sector::Definition&, */
-    /*              const InterpolationDef&>(), */
-    /*         py::arg("particle_def"), py::arg("sector_definition"), */
-    /*         py::arg("interpolation_def")) */
-    /*     .def("energy_decay", &Sector::EnergyDecay, py::arg("initial_energy"), */
-    /*         py::arg("rnd")) */
-    /*     .def("energy_interaction", &Sector::EnergyInteraction, */
-    /*         py::arg("initial_energy"), py::arg("rnd")) */
-    /*     .def("energy_minimal", &Sector::EnergyMinimal, */
-    /*         py::arg("initial_energy"), py::arg("cut")) */
-    /*     .def("energy_distance", &Sector::EnergyDistance, */
-    /*         py::arg("initial_energy"), py::arg("distance")) */
-    /*     .def("make_stochastic_loss", &Sector::MakeStochasticLoss, */
-    /*         py::arg("minimal_energy")) */
-    /*     .def("propagate", &Sector::Propagate, */
-    /*         py::arg("particle_condition"), py::arg("max_distance"), py::arg("min_energy")); */
-
     /* py::class_<RandomGenerator, std::unique_ptr<RandomGenerator, py::nodelete>>( */
     /*     m, "RandomGenerator") */
     /*     .def("random_double", &RandomGenerator::RandomDouble) */
@@ -445,113 +314,16 @@ PYBIND11_MODULE(proposal, m)
     /*     .def_static( */
     /*         "get", &RandomGenerator::Get, py::return_value_policy::reference); */
 
-    /* py::class_<Propagator, std::shared_ptr<Propagator>>(m, "Propagator") */
-    /*     .def(py::init<ParticleDef const&, std::vector<Sector>>()) */
-    /*     .def(py::init<GammaDef, std::string const&>()) */
-    /*     .def(py::init<EMinusDef, std::string const&>()) */
-    /*     .def(py::init<EPlusDef, std::string const&>()) */
-    /*     .def(py::init<MuMinusDef, std::string const&>()) */
-    /*     .def(py::init<MuPlusDef, std::string const&>()) */
-    /*     .def(py::init<TauMinusDef, std::string const&>()) */
-    /*     .def(py::init<TauPlusDef, std::string const&>()) */
-    /*     .def("propagate", &Propagator::Propagate, py::arg("initial_particle"), py::arg("max_distance"), py::arg("min_energy")); */
-
-    /*     .def( */
-    /*         py::init<const ParticleDef&, const std::vector<Sector::Definition>&, */
-    /*             std::shared_ptr<const Geometry>, const InterpolationDef&>(), */
-    /*         py::arg("particle_def"), py::arg("sector_defs"), */
-    /*         py::arg("detector"), py::arg("interpolation_def"), R"pbdoc( */
-    /*                 Function Docstring. */
-
-    /*                 Args: */
-    /*                     particle_def (proposal.particle.ParticleDef): definition of the particle to propagate describing the basic properties. */
-    /*                     sector_defs (List[proposal.SectorDefinition]): list of the sectors describing the environment around the detector. */
-    /*                     detector (proposal.geometry.Geometry): geometry of the detector. */
-    /*                     interpolation_def (proposal.InterpolationDef): definition of the Interpolation tables like path to store them, etc. */
-    /*             )pbdoc") */
-    /*     .def(py::init<const ParticleDef&, */
-    /*              const std::vector<Sector::Definition>&, std::shared_ptr<const Geometry>>(), */
-    /*         py::arg("particle_def"), py::arg("sector_defs"), */
-    /*         py::arg("detector")) */
-    /*     .def(py::init<const ParticleDef&, const std::string&>(), */
-    /*         py::arg("particle_def"), py::arg("config_file")) */
-    /*     .def("propagate", &Propagator::Propagate, */
-    /*         py::arg("particle_condition"), */
-    /*         py::arg("max_distance_cm") = 1e20, */
-    /*         py::arg("minimal_energy") = 0., */
-    /*         py::return_value_policy::reference, */
-    /*         R"pbdoc( */
-    /*                 Propagate a particle through sectors and produce stochastic */
-    /*                 losses, untill propagated distance is reached. */
-
-    /*                 Args: */
-    /*                     max_distance_cm (float): Maximum distance a particle is */
-    /*                         propagated before it is considered lost. */
-
-    /*                 Returns: */
-    /*                     list(DynamicData): list of stochastic losses parameters */
-    /*                     list(list): list of stochastic losses parameters */
-
-    /*                 Example: */
-    /*                     Propagate 1000 particle with an inital energy of 100 */
-    /*                     Tev and save the losses in daughters. */
-
-    /*                     >>> for i in range(int(1e3)): */
-    /*                     >>>   mu.energy = 1e8 */
-    /*                     >>>   mu.propagated_distance = 0 */
-    /*                     >>>   mu.position = pp.Vector3D(0, 0, 0) */
-    /*                     >>>   mu.direction = pp.Vector3D(0, 0, -1) */
-    /*                     >>>   daughters = prop.propagate() */
-
-    /*                 Further basic condition are set at the next point of */
-    /*                 interaction during generation. */
-    /*                 The aim is to introduce forced stochastic losses */
-    /*                 so that the particle can be propagated through homogeneous */
-    /*                 sectors. */
-    /*                 A more percise description of propagation through a */
-    /*                 homoegenous sector can be found in ???. */
-
-    /*                 .. figure:: figures/sector.png */
-    /*                     :height: 200px */
-    /*                     :align: center */
-
-    /*                     If the next interaction point is outside the actuell */
-    /*                     sector, the particle is forced to an interaction at the */
-    /*                     sector boundary. Thus it can be assumed that the */
-    /*                     particle is porpagated by a homogeneous medium. */
-
-    /*                 The propagated particle will be forced to interact in the */
-    /*                 closest point to the dector center. */
-    /*                 This will be stored in the closest_approach variable of */
-    /*                 the propagated particle. */
-
-    /*                 The propagation terminate if the maximal distance is */
-    /*                 reached. */
-    /*                 The energy loss of the particle (e_lost) in the detector */
-    /*                 will be calculated and the produced secondary particles */
-    /*                 returned. */
-    /*             )pbdoc") */
-    /*     .def_property_readonly("particle_def", &Propagator::GetParticleDef, */
-    /*         R"pbdoc( */
-    /*                 Get the internal particle definition to use its properties. */
-
-    /*                 Returns: */
-    /*                     ParticleDefinition: the definition of the propagated particle. */
-    /*             )pbdoc") */
-    /*     .def_property_readonly("sector", &Propagator::GetCurrentSector, */
-    /*         R"pbdoc( */
-    /*                 "Get the current sector" */
-
-    /*                 Returns: */
-    /*                     Sector: the current sector, where the particle is at the moment. */
-    /*             )pbdoc") */
-    /*     .def_property_readonly("detector", &Propagator::GetDetector, */
-    /*         R"pbdoc( */
-    /*                 Get the detector geometry. */
-
-    /*                 Returns: */
-    /*                     Geometry: the geometry of the detector. */
-    /*             )pbdoc"); */
+    py::class_<Propagator, std::shared_ptr<Propagator>>(m, "Propagator")
+        .def(py::init<ParticleDef const&, std::vector<Sector>>())
+        .def(py::init<GammaDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<EMinusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<EPlusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<MuMinusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<MuPlusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<TauMinusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<TauPlusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def("propagate", &Propagator::Propagate, py::arg("initial_particle"), py::arg("max_distance") = 1.e20, py::arg("min_energy") = 0.);
 
 
     /* py::class_<PropagatorService, std::shared_ptr<PropagatorService>>( */
@@ -564,14 +336,3 @@ PYBIND11_MODULE(proposal, m)
     /*         py::arg("propagator")); */
 }
 
-// #undef COMPONENT_DEF
-// #undef MEDIUM_DEF
-// #undef AXIS_DEF
-// #undef BREMS_DEF
-// #undef PHOTO_REAL_DEF
-// #undef PHOTO_Q2_DEF
-// #undef PHOTO_Q2_INTERPOL_DEF
-// #undef EPAIR_DEF
-// #undef EPAIR_INTERPOL_DEF
-// #undef MUPAIR_DEF
-// #undef MUPAIR_INTERPOL_DEF

--- a/interface/python/pybindings.cxx
+++ b/interface/python/pybindings.cxx
@@ -316,13 +316,13 @@ PYBIND11_MODULE(proposal, m)
 
     py::class_<Propagator, std::shared_ptr<Propagator>>(m, "Propagator")
         .def(py::init<ParticleDef const&, std::vector<Sector>>())
-        .def(py::init<GammaDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
-        .def(py::init<EMinusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
-        .def(py::init<EPlusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
-        .def(py::init<MuMinusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
-        .def(py::init<MuPlusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
-        .def(py::init<TauMinusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
-        .def(py::init<TauPlusDef, std::string const&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<GammaDef, const std::string&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<EMinusDef, const std::string&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<EPlusDef, const std::string&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<MuMinusDef, const std::string&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<MuPlusDef, const std::string&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<TauMinusDef, const std::string&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
+        .def(py::init<TauPlusDef, const std::string&>(), py::arg("particle_def"), py::arg("path_to_config_file"))
         .def("propagate", &Propagator::Propagate, py::arg("initial_particle"), py::arg("max_distance") = 1.e20, py::arg("min_energy") = 0.);
 
 

--- a/resources/config_new.json
+++ b/resources/config_new.json
@@ -14,9 +14,25 @@
 			"medium": "ice",
 			"geometries": [
 				{
+					"hierarchy": 0,
 					"shape": "sphere",
 					"origin": [0, 0, 0],
 					"outer_radius": 6374134000000
+				},
+				{
+					"hierarchy": 1,
+					"shape": "box",
+					"origin": [0, 0, 10000],
+					"length": 1000,
+					"width" : 1000,
+					"height" : 1000
+				},
+				{
+					"hierarchy": 1,
+					"shape": "sphere",
+					"origin": [0, 0, 30000],
+					"outer_radius": 1000,
+					"inner_radius": 500
 				}
 			]
 		}

--- a/src/PROPOSAL/EnergyCutSettings.cxx
+++ b/src/PROPOSAL/EnergyCutSettings.cxx
@@ -1,6 +1,7 @@
 #include "PROPOSAL/EnergyCutSettings.h"
 #include "PROPOSAL/Logging.h"
 #include "PROPOSAL/methods.h"
+#include "PROPOSAL/Constants.h"
 
 #include <sstream>
 #include <stdexcept>
@@ -49,7 +50,18 @@ EnergyCutSettings::EnergyCutSettings(const nlohmann::json& config)
     double ecut, vcut;
     bool cont_rand;
 
-    config.at("e_cut").get_to(ecut);
+    if(config["e_cut"].is_string()) {
+        std::string setting = config["e_cut"];
+        std::transform(setting.begin(), setting.end(), setting.begin(), ::tolower);
+        if (setting == "inf" or setting == "infinity") {
+            ecut = INF;
+        } else {
+            throw std::invalid_argument("e_cut must be numerical "
+                                        "value or 'inf' / 'infinity'");
+        }
+    } else {
+        config.at("e_cut").get_to(ecut);
+    }
     config.at("v_cut").get_to(vcut);
     config.at("cont_rand").get_to(cont_rand);
 

--- a/src/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/Propagator.cxx
@@ -36,12 +36,12 @@ Propagator::Propagator(const ParticleDef& p_def, std::vector<Sector> sectors)
 }
 
 Secondaries Propagator::Propagate(
-    const DynamicData& initial_particle, double max_distance, double min_energy)
+        const ParticleState& initial_particle, double max_distance, double min_energy)
 {
     Secondaries track(std::make_shared<ParticleDef>(p_def), sector_list);
 
     track.push_back(initial_particle, InteractionType::ContinuousEnergyLoss);
-    auto state = DynamicData(initial_particle);
+    auto state = ParticleState(initial_particle);
 
     auto current_sector = GetCurrentSector(state.position, state.direction);
     auto rnd
@@ -103,8 +103,8 @@ Secondaries Propagator::Propagate(
     return track;
 }
 
-InteractionType Propagator::DoStochasticInteraction(DynamicData& p_cond,
-    PropagationUtility& utility, std::function<double()> rnd)
+InteractionType Propagator::DoStochasticInteraction(ParticleState& p_cond,
+                                                    PropagationUtility& utility, std::function<double()> rnd)
 {
     InteractionType loss_type;
     std::shared_ptr<const Component> comp;
@@ -121,8 +121,8 @@ InteractionType Propagator::DoStochasticInteraction(DynamicData& p_cond,
     return loss_type;
 }
 
-int Propagator::AdvanceParticle(DynamicData& state, double E_f,
-        double max_distance, std::function<double()> rnd, Sector& current_sector)
+int Propagator::AdvanceParticle(ParticleState& state, double E_f,
+                                double max_distance, std::function<double()> rnd, Sector& current_sector)
 {
     assert(max_distance > 0);
     assert(E_f >= 0);

--- a/src/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/Propagator.cxx
@@ -39,11 +39,11 @@ Secondaries Propagator::Propagate(
     const DynamicData& initial_particle, double max_distance, double min_energy)
 {
     Secondaries track(std::make_shared<ParticleDef>(p_def), sector_list);
-    track.push_back(initial_particle);
-    track.back().type = (int)InteractionType::ContinuousEnergyLoss;
 
-    auto current_sector = GetCurrentSector(
-            track.back().position, track.back().direction);
+    track.push_back(initial_particle, InteractionType::ContinuousEnergyLoss);
+    auto state = DynamicData(initial_particle);
+
+    auto current_sector = GetCurrentSector(state.position, state.direction);
     auto rnd
         = std::bind(&RandomGenerator::RandomDouble, &RandomGenerator::Get());
 
@@ -54,45 +54,46 @@ Secondaries Propagator::Propagate(
     auto InteractionEnergy
         = std::array<double, 3>{std::max(min_energy, p_def.mass), 0., 0.};
     while (continue_propagation) {
-        //std::cout << "E: " << track.back().GetEnergy() << ", d: "  << track.back().GetPropagatedDistance() << std::endl;
+        //std::cout << "E: " << state.GetEnergy() << ", d: "  << state.GetPropagatedDistance() << std::endl;
         auto &utility = get<UTILITY>(current_sector);
         auto &density = get<DENSITY_DISTR>(current_sector);
 
-        InteractionEnergy[Decay] = utility.EnergyDecay(track.back().energy,
-                                                       rnd, density->Evaluate(track.back().position));
-        InteractionEnergy[Stochastic]
-                = utility.EnergyInteraction(track.back().energy, rnd);
+        InteractionEnergy[Decay] = utility.EnergyDecay(state.energy, rnd,
+                                                       density->Evaluate(state.position));
+        InteractionEnergy[Stochastic] = utility.EnergyInteraction(state.energy, rnd);
 
         //std::cout << "Decay: " << InteractionEnergy[Decay] << ", " << "Stochastic: " << InteractionEnergy[Stochastic] << std::endl;
 
         auto next_interaction_type = maximize(InteractionEnergy);
         auto energy_at_next_interaction = InteractionEnergy[next_interaction_type];
 
-        track.push_back(track.back());
-        advancement_type = AdvanceParticle(track.back(),
-                                           energy_at_next_interaction,
+        advancement_type = AdvanceParticle(state, energy_at_next_interaction,
                                            max_distance, rnd, current_sector);
+        track.push_back(state, InteractionType::ContinuousEnergyLoss);
+
         switch (advancement_type) {
             case ReachedInteraction :
                 switch (next_interaction_type) {
-                    case Stochastic:
-                        track.push_back(track.back());
-                        DoStochasticInteraction(track.back(), utility, rnd);
-                        if (track.back().energy <= InteractionEnergy[MinimalE])
+                    case Stochastic: {
+                        auto type = DoStochasticInteraction(state, utility, rnd);
+                        track.push_back(state, type);
+                        if (state.energy <= InteractionEnergy[MinimalE])
                             continue_propagation = false;
                         break;
-                    case Decay:
-                        track.push_back(track.back());
-                        track.back().type = (int)InteractionType::Decay;
+                    }
+                    case Decay: {
+                        track.push_back(state, InteractionType::Decay);
                         continue_propagation = false;
                         break;
-                    case MinimalE:
+                    }
+                    case MinimalE: {
                         continue_propagation = false;
                         break;
+                    }
                 }
                 break;
             case ReachedBorder :
-                current_sector = GetCurrentSector(track.back().position, track.back().direction);
+                current_sector = GetCurrentSector(state.position, state.direction);
                 break;
             case ReachedMaxDistance :
                 continue_propagation = false;
@@ -102,7 +103,7 @@ Secondaries Propagator::Propagate(
     return track;
 }
 
-void Propagator::DoStochasticInteraction(DynamicData& p_cond,
+InteractionType Propagator::DoStochasticInteraction(DynamicData& p_cond,
     PropagationUtility& utility, std::function<double()> rnd)
 {
     InteractionType loss_type;
@@ -117,10 +118,10 @@ void Propagator::DoStochasticInteraction(DynamicData& p_cond,
     /*     get<0>(deflection_angles), get<1>(deflection_angles)); */
 
     p_cond.energy = p_cond.energy - loss_energy;
-    p_cond.type = (int)loss_type;
+    return loss_type;
 }
 
-int Propagator::AdvanceParticle(DynamicData& p_cond, double E_f,
+int Propagator::AdvanceParticle(DynamicData& state, double E_f,
         double max_distance, std::function<double()> rnd, Sector& current_sector)
 {
     assert(max_distance > 0);
@@ -133,30 +134,30 @@ int Propagator::AdvanceParticle(DynamicData& p_cond, double E_f,
     auto& density = get<DENSITY_DISTR>(current_sector);
     auto& geometry = get<GEOMETRY>(current_sector);
 
-    auto grammage_next_interaction = utility.LengthContinuous(p_cond.energy, E_f);
-    auto max_distance_left = max_distance - p_cond.propagated_distance;
+    auto grammage_next_interaction = utility.LengthContinuous(state.energy, E_f);
+    auto max_distance_left = max_distance - state.propagated_distance;
     assert(max_distance_left > 0);
 
     Vector3D mean_direction, new_direction;
     std::tie(mean_direction, new_direction) = utility.DirectionsScatter(
-            grammage_next_interaction, p_cond.energy, E_f, p_cond.direction,
+            grammage_next_interaction, state.energy, E_f, state.direction,
         rnd_scattering);
 
     double distance_next_interaction;
     try {
-        distance_next_interaction = density->Correct(p_cond.position,
+        distance_next_interaction = density->Correct(state.position,
                   mean_direction, grammage_next_interaction, max_distance_left);
     } catch (const DensityException&) {
         Logging::Get("proposal.propagator")->debug("Interaction point exceeds "
                      "maximum propagation distance or lies in infinity.");
         distance_next_interaction = INF;
     }
-    auto new_position = p_cond.position + distance_next_interaction * mean_direction;
+    auto new_position = state.position + distance_next_interaction * mean_direction;
 
     auto AdvanceDistance = std::array<double, 3>{0., 0., 0.};
     AdvanceDistance[ReachedInteraction] = distance_next_interaction;
     AdvanceDistance[ReachedMaxDistance] = max_distance_left;
-    AdvanceDistance[ReachedBorder] = CalculateDistanceToBorder(p_cond.position, mean_direction, *geometry);
+    AdvanceDistance[ReachedBorder] = CalculateDistanceToBorder(state.position, mean_direction, *geometry);
 
     int advancement_type = minimize(AdvanceDistance);
     double advance_distance = AdvanceDistance[advancement_type];
@@ -167,24 +168,24 @@ int Propagator::AdvanceParticle(DynamicData& p_cond, double E_f,
         //std::cout << "AdvanceParticle can't reach interaction, varying propagation step..." << std::endl;
         do {
             advance_distance = AdvanceDistance[advancement_type];
-            advance_grammage = density->Calculate(p_cond.position,
-                                       p_cond.direction, advance_distance);
-            E_f = utility.EnergyDistance(p_cond.energy, advance_grammage);
+            advance_grammage = density->Calculate(state.position,
+                                       state.direction, advance_distance);
+            E_f = utility.EnergyDistance(state.energy, advance_grammage);
 
             std::tie(mean_direction, new_direction) = utility.DirectionsScatter(
-                    advance_grammage, p_cond.energy, E_f,
-                    p_cond.direction, rnd_scattering);
+                    advance_grammage, state.energy, E_f,
+                    state.direction, rnd_scattering);
 
             try {
                 AdvanceDistance[ReachedInteraction] = density->Correct(
-                        p_cond.position, mean_direction,
+                        state.position, mean_direction,
                         grammage_next_interaction, max_distance_left);
             } catch (const DensityException&) {
                 AdvanceDistance[ReachedInteraction] = INF;
             }
 
             AdvanceDistance[ReachedBorder] = CalculateDistanceToBorder(
-                    p_cond.position, mean_direction, *geometry);
+                    state.position, mean_direction, *geometry);
             advancement_type = minimize(AdvanceDistance);
             control_distance = AdvanceDistance[advancement_type];
             //std::cout << "Step - old_distance: " << advance_distance << ", new distance: " << control_distance << ", advancement type " << advancement_type << std::endl;
@@ -192,16 +193,15 @@ int Propagator::AdvanceParticle(DynamicData& p_cond, double E_f,
                  > PARTICLE_POSITION_RESOLUTION);
         //std::cout << "Difference negligible, use control_distance" << std::endl;
         advance_distance = control_distance;
-        new_position = p_cond.position + advance_distance * mean_direction;
+        new_position = state.position + advance_distance * mean_direction;
     }
 
-    p_cond.time =  p_cond.time + utility.TimeElapsed(p_cond.energy, E_f,
-                   advance_distance, density->Evaluate(p_cond.position));
-    p_cond.position = new_position;
-    p_cond.direction = new_direction;
-    p_cond.propagated_distance = p_cond.propagated_distance + advance_distance;
-    p_cond.energy = utility.EnergyRandomize(p_cond.energy, E_f, rnd);
-    p_cond.type = (int)InteractionType::ContinuousEnergyLoss;
+    state.time =  state.time + utility.TimeElapsed(state.energy, E_f,
+                   advance_distance, density->Evaluate(state.position));
+    state.position = new_position;
+    state.direction = new_direction;
+    state.propagated_distance = state.propagated_distance + advance_distance;
+    state.energy = utility.EnergyRandomize(state.energy, E_f, rnd);
 
     return advancement_type;
 }

--- a/src/PROPOSAL/decay/DecayChannel.cxx
+++ b/src/PROPOSAL/decay/DecayChannel.cxx
@@ -49,7 +49,7 @@ std::ostream& operator<<(std::ostream& os, DecayChannel const& channel)
 } // namespace PROPOSAL
 
 // ------------------------------------------------------------------------- //
-void DecayChannel::Boost(DynamicData& particle, const Vector3D& direction_unnormalized, double gamma, double betagamma)
+void DecayChannel::Boost(ParticleState& particle, const Vector3D& direction_unnormalized, double gamma, double betagamma)
 {
     Vector3D direction = direction_unnormalized;
     direction.normalise();
@@ -70,7 +70,7 @@ void DecayChannel::Boost(DynamicData& particle, const Vector3D& direction_unnorm
 }
 
 // ------------------------------------------------------------------------- //
-void DecayChannel::Boost(std::vector<DynamicData>& secondaries, const Vector3D& direction, double gamma, double betagamma)
+void DecayChannel::Boost(std::vector<ParticleState>& secondaries, const Vector3D& direction, double gamma, double betagamma)
 {
     for (auto& p : secondaries)
     {

--- a/src/PROPOSAL/decay/DecayChannel.cxx
+++ b/src/PROPOSAL/decay/DecayChannel.cxx
@@ -54,10 +54,10 @@ void DecayChannel::Boost(DynamicData& particle, const Vector3D& direction_unnorm
     Vector3D direction = direction_unnormalized;
     direction.normalise();
 
-    Vector3D momentum_vec(particle.GetMomentum() * particle.GetDirection());
+    Vector3D momentum_vec(particle.GetMomentum() * particle.direction);
 
     double direction_correction =
-        (gamma - 1.0) * scalar_product(momentum_vec, direction) - betagamma * particle.GetEnergy();
+        (gamma - 1.0) * scalar_product(momentum_vec, direction) - betagamma * particle.energy;
 
     momentum_vec = momentum_vec + direction_correction * direction;
 
@@ -66,7 +66,7 @@ void DecayChannel::Boost(DynamicData& particle, const Vector3D& direction_unnorm
 
     momentum_vec.normalise();
     momentum_vec.CalculateSphericalCoordinates();
-    particle.SetDirection(momentum_vec);
+    particle.direction = momentum_vec;
 }
 
 // ------------------------------------------------------------------------- //

--- a/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
+++ b/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
@@ -96,7 +96,7 @@ double LeptonicDecayChannelApprox::FindRoot(double min, double parent_mass, doub
 }
 
 // ------------------------------------------------------------------------- //
-std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_def, const DynamicData& p_condition)
+std::vector<ParticleState> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_def, const ParticleState& p_condition)
 {
 
     // Sample energy from decay rate
@@ -114,12 +114,12 @@ std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_
 
 
     // Sample directions For the massive letpon
-    DynamicData massive_lepton((ParticleType)massive_lepton_.particle_type,
-                               p_condition.position,
-                               GenerateRandomDirection(),
-                               lepton_energy,
-                               p_condition.time,
-                               0.);
+    ParticleState massive_lepton((ParticleType)massive_lepton_.particle_type,
+                                 p_condition.position,
+                                 GenerateRandomDirection(),
+                                 lepton_energy,
+                                 p_condition.time,
+                                 0.);
 
     // Sample directions For the massless letpon
     double energy_neutrinos   = p_def.mass - lepton_energy;
@@ -130,22 +130,22 @@ std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_
     Vector3D direction = GenerateRandomDirection();
     direction.CalculateSphericalCoordinates();
 
-    DynamicData neutrino((ParticleType)neutrino_.particle_type,
-                         p_condition.position,
-                         direction,
-                         momentum_neutrinos,
-                         p_condition.time,
-                         0.);
+    ParticleState neutrino((ParticleType)neutrino_.particle_type,
+                           p_condition.position,
+                           direction,
+                           momentum_neutrinos,
+                           p_condition.time,
+                           0.);
 
     Vector3D opposite_direction = -direction;
     opposite_direction.CalculateSphericalCoordinates();
 
-    DynamicData anti_neutrino((ParticleType)anti_neutrino_.particle_type,
-                              p_condition.position,
-                              opposite_direction,
-                              momentum_neutrinos,
-                              p_condition.time,
-                              0.);
+    ParticleState anti_neutrino((ParticleType)anti_neutrino_.particle_type,
+                                p_condition.position,
+                                opposite_direction,
+                                momentum_neutrinos,
+                                p_condition.time,
+                                0.);
 
     // Boost neutrinos to lepton frame
     // double beta = lepton_momentum / energy_neutrinos;
@@ -157,7 +157,7 @@ std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_
     Boost(anti_neutrino, massive_lepton.direction, gamma, betagamma);
 
 
-    std::vector<DynamicData> secondaries;
+    std::vector<ParticleState> secondaries;
     secondaries.push_back(massive_lepton);
     secondaries.push_back(neutrino);
     secondaries.push_back(anti_neutrino);

--- a/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
+++ b/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
@@ -114,12 +114,11 @@ std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_
 
 
     // Sample directions For the massive letpon
-    DynamicData massive_lepton(massive_lepton_.particle_type,
-                               p_condition.GetPosition(),
+    DynamicData massive_lepton((ParticleType)massive_lepton_.particle_type,
+                               p_condition.position,
                                GenerateRandomDirection(),
                                lepton_energy,
-                               p_condition.GetEnergy(),
-                               p_condition.GetTime(),
+                               p_condition.time,
                                0.);
 
     // Sample directions For the massless letpon
@@ -131,23 +130,21 @@ std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_
     Vector3D direction = GenerateRandomDirection();
     direction.CalculateSphericalCoordinates();
 
-    DynamicData neutrino(neutrino_.particle_type,
-                         p_condition.GetPosition(),
+    DynamicData neutrino((ParticleType)neutrino_.particle_type,
+                         p_condition.position,
                          direction,
                          momentum_neutrinos,
-                         p_condition.GetEnergy(),
-                         p_condition.GetTime(),
+                         p_condition.time,
                          0.);
 
     Vector3D opposite_direction = -direction;
     opposite_direction.CalculateSphericalCoordinates();
 
-    DynamicData anti_neutrino(anti_neutrino_.particle_type,
-                              p_condition.GetPosition(),
+    DynamicData anti_neutrino((ParticleType)anti_neutrino_.particle_type,
+                              p_condition.position,
                               opposite_direction,
                               momentum_neutrinos,
-                              p_condition.GetEnergy(),
-                              p_condition.GetTime(),
+                              p_condition.time,
                               0.);
 
     // Boost neutrinos to lepton frame
@@ -156,8 +153,8 @@ std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_
     double betagamma = lepton_momentum / virtual_mass;
 
 
-    Boost(neutrino, massive_lepton.GetDirection(), gamma, betagamma);
-    Boost(anti_neutrino, massive_lepton.GetDirection(), gamma, betagamma);
+    Boost(neutrino, massive_lepton.direction, gamma, betagamma);
+    Boost(anti_neutrino, massive_lepton.direction, gamma, betagamma);
 
 
     std::vector<DynamicData> secondaries;
@@ -167,9 +164,9 @@ std::vector<DynamicData> LeptonicDecayChannelApprox::Decay(const ParticleDef& p_
 
     // Get Momentum is not defined for pseudo particle decay, so it must be
     // calculated manually
-    double primary_momentum = std::sqrt(std::max((p_condition.GetEnergy() + p_def.mass) * (p_condition.GetEnergy() - p_def.mass), 0.0));
+    double primary_momentum = std::sqrt(std::max((p_condition.energy + p_def.mass) * (p_condition.energy - p_def.mass), 0.0));
     // Boost all products in Lab frame (the reason, why the boosting goes in the negative direction of the particle)
-    Boost(secondaries, -p_condition.GetDirection(), p_condition.GetEnergy()/p_def.mass, primary_momentum/p_def.mass);
+    Boost(secondaries, -p_condition.direction, p_condition.energy/p_def.mass, primary_momentum/p_def.mass);
 
     return secondaries;
 }

--- a/src/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
@@ -103,10 +103,10 @@ bool ManyBodyPhaseSpace::compare(const DecayChannel& channel) const
 }
 
 // ------------------------------------------------------------------------- //
-std::vector<DynamicData> ManyBodyPhaseSpace::Decay(const ParticleDef& p_def, const DynamicData& p_condition)
+std::vector<ParticleState> ManyBodyPhaseSpace::Decay(const ParticleDef& p_def, const ParticleState& p_condition)
 {
     // Create vector for decay products
-    std::vector<DynamicData> products;
+    std::vector<ParticleState> products;
 
     for (auto p : daughters_) {
         products.emplace_back((ParticleType)p->particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
@@ -145,7 +145,7 @@ std::vector<DynamicData> ManyBodyPhaseSpace::Decay(const ParticleDef& p_def, con
 }
 
 // ------------------------------------------------------------------------- //
-void ManyBodyPhaseSpace::GenerateEvent(std::vector<DynamicData>& products, const PhaseSpaceKinematics& kinematics)
+void ManyBodyPhaseSpace::GenerateEvent(std::vector<ParticleState>& products, const PhaseSpaceKinematics& kinematics)
 {
     // Calculate first momentum in R2
     Vector3D direction = GenerateRandomDirection();
@@ -182,7 +182,7 @@ void ManyBodyPhaseSpace::GenerateEvent(std::vector<DynamicData>& products, const
 }
 
 // ------------------------------------------------------------------------- //
-double ManyBodyPhaseSpace::DefaultEvaluate(const DynamicData& p_condition, const std::vector<DynamicData>& products)
+double ManyBodyPhaseSpace::DefaultEvaluate(const ParticleState& p_condition, const std::vector<ParticleState>& products)
 {
     (void) p_condition;
     (void) products;
@@ -191,7 +191,7 @@ double ManyBodyPhaseSpace::DefaultEvaluate(const DynamicData& p_condition, const
 }
 
 // ------------------------------------------------------------------------- //
-double ManyBodyPhaseSpace::Evaluate(const DynamicData& p_condition, const std::vector<DynamicData>& products)
+double ManyBodyPhaseSpace::Evaluate(const ParticleState& p_condition, const std::vector<ParticleState>& products)
 {
     return matrix_element_(p_condition, products);
 }
@@ -250,7 +250,7 @@ void ManyBodyPhaseSpace::EstimateMaxWeight(PhaseSpaceParameters& params, const P
 void ManyBodyPhaseSpace::SampleEstimateMaxWeight(PhaseSpaceParameters& params, const ParticleDef& parent_def)
 {
     // Create vector for decay products
-    std::vector<DynamicData> products;
+    std::vector<ParticleState> products;
 
     for (auto d : daughters_) {
         products.emplace_back();
@@ -259,7 +259,7 @@ void ManyBodyPhaseSpace::SampleEstimateMaxWeight(PhaseSpaceParameters& params, c
 
     // precalculated kinematics
     PhaseSpaceKinematics kinematics;
-    DynamicData particle;
+    ParticleState particle;
     particle.type = parent_def.particle_type;
     particle.energy = parent_def.mass;
 

--- a/src/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
@@ -109,7 +109,7 @@ std::vector<DynamicData> ManyBodyPhaseSpace::Decay(const ParticleDef& p_def, con
     std::vector<DynamicData> products;
 
     for (auto p : daughters_) {
-        products.emplace_back(p->particle_type, p_condition.GetPosition(), p_condition.GetDirection(), p_condition.GetEnergy(), p_condition.GetParentParticleEnergy(), p_condition.GetTime(), 0);
+        products.emplace_back((ParticleType)p->particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
     }
 
     // prefactor for the phase space density
@@ -139,7 +139,7 @@ std::vector<DynamicData> ManyBodyPhaseSpace::Decay(const ParticleDef& p_def, con
     }
 
     // Boost all products in Lab frame (the reason, why the boosting goes in the negative direction of the particle)
-    Boost(products, -p_condition.GetDirection(), p_condition.GetEnergy()/p_def.mass, p_condition.GetMomentum() / p_def.mass);
+    Boost(products, -p_condition.direction, p_condition.energy/p_def.mass, p_condition.GetMomentum() / p_def.mass);
 
     return products;
 }
@@ -150,12 +150,12 @@ void ManyBodyPhaseSpace::GenerateEvent(std::vector<DynamicData>& products, const
     // Calculate first momentum in R2
     Vector3D direction = GenerateRandomDirection();
 
-    products[1].SetDirection(direction);
+    products[1].direction = direction;
     products[1].SetMomentum(kinematics.momenta[0]);
 
     Vector3D opposite_direction = -direction;
     opposite_direction.CalculateSphericalCoordinates();
-    products[0].SetDirection(opposite_direction);
+    products[0].direction = opposite_direction;
     products[0].SetMomentum(kinematics.momenta[0]);
 
     // Correct the previous momenta
@@ -163,7 +163,7 @@ void ManyBodyPhaseSpace::GenerateEvent(std::vector<DynamicData>& products, const
     {
         double momentum = kinematics.momenta[i-1];
 
-        products[i].SetDirection(GenerateRandomDirection());
+        products[i].direction = GenerateRandomDirection();
         products[i].SetMomentum(momentum);
 
         // Boost previous particles to new frame
@@ -176,7 +176,7 @@ void ManyBodyPhaseSpace::GenerateEvent(std::vector<DynamicData>& products, const
         for (unsigned int s = 0; s < i; ++s)
         {
             // Boost in -p_i direction
-            Boost(products[s], products[i].GetDirection(), gamma, betagamma);
+            Boost(products[s], products[i].direction, gamma, betagamma);
         }
     }
 }
@@ -253,13 +253,15 @@ void ManyBodyPhaseSpace::SampleEstimateMaxWeight(PhaseSpaceParameters& params, c
     std::vector<DynamicData> products;
 
     for (auto d : daughters_) {
-        products.emplace_back(d->particle_type);
+        products.emplace_back();
+        products.back().type = d->particle_type;
     }
 
     // precalculated kinematics
     PhaseSpaceKinematics kinematics;
-    DynamicData particle(parent_def.particle_type);
-    particle.SetEnergy(parent_def.mass);
+    DynamicData particle;
+    particle.type = parent_def.particle_type;
+    particle.energy = parent_def.mass;
 
     double result = 0.0;
 

--- a/src/PROPOSAL/decay/StableChannel.cxx
+++ b/src/PROPOSAL/decay/StableChannel.cxx
@@ -29,9 +29,9 @@ bool StableChannel::compare(const DecayChannel& channel) const
         return true;
 }
 
-std::vector<DynamicData> StableChannel::Decay(const ParticleDef&, const DynamicData&)
+std::vector<ParticleState> StableChannel::Decay(const ParticleDef&, const ParticleState&)
 {
     // return empty vector;
-    std::vector<DynamicData> vec;
+    std::vector<ParticleState> vec;
     return vec;
 }

--- a/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
@@ -41,22 +41,22 @@ bool TwoBodyPhaseSpace::compare(const DecayChannel& channel) const
 std::vector<DynamicData> TwoBodyPhaseSpace::Decay(const ParticleDef& p_def, const DynamicData& p_condition)
 {
     std::vector<DynamicData> products;
-    products.emplace_back(first_daughter_.particle_type, p_condition.GetPosition(), p_condition.GetDirection(), p_condition.GetEnergy(), p_condition.GetParentParticleEnergy(), p_condition.GetTime(), 0);
-    products.emplace_back(second_daughter_.particle_type, p_condition.GetPosition(), p_condition.GetDirection(), p_condition.GetEnergy(), p_condition.GetParentParticleEnergy(), p_condition.GetTime(), 0);
+    products.emplace_back((ParticleType)first_daughter_.particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
+    products.emplace_back((ParticleType)second_daughter_.particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
 
     double momentum    = Momentum(p_def.mass, first_daughter_.mass, second_daughter_.mass);
     Vector3D direction = GenerateRandomDirection();
 
-    products[0].SetDirection(direction);
+    products[0].direction = direction;
     products[0].SetMomentum(momentum);
 
     Vector3D opposite_direction = -direction;
     opposite_direction.CalculateSphericalCoordinates();
-    products[1].SetDirection(opposite_direction);
+    products[1].direction = opposite_direction;
     products[1].SetMomentum(momentum);
 
     // Boost all products in Lab frame (the reason, why the boosting goes in the negative direction of the particle)
-    Boost(products, -p_condition.GetDirection(), p_condition.GetEnergy() / p_def.mass, p_condition.GetMomentum() / p_def.mass);
+    Boost(products, -p_condition.direction, p_condition.energy / p_def.mass, p_condition.GetMomentum() / p_def.mass);
 
     return products;
 }

--- a/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
@@ -38,9 +38,9 @@ bool TwoBodyPhaseSpace::compare(const DecayChannel& channel) const
         return true;
 }
 
-std::vector<DynamicData> TwoBodyPhaseSpace::Decay(const ParticleDef& p_def, const DynamicData& p_condition)
+std::vector<ParticleState> TwoBodyPhaseSpace::Decay(const ParticleDef& p_def, const ParticleState& p_condition)
 {
-    std::vector<DynamicData> products;
+    std::vector<ParticleState> products;
     products.emplace_back((ParticleType)first_daughter_.particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
     products.emplace_back((ParticleType)second_daughter_.particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
 

--- a/src/PROPOSAL/geometry/GeometryFactory.cxx
+++ b/src/PROPOSAL/geometry/GeometryFactory.cxx
@@ -37,6 +37,7 @@ namespace PROPOSAL{
 std::shared_ptr<Geometry> CreateGeometry(const nlohmann::json& config){
     if (config.contains("shape")){
         std::string shape = config["shape"];
+        std::transform(shape.begin(), shape.end(), shape.begin(), ::tolower);
         if (shape == "sphere") {
             return std::make_shared<Sphere>(config);
         } else if (shape == "box") {

--- a/src/PROPOSAL/particle/Particle.cxx
+++ b/src/PROPOSAL/particle/Particle.cxx
@@ -18,7 +18,6 @@ using namespace PROPOSAL;
 
 namespace PROPOSAL {
 
-// ------------------------------------------------------------------------- //
 std::ostream& operator<<(std::ostream& os, DynamicData const& data)
 {
     std::stringstream ss;
@@ -41,10 +40,6 @@ std::ostream& operator<<(std::ostream& os, DynamicData const& data)
 }
 
 } // namespace PROPOSAL
-
-/******************************************************************************
- *                              Dynamic Particle                              *
- ******************************************************************************/
 
 DynamicData::DynamicData()
     : type(0)
@@ -80,7 +75,29 @@ DynamicData::DynamicData(const ParticleType& type, const Vector3D& position,
 {
 }
 
-// ------------------------------------------------------------------------- //
+bool DynamicData::operator==(const DynamicData& dynamic_data) const
+{
+    if (type != dynamic_data.type)
+        return false;
+    if (position != dynamic_data.position)
+        return false;
+    if (direction != dynamic_data.direction)
+        return false;
+    if (energy != dynamic_data.energy)
+        return false;
+    if (time != dynamic_data.time)
+        return false;
+    if (propagated_distance != dynamic_data.propagated_distance)
+        return false;
+
+    return true;
+}
+
+bool DynamicData::operator!=(const DynamicData& dynamic_data) const
+{
+    return !(*this == dynamic_data);
+}
+
 std::string DynamicData::GetName() const
 {
     auto p_search = Type_Particle_Map.find(static_cast<ParticleType>(type));

--- a/src/PROPOSAL/particle/Particle.cxx
+++ b/src/PROPOSAL/particle/Particle.cxx
@@ -18,10 +18,10 @@ using namespace PROPOSAL;
 
 namespace PROPOSAL {
 
-std::ostream& operator<<(std::ostream& os, DynamicData const& data)
+std::ostream& operator<<(std::ostream& os, ParticleState const& data)
 {
     std::stringstream ss;
-    ss << " DynamicData (" << &data << ") ";
+    ss << " ParticleState (" << &data << ") ";
     os << Helper::Centered(60, ss.str()) << '\n';
 
     os << "type: " << data.type << '\n';
@@ -41,7 +41,7 @@ std::ostream& operator<<(std::ostream& os, DynamicData const& data)
 
 } // namespace PROPOSAL
 
-DynamicData::DynamicData()
+ParticleState::ParticleState()
     : type(0)
     , position(Vector3D())
     , direction(Vector3D())
@@ -51,9 +51,9 @@ DynamicData::DynamicData()
 {
 }
 
-DynamicData::DynamicData(const Vector3D& position, const Vector3D& direction,
-                         const double& energy, const double& time,
-                         const double& distance)
+ParticleState::ParticleState(const Vector3D& position, const Vector3D& direction,
+                             const double& energy, const double& time,
+                             const double& distance)
     : type(static_cast<int>(ParticleType::None))
     , position(position)
     , direction(direction)
@@ -63,9 +63,9 @@ DynamicData::DynamicData(const Vector3D& position, const Vector3D& direction,
 {
 }
 
-DynamicData::DynamicData(const ParticleType& type, const Vector3D& position,
-    const Vector3D& direction, const double& energy, const double& time,
-    const double& distance)
+ParticleState::ParticleState(const ParticleType& type, const Vector3D& position,
+                             const Vector3D& direction, const double& energy, const double& time,
+                             const double& distance)
     : type(static_cast<int>(type))
     , position(position)
     , direction(direction)
@@ -75,7 +75,7 @@ DynamicData::DynamicData(const ParticleType& type, const Vector3D& position,
 {
 }
 
-bool DynamicData::operator==(const DynamicData& dynamic_data) const
+bool ParticleState::operator==(const ParticleState& dynamic_data) const
 {
     if (type != dynamic_data.type)
         return false;
@@ -93,12 +93,12 @@ bool DynamicData::operator==(const DynamicData& dynamic_data) const
     return true;
 }
 
-bool DynamicData::operator!=(const DynamicData& dynamic_data) const
+bool ParticleState::operator!=(const ParticleState& dynamic_data) const
 {
     return !(*this == dynamic_data);
 }
 
-std::string DynamicData::GetName() const
+std::string ParticleState::GetName() const
 {
     auto p_search = Type_Particle_Map.find(static_cast<ParticleType>(type));
     if (p_search != Type_Particle_Map.end()) {
@@ -114,7 +114,7 @@ std::string DynamicData::GetName() const
     return "Not found.";
 }
 
-void DynamicData::SetMomentum(double momentum)
+void ParticleState::SetMomentum(double momentum)
 {
     auto particle = Type_Particle_Map.find(static_cast<ParticleType>(type));
     if (particle != Type_Particle_Map.end())
@@ -124,7 +124,7 @@ void DynamicData::SetMomentum(double momentum)
         energy = momentum;
 }
 
-double DynamicData::GetMomentum() const
+double ParticleState::GetMomentum() const
 {
     auto particle = Type_Particle_Map.find(static_cast<ParticleType>(type));
     if (particle != Type_Particle_Map.end())
@@ -133,7 +133,7 @@ double DynamicData::GetMomentum() const
     return energy;
 }
 
-void DynamicData::DeflectDirection(double cosphi_deflect, double theta_deflect)
+void ParticleState::DeflectDirection(double cosphi_deflect, double theta_deflect)
 {
 
     auto old_direction = direction;

--- a/src/PROPOSAL/secondaries/SecondariesCalculator.cxx
+++ b/src/PROPOSAL/secondaries/SecondariesCalculator.cxx
@@ -2,15 +2,13 @@
 
 using namespace PROPOSAL;
 
-std::vector<Loss::secondary_t> SecondariesCalculator::CalculateSecondaries(
-        double initial_energy, Loss::secondary_t loss, const Component& comp,
-        vector<double> rnd)
+std::vector<DynamicData> SecondariesCalculator::CalculateSecondaries(
+        StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
-    auto type = static_cast<InteractionType>(std::get<Loss::TYPE>(loss));
+    auto type = static_cast<InteractionType>(loss.type);
     auto it = secondary_generator.find(type);
     if (it != secondary_generator.end())
-        return it->second->CalculateSecondaries(
-                initial_energy, loss, comp, rnd);
+        return it->second->CalculateSecondaries(loss, comp, rnd);
     std::ostringstream s;
     s << "No secondary calculator for interaction type ("
         << Type_Interaction_Name_Map.find(type)->second << ") available.";

--- a/src/PROPOSAL/secondaries/SecondariesCalculator.cxx
+++ b/src/PROPOSAL/secondaries/SecondariesCalculator.cxx
@@ -2,7 +2,7 @@
 
 using namespace PROPOSAL;
 
-std::vector<DynamicData> SecondariesCalculator::CalculateSecondaries(
+std::vector<ParticleState> SecondariesCalculator::CalculateSecondaries(
         StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
     auto type = static_cast<InteractionType>(loss.type);

--- a/src/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.cxx
+++ b/src/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.cxx
@@ -53,7 +53,7 @@ secondaries::SingleDifferentialAnnihilation::CalculateEnergy(
     return make_tuple(energy_1, energy_2);
 }
 
-vector<DynamicData>
+vector<ParticleState>
 secondaries::SingleDifferentialAnnihilation::CalculateSecondaries(
         StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
@@ -61,7 +61,7 @@ secondaries::SingleDifferentialAnnihilation::CalculateSecondaries(
     auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, rho);
     auto secondary_dir = CalculateDirections(
             loss.direction, loss.parent_particle_energy, rho, rnd[1]);
-    auto sec = std::vector<DynamicData>();
+    auto sec = std::vector<ParticleState>();
     sec.emplace_back(ParticleType::Gamma, loss.position, get<0>(secondary_dir),
             get<0>(secondary_energies), loss.time, 0.);
     sec.emplace_back(ParticleType::Gamma, loss.position, get<1>(secondary_dir),

--- a/src/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.cxx
+++ b/src/PROPOSAL/secondaries/annihilation/SingleDifferentialAnnihilation.cxx
@@ -53,21 +53,18 @@ secondaries::SingleDifferentialAnnihilation::CalculateEnergy(
     return make_tuple(energy_1, energy_2);
 }
 
-vector<Loss::secondary_t>
+vector<DynamicData>
 secondaries::SingleDifferentialAnnihilation::CalculateSecondaries(
-    double primary_energy, Loss::secondary_t loss, const Component& comp,
-    vector<double> rnd)
+        StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
-    auto rho = CalculateRho(primary_energy, rnd[0], comp);
-    auto secondary_energy = CalculateEnergy(primary_energy, rho);
+    auto rho = CalculateRho(loss.parent_particle_energy, rnd[0], comp);
+    auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, rho);
     auto secondary_dir = CalculateDirections(
-        get<Loss::DIRECTION>(loss), primary_energy, rho, rnd[1]);
-    auto sec = std::vector<Loss::secondary_t>();
-    sec.emplace_back(static_cast<int>(ParticleType::Gamma),
-        get<Loss::POSITION>(loss), get<0>(secondary_dir),
-        get<0>(secondary_energy), 0.);
-    sec.emplace_back(static_cast<int>(ParticleType::Gamma),
-        get<Loss::POSITION>(loss), get<1>(secondary_dir),
-        get<1>(secondary_energy), 0.);
+            loss.direction, loss.parent_particle_energy, rho, rnd[1]);
+    auto sec = std::vector<DynamicData>();
+    sec.emplace_back(ParticleType::Gamma, loss.position, get<0>(secondary_dir),
+            get<0>(secondary_energies), loss.time, 0.);
+    sec.emplace_back(ParticleType::Gamma, loss.position, get<1>(secondary_dir),
+            get<1>(secondary_energies), loss.time, 0.);
     return sec;
 }

--- a/src/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.cxx
+++ b/src/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.cxx
@@ -7,13 +7,24 @@
 
 using namespace PROPOSAL;
 
-vector<Loss::secondary_t> secondaries::NaivBremsstrahlung::CalculateSecondaries(
-    double primary_energy, Loss::secondary_t loss, const Component&, vector<double>)
+vector<DynamicData> secondaries::NaivBremsstrahlung::CalculateSecondaries(
+    StochasticLoss loss, const Component&, vector<double>&)
 {
-    auto primary_lepton = loss;
-    std::get<Loss::ENERGY>(primary_lepton) = primary_energy - std::get<Loss::ENERGY>(loss);
-    std::get<Loss::TYPE>(primary_lepton) = primary_lepton_type;
-    std::get<Loss::TYPE>(loss) = static_cast<int>(PROPOSAL::ParticleType::Gamma);
-    auto sec = vector<Loss::secondary_t>{ move(primary_lepton), move(loss) };
+    auto primary_lepton = DynamicData();
+    primary_lepton.energy = loss.parent_particle_energy - loss.loss_energy;
+    primary_lepton.type = primary_lepton_type;
+    primary_lepton.time = loss.time;
+    primary_lepton.position = loss.position;
+    primary_lepton.direction = loss.direction;
+    primary_lepton.propagated_distance = 0.;
+
+    auto brems_photon = DynamicData();
+    brems_photon.energy = loss.loss_energy;
+    brems_photon.SetType(PROPOSAL::ParticleType::Gamma);
+    brems_photon.time = loss.time;
+    brems_photon.position = loss.position;
+    brems_photon.direction = loss.direction;
+
+    auto sec = vector<DynamicData>{ primary_lepton, brems_photon};
     return sec;
 }

--- a/src/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.cxx
+++ b/src/PROPOSAL/secondaries/bremsstrahlung/NaivBremsstrahlung.cxx
@@ -7,10 +7,10 @@
 
 using namespace PROPOSAL;
 
-vector<DynamicData> secondaries::NaivBremsstrahlung::CalculateSecondaries(
+vector<ParticleState> secondaries::NaivBremsstrahlung::CalculateSecondaries(
     StochasticLoss loss, const Component&, vector<double>&)
 {
-    auto primary_lepton = DynamicData();
+    auto primary_lepton = ParticleState();
     primary_lepton.energy = loss.parent_particle_energy - loss.loss_energy;
     primary_lepton.type = primary_lepton_type;
     primary_lepton.time = loss.time;
@@ -18,13 +18,13 @@ vector<DynamicData> secondaries::NaivBremsstrahlung::CalculateSecondaries(
     primary_lepton.direction = loss.direction;
     primary_lepton.propagated_distance = 0.;
 
-    auto brems_photon = DynamicData();
+    auto brems_photon = ParticleState();
     brems_photon.energy = loss.loss_energy;
     brems_photon.SetType(PROPOSAL::ParticleType::Gamma);
     brems_photon.time = loss.time;
     brems_photon.position = loss.position;
     brems_photon.direction = loss.direction;
 
-    auto sec = vector<DynamicData>{ primary_lepton, brems_photon};
+    auto sec = vector<ParticleState>{primary_lepton, brems_photon};
     return sec;
 }

--- a/src/PROPOSAL/secondaries/compton/NaivCompton.cxx
+++ b/src/PROPOSAL/secondaries/compton/NaivCompton.cxx
@@ -39,7 +39,7 @@ tuple<double, double> secondaries::NaivCompton::CalculateEnergy(
     return make_tuple(energy * (1 - v), energy * v);
 }
 
-vector<DynamicData> secondaries::NaivCompton::CalculateSecondaries(
+vector<ParticleState> secondaries::NaivCompton::CalculateSecondaries(
         StochasticLoss loss, const Component&, vector<double> &rnd)
 {
     auto v = loss.loss_energy /  loss.parent_particle_energy;
@@ -47,7 +47,7 @@ vector<DynamicData> secondaries::NaivCompton::CalculateSecondaries(
     auto secondary_dir = CalculateDirections(loss.direction, loss.loss_energy,
                                              v, rnd[1]);
 
-    auto sec = std::vector<DynamicData>();
+    auto sec = std::vector<ParticleState>();
     sec.emplace_back(ParticleType::Gamma, loss.position,
                      get<GAMMA>(secondary_dir), get<GAMMA>(secondary_energies),
                              loss.time, 0.);

--- a/src/PROPOSAL/secondaries/compton/NaivCompton.cxx
+++ b/src/PROPOSAL/secondaries/compton/NaivCompton.cxx
@@ -39,20 +39,20 @@ tuple<double, double> secondaries::NaivCompton::CalculateEnergy(
     return make_tuple(energy * (1 - v), energy * v);
 }
 
-vector<Loss::secondary_t> secondaries::NaivCompton::CalculateSecondaries(
-    double primary_energy, Loss::secondary_t loss, const Component&,
-    vector<double> rnd)
+vector<DynamicData> secondaries::NaivCompton::CalculateSecondaries(
+        StochasticLoss loss, const Component&, vector<double> &rnd)
 {
-    auto v = get<Loss::ENERGY>(loss) /primary_energy;
-    auto secondary_energy = CalculateEnergy(primary_energy, v);
-    auto secondary_dir = CalculateDirections(
-            get<Loss::DIRECTION>(loss), get<Loss::ENERGY>(loss), v, rnd[1]);
-    auto sec = std::vector<Loss::secondary_t>();
-    sec.emplace_back(static_cast<int>(ParticleType::Gamma),
-        get<Loss::POSITION>(loss), get<GAMMA>(secondary_dir),
-        get<GAMMA>(secondary_energy), 0.);
-    sec.emplace_back(static_cast<int>(ParticleType::EMinus),
-        get<Loss::POSITION>(loss), get<ELECTRON>(secondary_dir),
-        get<ELECTRON>(secondary_energy), 0.);
+    auto v = loss.loss_energy /  loss.parent_particle_energy;
+    auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, v);
+    auto secondary_dir = CalculateDirections(loss.direction, loss.loss_energy,
+                                             v, rnd[1]);
+
+    auto sec = std::vector<DynamicData>();
+    sec.emplace_back(ParticleType::Gamma, loss.position,
+                     get<GAMMA>(secondary_dir), get<GAMMA>(secondary_energies),
+                             loss.time, 0.);
+    sec.emplace_back(ParticleType::EMinus, loss.position,
+                     get<EMINUS>(secondary_dir), get<EMINUS>(secondary_energies),
+                             loss.time, 0.);
     return sec;
 }

--- a/src/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
+++ b/src/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
@@ -15,7 +15,7 @@ using namespace PROPOSAL;
 
 
 double secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateRho(
-        double energy, double v, const Component& comp, double rnd)
+        double energy, double v, const Component& comp, double rnd1, double rnd2)
 {
 
     auto aux = 1 - (4 * ME) / (energy * v);
@@ -32,8 +32,13 @@ double secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateRho(
                                       [&](double rho) {
                                           return param.FunctionToIntegral(p_def, comp, energy, v, rho);
                                       },
-                                      3, rnd);
-    return integral.GetUpperLimit();
+                                      3, rnd1);
+    auto rho_tmp = integral.GetUpperLimit();
+    if (rnd2 < 0.5) {
+        return rho_tmp;
+    } else {
+        return -rho_tmp;
+    }
 }
 
 tuple<Vector3D, Vector3D>
@@ -52,28 +57,27 @@ secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateEnergy(
     return make_tuple(energy_1, energy_2);
 }
 
-vector<Loss::secondary_t>
+vector<DynamicData>
 secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateSecondaries(
-        double initial_energy, Loss::secondary_t loss, const Component& comp,
-        vector<double> rnd)
+        StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
-    auto v = get<Loss::ENERGY>(loss) / initial_energy;
-    auto rho = CalculateRho(initial_energy, v, comp, rnd[0]);
-    auto secondary_energy = CalculateEnergy(get<Loss::ENERGY>(loss), rho);
-    auto secondary_dir = CalculateDirections(
-            get<Loss::DIRECTION>(loss), get<Loss::ENERGY>(loss), rho, rnd[1]);
-    auto sec = std::vector<Loss::secondary_t>();
+    auto v = loss.loss_energy / loss.parent_particle_energy;
+    auto rho = CalculateRho(loss.parent_particle_energy, v, comp, rnd[0], rnd[1]);
+    auto secondary_energies = CalculateEnergy(loss.loss_energy, rho);
+    auto secondary_dir = CalculateDirections(loss.direction, loss.loss_energy,
+                                             rho, rnd[2]);
 
-    std::get<Loss::TYPE>(loss) = p_def.particle_type;
-    std::get<Loss::ENERGY>(loss)
-            = initial_energy - std::get<Loss::ENERGY>(loss);
-    sec.emplace_back(loss);
+    auto sec = std::vector<DynamicData>();
+    sec.emplace_back(static_cast<const ParticleType>(p_def.particle_type),
+                     loss.position, loss.direction,
+                     loss.parent_particle_energy - loss.loss_energy, loss.time,
+                     loss.propagated_distance);
 
-    sec.emplace_back(static_cast<int>(ParticleType::EMinus),
-                     get<Loss::POSITION>(loss), get<0>(secondary_dir),
-                     get<0>(secondary_energy), 0.);
-    sec.emplace_back(static_cast<int>(ParticleType::EPlus),
-                     get<Loss::POSITION>(loss), get<1>(secondary_dir),
-                     get<1>(secondary_energy), 0.);
+    sec.emplace_back(ParticleType::EMinus, loss.position, get<0>(secondary_dir),
+            get<0>(secondary_energies), loss.time, 0.);
+
+    sec.emplace_back(ParticleType::EPlus, loss.position, get<1>(secondary_dir),
+            get<1>(secondary_energies), loss.time, 0.);
+
     return sec;
 }

--- a/src/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
+++ b/src/PROPOSAL/secondaries/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
@@ -57,7 +57,7 @@ secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateEnergy(
     return make_tuple(energy_1, energy_2);
 }
 
-vector<DynamicData>
+vector<ParticleState>
 secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateSecondaries(
         StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
@@ -67,7 +67,7 @@ secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateSecondaries(
     auto secondary_dir = CalculateDirections(loss.direction, loss.loss_energy,
                                              rho, rnd[2]);
 
-    auto sec = std::vector<DynamicData>();
+    auto sec = std::vector<ParticleState>();
     sec.emplace_back(static_cast<const ParticleType>(p_def.particle_type),
                      loss.position, loss.direction,
                      loss.parent_particle_energy - loss.loss_energy, loss.time,

--- a/src/PROPOSAL/secondaries/ionization/NaivIonization.cxx
+++ b/src/PROPOSAL/secondaries/ionization/NaivIonization.cxx
@@ -24,19 +24,19 @@ tuple<double, double> secondaries::NaivIonization::CalculateEnergy(
     return make_tuple(energy * (1 - v), energy * v);
 }
 
-vector<Loss::secondary_t> secondaries::NaivIonization::CalculateSecondaries(
-    double primary_energy, Loss::secondary_t loss, const Component&,
-    vector<double> rnd)
+vector<DynamicData> secondaries::NaivIonization::CalculateSecondaries(
+    StochasticLoss loss, const Component&, vector<double> &rnd)
 {
-    auto v = std::get<Loss::ENERGY>(loss) / primary_energy;
-    auto secondary_energy = CalculateEnergy(primary_energy, v);
-    auto secondary_dir = CalculateDirections(
-        get<Loss::DIRECTION>(loss), get<Loss::ENERGY>(loss), v, rnd[1]);
-    auto sec = std::vector<Loss::secondary_t>();
-    sec.emplace_back(primary_particle_type, get<Loss::POSITION>(loss),
-        get<0>(secondary_dir), get<0>(secondary_energy), 0.);
-    sec.emplace_back(static_cast<int>(ParticleType::EMinus),
-        get<Loss::POSITION>(loss), get<1>(secondary_dir),
-        get<1>(secondary_energy), 0.);
+    auto v = loss.loss_energy / loss.parent_particle_energy;
+    auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, v);
+    auto secondary_dir = CalculateDirections( loss.direction, loss.loss_energy,
+                                              v, rnd[1]);
+
+    auto sec = std::vector<DynamicData>();
+    sec.emplace_back(static_cast<ParticleType>(primary_particle_type),
+                     loss.position, get<0>(secondary_dir),
+                     get<0>(secondary_energies), loss.time, 0.);
+    sec.emplace_back(ParticleType::EMinus, loss.position, get<1>(secondary_dir),
+                     get<1>(secondary_energies), loss.time, 0.);
     return sec;
 }

--- a/src/PROPOSAL/secondaries/ionization/NaivIonization.cxx
+++ b/src/PROPOSAL/secondaries/ionization/NaivIonization.cxx
@@ -24,7 +24,7 @@ tuple<double, double> secondaries::NaivIonization::CalculateEnergy(
     return make_tuple(energy * (1 - v), energy * v);
 }
 
-vector<DynamicData> secondaries::NaivIonization::CalculateSecondaries(
+vector<ParticleState> secondaries::NaivIonization::CalculateSecondaries(
     StochasticLoss loss, const Component&, vector<double> &rnd)
 {
     auto v = loss.loss_energy / loss.parent_particle_energy;
@@ -32,7 +32,7 @@ vector<DynamicData> secondaries::NaivIonization::CalculateSecondaries(
     auto secondary_dir = CalculateDirections( loss.direction, loss.loss_energy,
                                               v, rnd[1]);
 
-    auto sec = std::vector<DynamicData>();
+    auto sec = std::vector<ParticleState>();
     sec.emplace_back(static_cast<ParticleType>(primary_particle_type),
                      loss.position, get<0>(secondary_dir),
                      get<0>(secondary_energies), loss.time, 0.);

--- a/src/PROPOSAL/secondaries/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.cxx
+++ b/src/PROPOSAL/secondaries/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.cxx
@@ -50,7 +50,7 @@ secondaries::KelnerKokoulinPetrukhinMupairProduction::CalculateEnergy(
     return make_tuple(energy_1, energy_2);
 }
 
-vector<DynamicData>
+vector<ParticleState>
 secondaries::KelnerKokoulinPetrukhinMupairProduction::CalculateSecondaries(
     StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
@@ -60,7 +60,7 @@ secondaries::KelnerKokoulinPetrukhinMupairProduction::CalculateSecondaries(
     auto secondary_dir = CalculateDirections(
         loss.direction, loss.loss_energy, rho, rnd[2]);
 
-    auto sec = std::vector<DynamicData>();
+    auto sec = std::vector<ParticleState>();
 
     sec.emplace_back(static_cast<ParticleType>(p_def.particle_type),
                      loss.position, loss.direction,

--- a/src/PROPOSAL/secondaries/photopairproduction/PhotoTsai.cxx
+++ b/src/PROPOSAL/secondaries/photopairproduction/PhotoTsai.cxx
@@ -158,7 +158,7 @@ tuple<double, double> secondaries::PhotoTsai::CalculateEnergy(
     return make_tuple(energy * rho, energy * (1 - rho));
 }
 
-vector<DynamicData> secondaries::PhotoTsai::CalculateSecondaries(
+vector<ParticleState> secondaries::PhotoTsai::CalculateSecondaries(
     StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
     auto rho = CalculateRho(loss.parent_particle_energy, rnd[0], comp);
@@ -167,7 +167,7 @@ vector<DynamicData> secondaries::PhotoTsai::CalculateSecondaries(
     auto secondary_dir = CalculateDirections(
         loss.direction, loss.parent_particle_energy, rho, comp, rnd);
 
-    auto sec = std::vector<DynamicData>();
+    auto sec = std::vector<ParticleState>();
     sec.emplace_back(ParticleType::EMinus, loss.position, get<0>(secondary_dir),
                      get<0>(secondary_energies), loss.time, 0.);
     sec.emplace_back(ParticleType::EPlus, loss.position, get<1>(secondary_dir),

--- a/src/PROPOSAL/secondaries/photopairproduction/PhotoTsai.cxx
+++ b/src/PROPOSAL/secondaries/photopairproduction/PhotoTsai.cxx
@@ -158,20 +158,19 @@ tuple<double, double> secondaries::PhotoTsai::CalculateEnergy(
     return make_tuple(energy * rho, energy * (1 - rho));
 }
 
-vector<Loss::secondary_t> secondaries::PhotoTsai::CalculateSecondaries(
-    double primary_energy, Loss::secondary_t loss, const Component& comp, vector<double> rnd)
+vector<DynamicData> secondaries::PhotoTsai::CalculateSecondaries(
+    StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
-    auto rho = CalculateRho(primary_energy, rnd[0], comp);
-    auto secondary_energy
-        = CalculateEnergy(primary_energy, rho, rnd[1]);
+    auto rho = CalculateRho(loss.parent_particle_energy, rnd[0], comp);
+    auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, rho,
+                                            rnd[1]);
     auto secondary_dir = CalculateDirections(
-        get<Loss::DIRECTION>(loss), primary_energy, rho, comp, rnd);
-    auto sec = std::vector<Loss::secondary_t>();
-    sec.emplace_back(static_cast<int>(ParticleType::EMinus),
-        get<Loss::POSITION>(loss), get<0>(secondary_dir),
-        get<0>(secondary_energy), 0.);
-    sec.emplace_back(static_cast<int>(ParticleType::EPlus),
-        get<Loss::POSITION>(loss), get<1>(secondary_dir),
-        get<1>(secondary_energy), 0.);
+        loss.direction, loss.parent_particle_energy, rho, comp, rnd);
+
+    auto sec = std::vector<DynamicData>();
+    sec.emplace_back(ParticleType::EMinus, loss.position, get<0>(secondary_dir),
+                     get<0>(secondary_energies), loss.time, 0.);
+    sec.emplace_back(ParticleType::EPlus, loss.position, get<1>(secondary_dir),
+                     get<1>(secondary_energies), loss.time, 0.);
     return sec;
 }

--- a/src/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.cxx
+++ b/src/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.cxx
@@ -7,13 +7,13 @@
 
 using namespace PROPOSAL;
 
-vector<DynamicData>
+vector<ParticleState>
 secondaries::NaivWeakInteraction::CalculateSecondaries(StochasticLoss loss,
                                                        const Component&,
                                                        vector<double>&)
 {
     // TODO: Treatment of hadronic parts of interaction
-    auto sec = std::vector<DynamicData>();
+    auto sec = std::vector<ParticleState>();
     sec.emplace_back(static_cast<ParticleType>(weak_partner_type),
                      loss.position, loss.direction, loss.loss_energy, loss.time,
                      0.);

--- a/src/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.cxx
+++ b/src/PROPOSAL/secondaries/weakinteraction/NaivWeakInteraction.cxx
@@ -7,12 +7,15 @@
 
 using namespace PROPOSAL;
 
-vector<Loss::secondary_t>
-secondaries::NaivWeakInteraction::CalculateSecondaries(double,
-    Loss::secondary_t loss, const Component&,
-    vector<double>)
+vector<DynamicData>
+secondaries::NaivWeakInteraction::CalculateSecondaries(StochasticLoss loss,
+                                                       const Component&,
+                                                       vector<double>&)
 {
-    std::get<Loss::TYPE>(loss) = weak_partner_type;
-    auto sec = vector<Loss::secondary_t>{ move(loss) };
+    // TODO: Treatment of hadronic parts of interaction
+    auto sec = std::vector<DynamicData>();
+    sec.emplace_back(static_cast<ParticleType>(weak_partner_type),
+                     loss.position, loss.direction, loss.loss_energy, loss.time,
+                     0.);
     return sec;
 }

--- a/tests/DecayChannel_TEST.cxx
+++ b/tests/DecayChannel_TEST.cxx
@@ -20,8 +20,8 @@ double matrix_element_evaluate(const DynamicData& p_condition, const std::vector
     DynamicData numu = products.at(1);
     DynamicData nuebar = products.at(2);
 
-    double p1 = p_condition.GetEnergy() * nuebar.GetEnergy() - (p_condition.GetMomentum() * p_condition.GetDirection()) * (nuebar.GetMomentum() * nuebar.GetDirection());
-    double p2 = electron.GetEnergy() * numu.GetEnergy() - (electron.GetMomentum() * electron.GetDirection()) * (numu.GetMomentum() * numu.GetDirection());
+    double p1 = p_condition.energy * nuebar.energy - (p_condition.GetMomentum() * p_condition.direction) * (nuebar.GetMomentum() * nuebar.direction);
+    double p2 = electron.energy * numu.energy - (electron.GetMomentum() * electron.direction) * (numu.GetMomentum() * numu.direction);
 
     return 64 * G_F*G_F * p1 * p2;
 }
@@ -161,7 +161,8 @@ TEST(DecaySpectrum, MuMinus_Rest){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle(init_particle_def.particle_type);
+    DynamicData init_particle;
+    init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
     ParticleDef p1  = getParticleDef(particleDecay1);
@@ -174,29 +175,29 @@ TEST(DecaySpectrum, MuMinus_Rest){
 
     double aux_energy, energy_sum;
 
-    init_particle.SetEnergy(init_energy);
+    init_particle.energy = init_energy;
 
     double v_max = ( std::pow(init_particle_def.mass,2 ) + pow(p0.mass,2))/(2 * init_particle_def.mass);
-    double gamma = init_particle.GetEnergy() / init_particle_def.mass;
+    double gamma = init_particle.energy / init_particle_def.mass;
     double betagamma = init_particle.GetMomentum() / init_particle_def.mass;
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0.;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -235,21 +236,21 @@ TEST(DecaySpectrum, MuMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -293,21 +294,21 @@ TEST(DecaySpectrum, MuMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -361,7 +362,8 @@ TEST(DecaySpectrum, MuMinus_Energy){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle(init_particle_def.particle_type);
+    DynamicData init_particle;
+    init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
     ParticleDef p1  = getParticleDef(particleDecay1);
@@ -374,29 +376,29 @@ TEST(DecaySpectrum, MuMinus_Energy){
 
     double aux_energy, energy_sum;
 
-    init_particle.SetEnergy(init_energy);
+    init_particle.energy = init_energy;
 
     double v_max = ( std::pow(init_particle_def.mass,2 ) + pow(p0.mass,2))/(2 * init_particle_def.mass);
-    double gamma = init_particle.GetEnergy() / init_particle_def.mass;
+    double gamma = init_particle.energy / init_particle_def.mass;
     double betagamma = init_particle.GetMomentum() / init_particle_def.mass;
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -436,21 +438,21 @@ TEST(DecaySpectrum, MuMinus_Energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -494,21 +496,21 @@ TEST(DecaySpectrum, MuMinus_Energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -561,7 +563,8 @@ TEST(DecaySpectrum, TauMinus_Rest){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle(init_particle_def.particle_type);
+    DynamicData init_particle;
+    init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
     ParticleDef p1  = getParticleDef(particleDecay1);
@@ -574,29 +577,29 @@ TEST(DecaySpectrum, TauMinus_Rest){
 
     double aux_energy, energy_sum;
 
-    init_particle.SetEnergy(init_energy);
+    init_particle.energy = init_energy;
 
     double v_max = ( std::pow(init_particle_def.mass,2 ) + pow(p0.mass,2))/(2 * init_particle_def.mass);
-    double gamma = init_particle.GetEnergy() / init_particle_def.mass;
+    double gamma = init_particle.energy / init_particle_def.mass;
     double betagamma = init_particle.GetMomentum() / init_particle_def.mass;
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -635,21 +638,21 @@ TEST(DecaySpectrum, TauMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -693,21 +696,21 @@ TEST(DecaySpectrum, TauMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -761,7 +764,8 @@ TEST(DecaySpectrum, TauMinus_energy){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle(init_particle_def.particle_type);
+    DynamicData init_particle;
+    init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
     ParticleDef p1  = getParticleDef(particleDecay1);
@@ -774,29 +778,29 @@ TEST(DecaySpectrum, TauMinus_energy){
 
     double aux_energy, energy_sum;
 
-    init_particle.SetEnergy(init_energy);
+    init_particle.energy = init_energy;
 
     double v_max = ( std::pow(init_particle_def.mass,2 ) + pow(p0.mass,2))/(2 * init_particle_def.mass);
-    double gamma = init_particle.GetEnergy() / init_particle_def.mass;
+    double gamma = init_particle.energy / init_particle_def.mass;
     double betagamma = init_particle.GetMomentum() / init_particle_def.mass;
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -835,21 +839,21 @@ TEST(DecaySpectrum, TauMinus_energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";
@@ -893,21 +897,21 @@ TEST(DecaySpectrum, TauMinus_energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.SetDirection(Vector3D(0, 0, -1));
-        init_particle.SetPosition(Vector3D(0, 0, -1));
-        init_particle.SetEnergy(init_energy);
-        init_particle.SetPropagatedDistance(0);
+        init_particle.direction = Vector3D(0, 0, -1);
+        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.energy = init_energy;
+        init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
         for(DynamicData particle : aux){
-            aux_energy = particle.GetEnergy();
-            if(particle.GetType() == p0.particle_type) {
+            aux_energy = particle.energy;
+            if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p1.particle_type) {
+            else if(particle.type == p1.particle_type) {
                 prod_1.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             }
-            else if(particle.GetType() == p2.particle_type) {
+            else if(particle.type == p2.particle_type) {
                 prod_2.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
             } else {
                 FAIL() << "Unknown return particle";

--- a/tests/DecayChannel_TEST.cxx
+++ b/tests/DecayChannel_TEST.cxx
@@ -12,13 +12,13 @@
 
 using namespace PROPOSAL;
 
-double matrix_element_evaluate(const DynamicData& p_condition, const std::vector<DynamicData>& products)
+double matrix_element_evaluate(const ParticleState& p_condition, const std::vector<ParticleState>& products)
 {
     double G_F = 1.1663787*1e-2; // MeV
 
-    DynamicData electron = products.at(0);
-    DynamicData numu = products.at(1);
-    DynamicData nuebar = products.at(2);
+    ParticleState electron = products.at(0);
+    ParticleState numu = products.at(1);
+    ParticleState nuebar = products.at(2);
 
     double p1 = p_condition.energy * nuebar.energy - (p_condition.GetMomentum() * p_condition.direction) * (nuebar.GetMomentum() * nuebar.direction);
     double p2 = electron.energy * numu.energy - (electron.GetMomentum() * electron.direction) * (numu.GetMomentum() * numu.direction);
@@ -161,7 +161,7 @@ TEST(DecaySpectrum, MuMinus_Rest){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle;
+    ParticleState init_particle;
     init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
@@ -189,7 +189,7 @@ TEST(DecaySpectrum, MuMinus_Rest){
         init_particle.propagated_distance = 0.;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -242,7 +242,7 @@ TEST(DecaySpectrum, MuMinus_Rest){
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -300,7 +300,7 @@ TEST(DecaySpectrum, MuMinus_Rest){
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -362,7 +362,7 @@ TEST(DecaySpectrum, MuMinus_Energy){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle;
+    ParticleState init_particle;
     init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
@@ -390,7 +390,7 @@ TEST(DecaySpectrum, MuMinus_Energy){
         init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -444,7 +444,7 @@ TEST(DecaySpectrum, MuMinus_Energy){
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -502,7 +502,7 @@ TEST(DecaySpectrum, MuMinus_Energy){
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -563,7 +563,7 @@ TEST(DecaySpectrum, TauMinus_Rest){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle;
+    ParticleState init_particle;
     init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
@@ -591,7 +591,7 @@ TEST(DecaySpectrum, TauMinus_Rest){
         init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -644,7 +644,7 @@ TEST(DecaySpectrum, TauMinus_Rest){
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -702,7 +702,7 @@ TEST(DecaySpectrum, TauMinus_Rest){
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -764,7 +764,7 @@ TEST(DecaySpectrum, TauMinus_energy){
     in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     ParticleDef init_particle_def = getParticleDef(particleName);
-    DynamicData init_particle;
+    ParticleState init_particle;
     init_particle.type = init_particle_def.particle_type;
 
     ParticleDef p0  = getParticleDef(particleDecay0);
@@ -792,7 +792,7 @@ TEST(DecaySpectrum, TauMinus_energy){
         init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -845,7 +845,7 @@ TEST(DecaySpectrum, TauMinus_energy){
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;
@@ -903,7 +903,7 @@ TEST(DecaySpectrum, TauMinus_energy){
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
         energy_sum = 0;
-        for(DynamicData particle : aux){
+        for(ParticleState particle : aux){
             aux_energy = particle.energy;
             if(particle.type == p0.particle_type) {
                 prod_0.at((unsigned long) floor(aux_energy / max_energy * NUM_bins)) += 1;

--- a/tests/Particle_TEST.cxx
+++ b/tests/Particle_TEST.cxx
@@ -16,14 +16,14 @@ TEST(Comparison, Comparison_equal)
     direction.SetSphericalCoordinates(1, 20 * PI / 180., 20 * PI / 180.);
     direction.CalculateCartesianFromSpherical();
 
-    DynamicData A;
-    DynamicData B;
+    ParticleState A;
+    ParticleState B;
     EXPECT_TRUE(A == B);
 
-    DynamicData* C = new DynamicData();
+    ParticleState* C = new ParticleState();
     C->position = position;
     C->direction = direction;
-    DynamicData* D = new DynamicData();
+    ParticleState* D = new ParticleState();
     D->position = position;
     D->direction = direction;
 
@@ -33,7 +33,7 @@ TEST(Comparison, Comparison_equal)
 
     position    = Vector3D();
     direction   = Vector3D();
-    DynamicData* E = new DynamicData();
+    ParticleState* E = new ParticleState();
     E->position = position;
     E->direction = direction;
     EXPECT_TRUE(A == *E);
@@ -44,16 +44,16 @@ TEST(Comparison, Comparison_not_equal)
     direction.SetSphericalCoordinates(1, 20 * PI / 180., 20 * PI / 180.);
     direction.CalculateCartesianFromSpherical();
 
-    DynamicData A;
-    DynamicData B;
+    ParticleState A;
+    ParticleState B;
     A.SetType(ParticleType::EMinus);
     B.SetType(ParticleType::MuMinus);
     EXPECT_TRUE(A != B);
 
-    DynamicData* C = new DynamicData();
+    ParticleState* C = new ParticleState();
     C->position = position;
     C->direction = direction;
-    DynamicData* D = new DynamicData();
+    ParticleState* D = new ParticleState();
 
     D->position = position;
     D->direction = direction;
@@ -63,8 +63,8 @@ TEST(Comparison, Comparison_not_equal)
 
 TEST(Assignment, Copyconstructor)
 {
-    DynamicData A;
-    DynamicData B = A;
+    ParticleState A;
+    ParticleState B = A;
 
     EXPECT_TRUE(A == B);
 }
@@ -73,11 +73,11 @@ TEST(Assignment, Copyconstructor2)
 {
     direction.SetSphericalCoordinates(1, 20 * PI / 180., 20 * PI / 180.);
     direction.CalculateCartesianFromSpherical();
-    DynamicData A;
+    ParticleState A;
     A.SetType(ParticleType::TauMinus);
     A.position = position;
     A.direction = direction;
-    DynamicData B(A);
+    ParticleState B(A);
 
     EXPECT_TRUE(A == B);
 }
@@ -88,7 +88,7 @@ TEST(Deflection, Deflection)
     Vector3D direction_B(0., -1./SQRT2, 1./SQRT2);
     Vector3D direction_C(1./3., 2./3., -2./3.);
     Vector3D direction_tmp(1., 0., 0.);
-    DynamicData particle;
+    ParticleState particle;
     particle.SetType(ParticleType::MuMinus);
     double cosangle;
 

--- a/tests/Particle_TEST.cxx
+++ b/tests/Particle_TEST.cxx
@@ -20,22 +20,22 @@ TEST(Comparison, Comparison_equal)
     DynamicData B;
     EXPECT_TRUE(A == B);
 
-    DynamicData* C = new DynamicData(TauMinusDef().particle_type);
-    C->SetPosition(position);
-    C->SetDirection(direction);
-    DynamicData* D = new DynamicData(TauMinusDef().particle_type);
-    D->SetPosition(position);
-    D->SetDirection(direction);
+    DynamicData* C = new DynamicData();
+    C->position = position;
+    C->direction = direction;
+    DynamicData* D = new DynamicData();
+    D->position = position;
+    D->direction = direction;
 
-    C->SetEnergy(1e6);
-    D->SetEnergy(1e6);
+    C->energy = 1e6;
+    D->energy = 1e6;
     EXPECT_TRUE(*C == *D);
 
     position    = Vector3D();
     direction   = Vector3D();
-    DynamicData* E = new DynamicData(0);
-    E->SetPosition(position);
-    E->SetDirection(direction);
+    DynamicData* E = new DynamicData();
+    E->position = position;
+    E->direction = direction;
     EXPECT_TRUE(A == *E);
 }
 
@@ -45,17 +45,19 @@ TEST(Comparison, Comparison_not_equal)
     direction.CalculateCartesianFromSpherical();
 
     DynamicData A;
-    DynamicData B(TauMinusDef().particle_type);
+    DynamicData B;
+    A.SetType(ParticleType::EMinus);
+    B.SetType(ParticleType::MuMinus);
     EXPECT_TRUE(A != B);
 
-    DynamicData* C = new DynamicData(TauMinusDef().particle_type);
-    C->SetPosition(position);
-    C->SetDirection(direction);
-    DynamicData* D = new DynamicData(TauMinusDef().particle_type);
+    DynamicData* C = new DynamicData();
+    C->position = position;
+    C->direction = direction;
+    DynamicData* D = new DynamicData();
 
-    D->SetPosition(position);
-    D->SetDirection(direction);
-    D->SetEnergy(1e6);
+    D->position = position;
+    D->direction = direction;
+    D->energy = 1e6;
     EXPECT_TRUE(*C != *D);
 }
 
@@ -71,9 +73,10 @@ TEST(Assignment, Copyconstructor2)
 {
     direction.SetSphericalCoordinates(1, 20 * PI / 180., 20 * PI / 180.);
     direction.CalculateCartesianFromSpherical();
-    DynamicData A(TauMinusDef().particle_type);
-    A.SetPosition(position);
-    A.SetDirection(direction);
+    DynamicData A;
+    A.SetType(ParticleType::TauMinus);
+    A.position = position;
+    A.direction = direction;
     DynamicData B(A);
 
     EXPECT_TRUE(A == B);
@@ -85,7 +88,8 @@ TEST(Deflection, Deflection)
     Vector3D direction_B(0., -1./SQRT2, 1./SQRT2);
     Vector3D direction_C(1./3., 2./3., -2./3.);
     Vector3D direction_tmp(1., 0., 0.);
-    DynamicData particle(MuMinusDef().particle_type);
+    DynamicData particle;
+    particle.SetType(ParticleType::MuMinus);
     double cosangle;
 
     std::vector<double> cos_phi_list{-1, -0.8, -0.2, 0., 0.2, 0.8, 1.};
@@ -93,21 +97,21 @@ TEST(Deflection, Deflection)
 
     for(auto const& cos_phi: cos_phi_list){
         for(auto const& theta: theta_list){
-            particle.SetDirection(direction_A);
+            particle.direction = direction_A;
             particle.DeflectDirection(cos_phi, theta);
-            direction_tmp = particle.GetDirection();
+            direction_tmp = particle.direction;
             cosangle = scalar_product(direction_A, direction_tmp);
             ASSERT_NEAR(cos_phi, cosangle, 1e-8);
 
-            particle.SetDirection(direction_B);
+            particle.direction = direction_B;
             particle.DeflectDirection(cos_phi, theta);
-            direction_tmp = particle.GetDirection();
+            direction_tmp = particle.direction;
             cosangle = scalar_product(direction_B, direction_tmp);
             ASSERT_NEAR(cos_phi, cosangle, 1e-8);
 
-            particle.SetDirection(direction_C);
+            particle.direction = direction_C;
             particle.DeflectDirection(cos_phi, theta);
-            direction_tmp = particle.GetDirection();
+            direction_tmp = particle.direction;
             cosangle = scalar_product(direction_C, direction_tmp);
             ASSERT_NEAR(cos_phi, cosangle, 1e-8);
         }

--- a/tests/Secondaries_TEST.cxx
+++ b/tests/Secondaries_TEST.cxx
@@ -44,7 +44,7 @@ TEST(SecondaryVector, EntryPointExitPoint)
     Vector3D position(0, 0, 0);
     Vector3D direction(0, 0, 1);
     auto energy = 1e8; // MeV
-    auto init_state = DynamicData(13, position, direction, energy, energy, 0., 0.);
+    auto init_state = DynamicData(position, direction, energy, 0., 0.);
 
     auto secondaries = prop->Propagate(init_state, 50000);
 
@@ -60,20 +60,19 @@ TEST(SecondaryVector, EntryPointExitPoint)
 
     // Test for track beginning in geometry
     auto sphere_start = Sphere(Vector3D(0, 0, 100), 100);
-    EXPECT_TRUE(secondaries.GetEntryPoint(sphere_start)->GetEnergy() == energy);
-    EXPECT_TRUE(secondaries.GetEntryPoint(sphere_start)->GetPropagatedDistance() == 0);
-    EXPECT_TRUE(secondaries.GetEntryPoint(sphere_start)->GetPosition() == position);
+    EXPECT_TRUE(secondaries.GetEntryPoint(sphere_start)->energy == energy);
+    EXPECT_TRUE(secondaries.GetEntryPoint(sphere_start)->position == position);
 
     // Test for track ending in geometry
     auto sphere_end = Sphere(Vector3D(0, 0, 49000), 1000);
-    EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->GetEnergy() == secondaries.back().GetEnergy());
-    EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->GetPropagatedDistance() == secondaries.back().GetPropagatedDistance());
-    EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->GetPosition() == secondaries.back().GetPosition());
+    EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->energy == secondaries.back().energy);
+    EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->propagated_distance == secondaries.back().propagated_distance);
+    EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->position == secondaries.back().position);
 
     // Test points where interaction points should be equal to entry/exit points
     auto sphere = Sphere(Vector3D(0, 0, 10000), 1000);
-    EXPECT_TRUE(secondaries.GetEntryPoint(sphere)->GetPropagatedDistance() == 9000);
-    EXPECT_TRUE(secondaries.GetExitPoint(sphere)->GetPropagatedDistance() == 11000);
+    EXPECT_TRUE(secondaries.GetEntryPoint(sphere)->propagated_distance == 9000);
+    EXPECT_TRUE(secondaries.GetExitPoint(sphere)->propagated_distance == 11000);
 }
 
 TEST(SecondaryVector, EntryPointExitPointRePropagation)
@@ -83,7 +82,7 @@ TEST(SecondaryVector, EntryPointExitPointRePropagation)
     Vector3D position(0, 0, 0);
     Vector3D direction(0, 0, 1);
     auto energy = 1e8; // MeV
-    auto init_state = DynamicData(13, position, direction, energy, energy, 0., 0.);
+    auto init_state = DynamicData(position, direction, energy, 0., 0.);
 
     auto secondaries = prop->Propagate(init_state, 1e5);
 
@@ -91,38 +90,38 @@ TEST(SecondaryVector, EntryPointExitPointRePropagation)
     auto entry_point = secondaries.GetEntryPoint(sphere);
     auto exit_point = secondaries.GetExitPoint(sphere);
     int i = 0;
-    while (secondaries[i].GetPropagatedDistance() < entry_point->GetPropagatedDistance() ) {
+    while (secondaries[i].propagated_distance < entry_point->propagated_distance ) {
         i++;
     }
     auto sec_i = secondaries[i-1];
     auto sec_f = secondaries[i];
 
-    EXPECT_TRUE(sec_i.GetEnergy() > entry_point->GetEnergy());
-    EXPECT_TRUE(sec_i.GetTime() < entry_point->GetTime());
-    EXPECT_TRUE(sec_i.GetPropagatedDistance() < entry_point->GetPropagatedDistance());
-    EXPECT_TRUE(sphere.IsInfront(sec_i.GetPosition(), sec_i.GetDirection()));
+    EXPECT_TRUE(sec_i.energy > entry_point->energy);
+    EXPECT_TRUE(sec_i.time < entry_point->time);
+    EXPECT_TRUE(sec_i.propagated_distance < entry_point->propagated_distance);
+    EXPECT_TRUE(sphere.IsInfront(sec_i.position, sec_i.direction));
 
-    EXPECT_TRUE(sec_f.GetEnergy() < entry_point->GetEnergy());
-    EXPECT_TRUE(sec_f.GetTime() > entry_point->GetTime());
-    EXPECT_TRUE(sec_f.GetPropagatedDistance() > entry_point->GetPropagatedDistance());
-    EXPECT_FALSE(sphere.IsInfront(sec_f.GetPosition(), sec_f.GetDirection()));
-    EXPECT_TRUE(entry_point->GetPropagatedDistance() == sphere.GetPosition().GetZ() - sphere.GetRadius());
+    EXPECT_TRUE(sec_f.energy < entry_point->energy);
+    EXPECT_TRUE(sec_f.time > entry_point->time);
+    EXPECT_TRUE(sec_f.propagated_distance > entry_point->propagated_distance);
+    EXPECT_FALSE(sphere.IsInfront(sec_f.position, sec_f.direction));
+    EXPECT_TRUE(entry_point->propagated_distance == sphere.GetPosition().GetZ() - sphere.GetRadius());
 
-    while (secondaries[i].GetPropagatedDistance() < exit_point->GetPropagatedDistance()) {
+    while (secondaries[i].propagated_distance < exit_point->propagated_distance) {
         i++;
     }
 
     sec_i = secondaries[i-1]; // point before exit point
     sec_f = secondaries[i]; // points after exit point
 
-    EXPECT_TRUE(sec_i.GetEnergy() > exit_point->GetEnergy());
-    EXPECT_TRUE(sec_i.GetTime() < exit_point->GetTime());
-    EXPECT_TRUE(sec_i.GetPropagatedDistance() < exit_point->GetPropagatedDistance());
-    EXPECT_FALSE(sphere.IsBehind(sec_i.GetPosition(), sec_i.GetDirection()));
+    EXPECT_TRUE(sec_i.energy > exit_point->energy);
+    EXPECT_TRUE(sec_i.time < exit_point->time);
+    EXPECT_TRUE(sec_i.propagated_distance < exit_point->propagated_distance);
+    EXPECT_FALSE(sphere.IsBehind(sec_i.position, sec_i.direction));
 
-    EXPECT_TRUE(sec_f.GetEnergy() < exit_point->GetEnergy());
-    EXPECT_TRUE(sec_f.GetTime() > exit_point->GetTime());
-    EXPECT_TRUE(sec_f.GetPropagatedDistance() > exit_point->GetPropagatedDistance());
-    EXPECT_TRUE(sphere.IsBehind(sec_f.GetPosition(), sec_f.GetDirection()));
-    EXPECT_TRUE(exit_point->GetPropagatedDistance() == sphere.GetPosition().GetZ() + sphere.GetRadius());
+    EXPECT_TRUE(sec_f.energy < exit_point->energy);
+    EXPECT_TRUE(sec_f.time > exit_point->time);
+    EXPECT_TRUE(sec_f.propagated_distance > exit_point->propagated_distance);
+    EXPECT_TRUE(sphere.IsBehind(sec_f.position, sec_f.direction));
+    EXPECT_TRUE(exit_point->propagated_distance == sphere.GetPosition().GetZ() + sphere.GetRadius());
 }

--- a/tests/Secondaries_TEST.cxx
+++ b/tests/Secondaries_TEST.cxx
@@ -44,7 +44,7 @@ TEST(SecondaryVector, EntryPointExitPoint)
     Vector3D position(0, 0, 0);
     Vector3D direction(0, 0, 1);
     auto energy = 1e8; // MeV
-    auto init_state = DynamicData(position, direction, energy, 0., 0.);
+    auto init_state = ParticleState(position, direction, energy, 0., 0.);
 
     auto secondaries = prop->Propagate(init_state, 50000);
 
@@ -82,7 +82,7 @@ TEST(SecondaryVector, EntryPointExitPointRePropagation)
     Vector3D position(0, 0, 0);
     Vector3D direction(0, 0, 1);
     auto energy = 1e8; // MeV
-    auto init_state = DynamicData(position, direction, energy, 0., 0.);
+    auto init_state = ParticleState(position, direction, energy, 0., 0.);
 
     auto secondaries = prop->Propagate(init_state, 1e5);
 


### PR DESCRIPTION
This merge request for the development branch is intended to improve the return type of the Propagator class, i.e. a Secondaries/Track object, as well as making the objects describing Particles and losses in PROPOSAL more intuitive (see also #104)

### Losses/Particles

At the moment, it is not entirely clear which objects describe energy losses and particle states in PROPOSAL. Therefore, I would like to introduce three different objects:

**1. DynamicData**
_DynamicData_ objects should only be used to described particle states. Examples are the initial state of the Propagator, secondary particles or elements of the Track. DynamicData objects are defined by their ParticleType (PDG code), position, direction, energy, time and propagated distance. I removed most of the Getter/Setter methods to simplify the class.

**2. StochasticLoss**
_Stochastic loss_ objects are used to describe particles losses. This is the object of interest for many users, for example the IceCube experiment. StochasticLoses are described by their (loss)energy, InteractionType, position, direction, time (when the StochasticLoss happend), propagated distance (when the StochasticLoss happend) and parent_particle_energy (initial energy of the particle causing the StochasticLoss).

**3. ContinuousLoss**
As an special loss type, _ContinuousLoss_ objects are introduced. Unlike stochastic losses, continuous losses are not defined by a single energy/position/time and should therefore be treated differently than the StochasticLoss objects. ContinuousLoss objects are destribed by a pair of energies (energies at the beginning and end of the stochastic loss), positions (at the beginning and end of the stochastic loss), times (at the beginning and end of the stochastic loss) and direction(s).

### Track/Secondaries
The output of the Propagator is a class called _Secondaries_ (although I would prefer renaming it, for example to _Track_).
Here, the information of the Propagation process is stored in a vector of _DynamicData_ objects, describing consecutive states of the propagated particle (therefore Track).

From this vector, the class provides the functionality to convert the _DynamicData_ objects into _StochasticLoss_ or _ContinuousLoss_ objects. This requires additional information about the last interaction type of the _DynamicData_ objects. These information are currently stored in the _type_ variable of the _DynamicData_ object, although I believe that this variable should be reserved for the PDG code of the particle object.

Furthermore, the Secondaries/Track class provides additional functionalities, including:
- Calculate the state of a particle when entering/exiting an arbitrary geometry _GetEntryPoint_ and _GetExitPoint_
- Calculate the state of a particle for the closest approach to an arbitrary geometry _GetClosesApproachPoint_
- Queries, filtering requested information from the track (e.g. only Track information inside a certain geometry or only information on specific variables)

### SecondariesCalculator

The SecondariesCalculator provides the functionality to convert energy losses into particle states. An electron-positron pair production for example can be described by a _StochasticLoss_ object. The corresponding SecondariesCalculator turns this _StochasticLoss_ objects into three _DynamicData_ objects: The incident lepton, an electron and and positron.


