### PR TITLE
Fix numerical problems for PropagationUtilityDisplacement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(PROPOSAL VERSION 6.1.3 LANGUAGES CXX)
+project(PROPOSAL VERSION 6.1.4 LANGUAGES CXX)
 
 
 IF(I3_PROJECTS)

--- a/private/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
+++ b/private/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
@@ -226,8 +226,9 @@ double UtilityInterpolantDisplacement::GetUpperLimit(double ei, double rnd) {
 
     int MaxSteps = 200;
     try{
-        return std::max(NewtonRaphson(f, df, 0, ei, ei, MaxSteps,
-                                      PARTICLE_POSITION_RESOLUTION), utility_.GetParticleDef().mass);
+        return std::max(NewtonRaphson(f, df, 0, ei, ei, MaxSteps, std::max(
+                PARTICLE_POSITION_RESOLUTION, ei * 1e-15)),
+                        utility_.GetParticleDef().mass);
     } catch (MathException& e){
         return utility_.GetParticleDef().mass;
     }


### PR DESCRIPTION
Fix an issue where the accuracy passed to the Newton Raphson method could not be reached because it was too high compared to the double precision for high energies. Fixes #106 