### PR TITLE
Add call to CalculateSphericalCoordinates() at the beginning of Scattering:Scatter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(PROPOSAL VERSION 6.1.4 LANGUAGES CXX)
+project(PROPOSAL VERSION 6.1.5 LANGUAGES CXX)
 
 
 IF(I3_PROJECTS)

--- a/private/PROPOSAL/scattering/Scattering.cxx
+++ b/private/PROPOSAL/scattering/Scattering.cxx
@@ -92,6 +92,7 @@ Directions Scattering::Scatter(double dr,
     // u averaged continous propagation direction
     // n_i direction after continous propagation
     directions_.n_i_ = Vector3D(old_direction);
+    directions_.n_i_.CalculateSphericalCoordinates();
 
     if(dr<=0)
     {
@@ -106,10 +107,10 @@ Directions Scattering::Scatter(double dr,
     tz = std::sqrt(std::max(1. - (random_angles.tx * random_angles.tx + random_angles.ty * random_angles.ty), 0.));
 
     double sinth, costh, sinph, cosph;
-    sinth = std::sin(old_direction.GetTheta());
-    costh = std::cos(old_direction.GetTheta());
-    sinph = std::sin(old_direction.GetPhi());
-    cosph = std::cos(old_direction.GetPhi());
+    sinth = std::sin(directions_.n_i_.GetTheta());
+    costh = std::cos(directions_.n_i_.GetTheta());
+    sinph = std::sin(directions_.n_i_.GetPhi());
+    cosph = std::cos(directions_.n_i_.GetPhi());
 
     const Vector3D rotate_vector_x = Vector3D(costh * cosph, costh * sinph, -sinth);
     const Vector3D rotate_vector_y = Vector3D(-sinph, cosph, 0.);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 SET(RESOURCE_URL https://proposal.app.tu-dortmund.de/resources)
-SET(TEST_FILES TestFiles_2020-10-21.tar.gz)
+SET(TEST_FILES TestFiles-2021-01-13.tar.gz)
 add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/google/googletest" "extern/googletest" EXCLUDE_FROM_ALL)
 mark_as_advanced(
 	BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS

--- a/tests/gen_testfiles_scripts/propagation.py
+++ b/tests/gen_testfiles_scripts/propagation.py
@@ -14,7 +14,7 @@ def create_table(dir_name):
         "resources/config_ice.json"
     )
 
-    mu = pp.particle.DynamicData(pp.particle.Particle_Id.MuMinus)
+    mu = pp.particle.DynamicData(pp.particle.Particle_Type.MuMinus)
 
     mu.energy = 1e8
     mu.propagated_distance = 0
@@ -26,7 +26,7 @@ def create_table(dir_name):
 
         buf = [""]
         buf.append("name")
-        buf.append("lenght")
+        buf.append("length")
         buf.append("energy")
         buf.append("x")
         buf.append("y")


### PR DESCRIPTION
Add call to CalculateSphericalCoordinates() at the beginning of Scattering:Scatter to ensure that return values of GetTheta() and GetPhi() are well-defined if spherical components have not been calculated yet.

Could be the solution for issue #119

There will be a better, conceptional fix for this issue in version 7.X