### PR TITLE
Separate Vector3D into Cartesian3D and Spherical3D

### DIFF
--- a/include/PROPOSAL/DefaultFactory.h
+++ b/include/PROPOSAL/DefaultFactory.h
@@ -8,6 +8,8 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <string>
+#include <sstream>
 #include <iostream>
 
 namespace PROPOSAL {

--- a/include/PROPOSAL/DefaultFactory.h
+++ b/include/PROPOSAL/DefaultFactory.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <memory>
 #include <vector>
-#include <string>
 #include <sstream>
 #include <iostream>
 

--- a/include/PROPOSAL/PROPOSAL.h
+++ b/include/PROPOSAL/PROPOSAL.h
@@ -45,19 +45,16 @@
 #include "PROPOSAL/crosssection/parametrization/Ionization.h"
 #include "PROPOSAL/crosssection/parametrization/MupairProduction.h"
 #include "PROPOSAL/crosssection/parametrization/ParamTables.h"
-#include "PROPOSAL/crosssection/parametrization/Parametrization.h"
 #include "PROPOSAL/crosssection/parametrization/PhotoPairProduction.h"
 #include "PROPOSAL/crosssection/parametrization/PhotoQ2Integration.h"
 #include "PROPOSAL/crosssection/parametrization/PhotoRealPhotonAssumption.h"
 #include "PROPOSAL/crosssection/parametrization/Photonuclear.h"
 #include "PROPOSAL/crosssection/parametrization/WeakInteraction.h"
 
-#include "PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDX.h"
 #include "PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXIntegral.h"
 #include "PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.h"
 
-#include "PROPOSAL/secondaries/parametrization/Parametrization.h"
 #include "PROPOSAL/secondaries/parametrization/annihilation/Annihilation.h"
 #include "PROPOSAL/secondaries/parametrization/annihilation/HeitlerAnnihilation.h"
 #include "PROPOSAL/secondaries/parametrization/annihilation/SingleDifferentialAnnihilation.h"
@@ -78,7 +75,6 @@
 
 #include "PROPOSAL/secondaries/SecondariesCalculator.h"
 
-#include "PROPOSAL/crosssection/CrossSection.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionIntegral.h"
@@ -86,14 +82,12 @@
 
 #include "PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h"
 
-#include "PROPOSAL/decay/DecayChannel.h"
 #include "PROPOSAL/decay/DecayTable.h"
 #include "PROPOSAL/decay/LeptonicDecayChannel.h"
 #include "PROPOSAL/decay/ManyBodyPhaseSpace.h"
 #include "PROPOSAL/decay/StableChannel.h"
 #include "PROPOSAL/decay/TwoBodyPhaseSpace.h"
 
-#include "PROPOSAL/density_distr/density_distr.h"
 #include "PROPOSAL/density_distr/density_exponential.h"
 #include "PROPOSAL/density_distr/density_homogeneous.h"
 #include "PROPOSAL/density_distr/density_polynomial.h"
@@ -107,7 +101,6 @@
 #include "PROPOSAL/math/RandomGenerator.h"
 #include "PROPOSAL/math/Spline.h"
 #include "PROPOSAL/math/TableWriter.h"
-#include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/math/Cartesian3D.h"
 #include "PROPOSAL/math/Spherical3D.h"
 
@@ -130,7 +123,6 @@
 #include "PROPOSAL/propagation_utility/Time.h"
 #include "PROPOSAL/propagation_utility/TimeBuilder.h"
 
-#include "PROPOSAL/scattering/stochastic_deflection/Parametrization.h"
 #include "PROPOSAL/scattering/stochastic_deflection/ScatteringFactory.h"
 #include "PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/Bremsstrahlung.h"
 #include "PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/NaivBremsstrahlung.h"
@@ -138,7 +130,6 @@
 #include "PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.h"
 
 #include "PROPOSAL/scattering/multiple_scattering/Coefficients.h"
-#include "PROPOSAL/scattering/multiple_scattering/Parametrization.h"
 #include "PROPOSAL/scattering/multiple_scattering/ScatteringFactory.h"
 #include "PROPOSAL/scattering/multiple_scattering/Highland.h"
 #include "PROPOSAL/scattering/multiple_scattering/HighlandIntegral.h"

--- a/include/PROPOSAL/PROPOSAL.h
+++ b/include/PROPOSAL/PROPOSAL.h
@@ -108,6 +108,8 @@
 #include "PROPOSAL/math/Spline.h"
 #include "PROPOSAL/math/TableWriter.h"
 #include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/math/Cartesian3D.h"
+#include "PROPOSAL/math/Spherical3D.h"
 
 #include "PROPOSAL/particle/Particle.h"
 #include "PROPOSAL/particle/ParticleDef.h"

--- a/include/PROPOSAL/Secondaries.h
+++ b/include/PROPOSAL/Secondaries.h
@@ -33,13 +33,13 @@
 
 #include "PROPOSAL/particle/Particle.h"
 #include "PROPOSAL/particle/ParticleDef.h"
-#include "PROPOSAL/math/Vector3D.h"
-#include "PROPOSAL/geometry/Geometry.h"
 #include "PROPOSAL/propagation_utility/PropagationUtility.h"
 
 namespace PROPOSAL {
 
 class Density_distr;
+class Geometry;
+class Vector3D;
 
 using Sector = std::tuple<std::shared_ptr<const Geometry>, PropagationUtility,
             std::shared_ptr<const Density_distr>>;
@@ -72,8 +72,8 @@ public:
     ParticleState GetStateForEnergy(double) const;
     ParticleState GetStateForDistance(double) const;
 
-    std::vector<Vector3D> GetTrackPositions() const;
-    std::vector<Vector3D> GetTrackDirections() const;
+    std::vector<Cartesian3D> GetTrackPositions() const;
+    std::vector<Cartesian3D> GetTrackDirections() const;
     std::vector<double> GetTrackEnergies() const;
     std::vector<double> GetTrackTimes() const;
     std::vector<double> GetTrackPropagatedDistances() const;

--- a/include/PROPOSAL/decay/DecayChannel.h
+++ b/include/PROPOSAL/decay/DecayChannel.h
@@ -35,6 +35,7 @@
 namespace PROPOSAL {
 
 class Vector3D;
+class Cartesian3D;
 struct ParticleState;
 class Particle;
 struct ParticleDef;
@@ -118,7 +119,7 @@ public:
     ///
     /// @return
     // ----------------------------------------------------------------------------
-    static Vector3D GenerateRandomDirection();
+    static Cartesian3D GenerateRandomDirection();
 
     // ----------------------------------------------------------------------------
     /// @brief Sets the uniform flag in the ManyBodyPhaseSpace channels

--- a/include/PROPOSAL/density_distr/density_distr.h
+++ b/include/PROPOSAL/density_distr/density_distr.h
@@ -51,7 +51,7 @@ class Axis {
     virtual double GetEffectiveDistance(const Vector3D& xi,
                                         const Vector3D& direction) const = 0;
 
-    Cartesian3D GetFp0() const { return fp0_; };
+    auto GetFp0() const { return fp0_; };
 
    protected:
     Cartesian3D fp0_;
@@ -86,7 +86,7 @@ class CartesianAxis : public Axis {
     bool operator==(const CartesianAxis& axis) const;
     bool operator!=(const CartesianAxis& axis) const;
 
-    Cartesian3D GetAxis() const { return fAxis_; };
+    auto GetAxis() const { return fAxis_; };
     double GetDepth(const Vector3D& xi) const override;
     double GetEffectiveDistance(const Vector3D& xi, const Vector3D& direction) const override;
 

--- a/include/PROPOSAL/density_distr/density_distr.h
+++ b/include/PROPOSAL/density_distr/density_distr.h
@@ -29,7 +29,7 @@
 #include <exception>
 #include <functional>
 #include <string>
-#include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/math/Cartesian3D.h"
 #include "PROPOSAL/json.hpp"
 
 namespace PROPOSAL {
@@ -51,10 +51,10 @@ class Axis {
     virtual double GetEffectiveDistance(const Vector3D& xi,
                                         const Vector3D& direction) const = 0;
 
-    Vector3D GetFp0() const { return fp0_; };
+    Cartesian3D GetFp0() const { return fp0_; };
 
    protected:
-    Vector3D fp0_;
+    Cartesian3D fp0_;
 };
 }  // namespace PROPOSAL
 
@@ -86,12 +86,12 @@ class CartesianAxis : public Axis {
     bool operator==(const CartesianAxis& axis) const;
     bool operator!=(const CartesianAxis& axis) const;
 
-    Vector3D GetAxis() const { return fAxis_; };
+    Cartesian3D GetAxis() const { return fAxis_; };
     double GetDepth(const Vector3D& xi) const override;
     double GetEffectiveDistance(const Vector3D& xi, const Vector3D& direction) const override;
 
    private:
-    Vector3D fAxis_;
+    Cartesian3D fAxis_;
 
 };
 }  // namespace PROPOSAL

--- a/include/PROPOSAL/density_distr/density_polynomial.h
+++ b/include/PROPOSAL/density_distr/density_polynomial.h
@@ -60,6 +60,7 @@ class Density_polynomial : public Density_distr {
                      const Vector3D& direction,
                      double distance) const override;
 
+   protected:
     double Helper_function(const Vector3D& xi,
                            const Vector3D& direction,
                            double res,
@@ -69,7 +70,6 @@ class Density_polynomial : public Density_distr {
                            double res,
                            double l) const;
 
-   protected:
     Polynom polynom_;
     Polynom Polynom_;
 

--- a/include/PROPOSAL/geometry/Box.h
+++ b/include/PROPOSAL/geometry/Box.h
@@ -38,7 +38,7 @@ namespace PROPOSAL {
 class Box : public Geometry
 {
 public:
-    Box(const Vector3D position, double x, double y, double z);
+    Box(const Vector3D& position, double x, double y, double z);
     Box(const nlohmann::json& config);
 
 

--- a/include/PROPOSAL/geometry/Cylinder.h
+++ b/include/PROPOSAL/geometry/Cylinder.h
@@ -36,7 +36,7 @@ namespace PROPOSAL {
 class Cylinder : public Geometry
 {
 public:
-    Cylinder(const Vector3D position, double z, double radius, double inner_radius = 0.);
+    Cylinder(const Vector3D& position, double z, double radius, double inner_radius = 0.);
     Cylinder(const nlohmann::json& config);
 
 

--- a/include/PROPOSAL/geometry/Geometry.h
+++ b/include/PROPOSAL/geometry/Geometry.h
@@ -98,7 +98,7 @@ public:
 
     ParticleLocation::Enum GetLocation(const Vector3D& position, const Vector3D& direction) const;
 
-    Cartesian3D GetPosition() const { return position_; }
+    auto GetPosition() const { return position_; }
 
     std::string GetName() const { return name_; }
 

--- a/include/PROPOSAL/geometry/Geometry.h
+++ b/include/PROPOSAL/geometry/Geometry.h
@@ -31,6 +31,7 @@
 
 #include <map>
 #include <memory>
+#include <PROPOSAL/math/Cartesian3D.h>
 
 #include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/json.hpp"
@@ -45,7 +46,7 @@ public:
     };
 
 public:
-    Geometry(const std::string, const Vector3D position);
+    Geometry(const std::string, const Vector3D& position);
     Geometry(const nlohmann::json&);
 
     virtual ~Geometry(){};
@@ -97,7 +98,7 @@ public:
 
     ParticleLocation::Enum GetLocation(const Vector3D& position, const Vector3D& direction) const;
 
-    Vector3D GetPosition() const { return position_; }
+    Cartesian3D GetPosition() const { return position_; }
 
     std::string GetName() const { return name_; }
 
@@ -112,7 +113,7 @@ protected:
     virtual bool compare(const Geometry&) const = 0;
     virtual void print(std::ostream&) const     = 0;
 
-    Vector3D position_; //!< x,y,z-coordinate of origin ( center of box, cylinder, sphere)
+    Cartesian3D position_; //!< x,y,z-coordinate of origin ( center of box, cylinder, sphere)
 
     std::string name_; //!< "box" , "cylinder" , "sphere" (sphere and cylinder might be hollow)
 

--- a/include/PROPOSAL/geometry/Sphere.h
+++ b/include/PROPOSAL/geometry/Sphere.h
@@ -37,7 +37,7 @@ namespace PROPOSAL {
 class Sphere : public Geometry
 {
 public:
-    Sphere(const Vector3D position, double radius, double inner_radius = 0.);
+    Sphere(const Vector3D& position, double radius, double inner_radius = 0.);
     Sphere(const nlohmann::json& config);
 
     // Methods

--- a/include/PROPOSAL/math/Cartesian3D.h
+++ b/include/PROPOSAL/math/Cartesian3D.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/json.hpp"
+
+namespace PROPOSAL{
+    class Spherical3D;
+    class Cartesian3D : public Vector3D {
+    public:
+        Cartesian3D() : Vector3D() {};
+        Cartesian3D(std::array<double, 3> val) : Vector3D(val) {};
+        Cartesian3D(double x, double y, double z) : Vector3D({x, y, z}) {};
+        Cartesian3D(const Vector3D& vec) : Cartesian3D(vec.GetCartesianCoordinates()) {};
+        Cartesian3D(const nlohmann::json&);
+
+        double GetX() const {return coordinates[0];}
+        double GetY() const {return coordinates[1];}
+        double GetZ() const {return coordinates[2];}
+        void SetX(double x) {coordinates[0] = x;}
+        void SetY(double y) {coordinates[1] = y;}
+        void SetZ(double z) {coordinates[2] = z;}
+
+        friend Cartesian3D operator +(const Cartesian3D&, const Cartesian3D&);
+        friend Cartesian3D operator -(const Cartesian3D&, const Cartesian3D&);
+        friend double operator *(const Cartesian3D&, const Cartesian3D&);
+        friend Cartesian3D operator*(const Cartesian3D&, double);
+        friend Cartesian3D operator*(double, const Cartesian3D&);
+        Cartesian3D operator-() const;
+        Cartesian3D& operator+=(const Cartesian3D&);
+        friend Cartesian3D vector_product(const Cartesian3D&, const Cartesian3D&);
+
+        void deflect(double, double);
+        double magnitude() const override;
+        void normalize() override;
+        std::array<double, 3> GetCartesianCoordinates() const override;
+        std::array<double, 3> GetSphericalCoordinates() const override;
+
+    protected:
+        void print(std::ostream&) const override;
+    };
+
+} // namespace PROPOSAL

--- a/include/PROPOSAL/math/Cartesian3D.h
+++ b/include/PROPOSAL/math/Cartesian3D.h
@@ -6,15 +6,15 @@ namespace PROPOSAL{
     class Spherical3D;
     class Cartesian3D : public Vector3D {
     public:
-        Cartesian3D() : Vector3D() {};
+        Cartesian3D() = default;
         Cartesian3D(std::array<double, 3> val) : Vector3D(val) {};
         Cartesian3D(double x, double y, double z) : Vector3D({x, y, z}) {};
         Cartesian3D(const Vector3D& vec) : Cartesian3D(vec.GetCartesianCoordinates()) {};
         Cartesian3D(const nlohmann::json&);
 
-        double GetX() const {return coordinates[0];}
-        double GetY() const {return coordinates[1];}
-        double GetZ() const {return coordinates[2];}
+        auto GetX() const {return coordinates[0];}
+        auto GetY() const {return coordinates[1];}
+        auto GetZ() const {return coordinates[2];}
         void SetX(double x) {coordinates[0] = x;}
         void SetY(double y) {coordinates[1] = y;}
         void SetZ(double z) {coordinates[2] = z;}

--- a/include/PROPOSAL/math/Spherical3D.h
+++ b/include/PROPOSAL/math/Spherical3D.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/json.hpp"
+namespace PROPOSAL  {
+    class Cartesian3D;
+    class Spherical3D : public Vector3D {
+    public:
+        Spherical3D() : Vector3D() {};
+        Spherical3D(std::array<double, 3> val) : Vector3D(val) {};
+        Spherical3D(double radius, double azimuth, double zenith)
+            : Vector3D({radius, azimuth, zenith}) {};
+        Spherical3D(const Vector3D& vec) : Spherical3D(vec.GetSphericalCoordinates()) {};
+        Spherical3D(const nlohmann::json&);
+
+
+        double GetRadius() const {return coordinates[Radius];}
+        double GetAzimuth() const {return coordinates[Azimuth];}
+        double GetZenith() const {return coordinates[Zenith];}
+        void SetRadius(double radius) {coordinates[Radius] = radius;}
+        void SetAzimuth(double azimuth) {coordinates[Azimuth] = azimuth;}
+        void SetZenith(double zenith) {coordinates[Zenith] = zenith;}
+
+        double magnitude() const override;
+        void normalize() override;
+        std::array<double, 3> GetCartesianCoordinates() const override;
+        std::array<double, 3> GetSphericalCoordinates() const override;
+
+        enum SphericalCoordinate : int {
+            Radius = 0,
+            Azimuth = 1,
+            Zenith = 2,
+        };
+    protected:
+        void print(std::ostream&) const override;
+     };
+} // namespace PROPOSAL

--- a/include/PROPOSAL/math/Spherical3D.h
+++ b/include/PROPOSAL/math/Spherical3D.h
@@ -13,9 +13,9 @@ namespace PROPOSAL  {
         Spherical3D(const nlohmann::json&);
 
 
-        double GetRadius() const {return coordinates[Radius];}
-        double GetAzimuth() const {return coordinates[Azimuth];}
-        double GetZenith() const {return coordinates[Zenith];}
+        auto GetRadius() const {return coordinates[Radius];}
+        auto GetAzimuth() const {return coordinates[Azimuth];}
+        auto GetZenith() const {return coordinates[Zenith];}
         void SetRadius(double radius) {coordinates[Radius] = radius;}
         void SetAzimuth(double azimuth) {coordinates[Azimuth] = azimuth;}
         void SetZenith(double zenith) {coordinates[Zenith] = zenith;}

--- a/include/PROPOSAL/math/Vector3D.h
+++ b/include/PROPOSAL/math/Vector3D.h
@@ -28,7 +28,7 @@
 
 #pragma once
 #include <array>
-
+#include <ostream>
 namespace PROPOSAL {
 class Cartesian3D;
 class Spherical3D;

--- a/include/PROPOSAL/math/Vector3D.h
+++ b/include/PROPOSAL/math/Vector3D.h
@@ -27,115 +27,34 @@
  ******************************************************************************/
 
 #pragma once
-
-#include "PROPOSAL/json.hpp"
-#include <sstream>
+#include <array>
 
 namespace PROPOSAL {
-
+class Cartesian3D;
+class Spherical3D;
 class Vector3D {
 public:
-    // constructors
-    Vector3D();
-    Vector3D(const double x, const double y, const double z);
-    Vector3D(const Vector3D& vector_3d);
-    Vector3D(Vector3D&& other);
-    Vector3D(const nlohmann::json&);
-    ~Vector3D();
+    Vector3D() : coordinates({0, 0, 0}) {};
+    Vector3D(std::array<double, 3> val) : coordinates(val) {};
+    virtual ~Vector3D() = default;
 
-    //-------------------------------------//
-    // operator functions and swap
-    Vector3D& operator=(const Vector3D& vector_3d);
-    Vector3D& operator+=(const Vector3D& vector_3d);
-    bool operator==(const Vector3D& vector_3d) const;
-    bool operator!=(const Vector3D& vector_3d) const;
-    void swap(Vector3D& vector_3d);
-    friend std::ostream& operator<<(
-        std::ostream& os, Vector3D const& vector_3d);
+    virtual bool operator==(const Vector3D&) const;
+    virtual bool operator!=(const Vector3D&) const;
+    double& operator[](size_t idx);
+    const double& operator[](size_t idx) const;
+    friend std::ostream& operator<<(std::ostream&, const Vector3D&);
 
-    //-------------------------------------//
-    // basic arithmetic
-    friend Vector3D operator+(const Vector3D& vec1, const Vector3D& vec2);
-    friend Vector3D operator-(const Vector3D& vec1, const Vector3D& vec2);
-    friend Vector3D operator*(const double factor1, const Vector3D& vec1);
-    friend Vector3D operator*(const Vector3D& vec1, const double factor1);
-    friend double operator*(const Vector3D& vec1, const Vector3D& vec2);
-    friend double scalar_product(const Vector3D& vec1, const Vector3D& vec2);
-    friend Vector3D vector_product(const Vector3D& vec1, const Vector3D& vec2);
-    Vector3D operator-() const;
-    double magnitude() const;
-    void normalise();
+    virtual double magnitude() const = 0;
+    virtual void normalize() = 0;
 
-    void deflect(double, double);
+    void SetCoordinates(std::array<double, 3> val) {coordinates = val;}
+    void SetCoordinates(double, double, double);
+    virtual std::array<double, 3> GetSphericalCoordinates() const = 0;
+    virtual std::array<double, 3> GetCartesianCoordinates() const = 0;
 
-    struct CartesianCoordinates {
-        CartesianCoordinates(){};
-        CartesianCoordinates(double, double, double);
-        CartesianCoordinates(const CartesianCoordinates&);
+protected:
+    std::array<double, 3> coordinates;
+    virtual void print(std::ostream&) const = 0;
 
-        double x_, y_, z_;
-    };
-
-    struct SphericalCoordinates {
-        SphericalCoordinates(){};
-        SphericalCoordinates(double, double, double);
-        SphericalCoordinates(const SphericalCoordinates&);
-
-        double radius_, azimuth_, zenith_;
-    };
-
-    //-------------------------------------//
-    // conversions to spherical and cylindrical coordinate
-    void CalculateCartesianFromSpherical();
-    void CalculateSphericalCoordinates();
-    // void CalculateCartesianFromCylindrical();
-    // void CalculateCylindricalCoordinates();
-
-    //-------------------------------------//
-    // setter
-    void SetCartesianCoordinates(const double x, const double y, const double z)
-    {
-        cartesian_.x_ = x;
-        cartesian_.y_ = y;
-        cartesian_.z_ = z;
-    }
-    void SetSphericalCoordinates(
-        const double radius, const double azimuth, const double zenith)
-    {
-        spherical_.radius_ = radius;
-        spherical_.azimuth_ = azimuth;
-        spherical_.zenith_ = zenith;
-    }
-    // void SetCylindricalCoordinates(const double radius, const double azimuth,
-    // const double height)
-    // {
-    //     cylindric_radius_  = radius;
-    //     cylindric_azimuth_ = azimuth;
-    //     cylindric_height_  = height;
-    // }
-
-    //-------------------------------------//
-    // getter
-    double GetX() const { return cartesian_.x_; }
-    double GetY() const { return cartesian_.y_; }
-    double GetZ() const { return cartesian_.z_; }
-    double GetRadius() const { return spherical_.radius_; }
-    double GetPhi() const { return spherical_.azimuth_; }
-    double GetTheta() const { return spherical_.zenith_; }
-    Vector3D::CartesianCoordinates GetCartesianCoordinates() const
-    {
-        return cartesian_;
-    }
-    Vector3D::SphericalCoordinates GetSphericalCoordinates() const
-    {
-        return spherical_;
-    }
-
-    //----------------------------------------------//
-private:
-    CartesianCoordinates cartesian_;
-    SphericalCoordinates spherical_;
-
-    // double cylindric_radius_, cylindric_azimuth_, cylindric_height_;
 };
 } // namespace PROPOSAL

--- a/include/PROPOSAL/particle/Particle.h
+++ b/include/PROPOSAL/particle/Particle.h
@@ -32,7 +32,6 @@
 #include <memory>
 #include <string>
 
-#include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/math/Cartesian3D.h"
 #include "PROPOSAL/particle/ParticleDef.h"
 

--- a/include/PROPOSAL/particle/Particle.h
+++ b/include/PROPOSAL/particle/Particle.h
@@ -113,9 +113,11 @@ private:
 };
 
 struct Loss {
-    Loss(int type, double loss_energy) : type(type), loss_energy(loss_energy){};
+    Loss(int type, double energy, double parent_particle_energy)
+        : type(type), energy(energy), parent_particle_energy(parent_particle_energy) {};
     int type;
-    double loss_energy;
+    double energy;
+    double parent_particle_energy;
 };
 
 struct StochasticLoss : public Loss {
@@ -124,15 +126,16 @@ struct StochasticLoss : public Loss {
     Cartesian3D direction;
     double time;
     double propagated_distance;
-    double parent_particle_energy;
 };
 
 struct ContinuousLoss : public Loss {
-    ContinuousLoss(std::pair<double, double>, std::pair<const Vector3D&, const Vector3D&>,
-            std::pair<const Vector3D&, const Vector3D&>, std::pair<double, double>);
-    std::pair<double, double> energies;
-    std::pair<Cartesian3D, Cartesian3D> positions;
-    std::pair<Cartesian3D, Cartesian3D> directions;
-    std::pair<double, double> times;
+    ContinuousLoss(double, double, const Vector3D&, double, const Vector3D&,
+            const Vector3D&, double, double);
+    Cartesian3D start_position;
+    double length;
+    Cartesian3D direction_initial;
+    Cartesian3D direction_final;
+    double time_initial;
+    double time_final;
 };
 } // namespace PROPOSAL

--- a/include/PROPOSAL/particle/Particle.h
+++ b/include/PROPOSAL/particle/Particle.h
@@ -33,6 +33,7 @@
 #include <string>
 
 #include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/math/Cartesian3D.h"
 #include "PROPOSAL/particle/ParticleDef.h"
 
 namespace PROPOSAL {
@@ -96,8 +97,8 @@ public:
     friend std::ostream& operator<<(std::ostream&, ParticleState const&);
 
     int type;
-    Vector3D position;  //!< position coordinates [cm]
-    Vector3D direction; //!< direction vector, angles in [rad]
+    Cartesian3D position;  //!< position coordinates [cm]
+    Cartesian3D direction; //!< direction vector, angles in [rad]
     double energy;                 //!< energy [MeV]
     double time;                   //!< age [sec]
     double propagated_distance;    //!< propagation distance [cm]
@@ -119,20 +120,20 @@ struct Loss {
 };
 
 struct StochasticLoss : public Loss {
-    StochasticLoss(int, double, Vector3D, Vector3D, double, double, double);
-    Vector3D position;
-    Vector3D direction;
+    StochasticLoss(int, double, const Vector3D&, const Vector3D&, double, double, double);
+    Cartesian3D position;
+    Cartesian3D direction;
     double time;
     double propagated_distance;
     double parent_particle_energy;
 };
 
 struct ContinuousLoss : public Loss {
-    ContinuousLoss(std::pair<double, double>, std::pair<Vector3D, Vector3D>,
-            std::pair<Vector3D, Vector3D>, std::pair<double, double>);
+    ContinuousLoss(std::pair<double, double>, std::pair<const Vector3D&, const Vector3D&>,
+            std::pair<const Vector3D&, const Vector3D&>, std::pair<double, double>);
     std::pair<double, double> energies;
-    std::pair<Vector3D, Vector3D> positions;
-    std::pair<Vector3D, Vector3D> directions;
+    std::pair<Cartesian3D, Cartesian3D> positions;
+    std::pair<Cartesian3D, Cartesian3D> directions;
     std::pair<double, double> times;
 };
 } // namespace PROPOSAL

--- a/include/PROPOSAL/propagation_utility/PropagationUtility.h
+++ b/include/PROPOSAL/propagation_utility/PropagationUtility.h
@@ -40,7 +40,7 @@
 #include "PROPOSAL/scattering/Scattering.h"
 
 namespace PROPOSAL {
-
+class Cartesian3D;
 class PropagationUtility {
 public:
     struct Collection {
@@ -75,10 +75,10 @@ public:
     // there could be a possible access with the position of the object stored
     // in an enum.
 
-    std::tuple<Vector3D, Vector3D> DirectionsScatter(
+    std::tuple<Cartesian3D, Cartesian3D> DirectionsScatter(
         double, double, double, const Vector3D&, std::function<double()>);
-    Vector3D DirectionDeflect(InteractionType, double, double, Vector3D,
-        std::function<double()>) const;
+    Cartesian3D DirectionDeflect(InteractionType, double, double,
+                                 const Vector3D&, std::function<double()>) const;
 
     Collection collection;
 };

--- a/include/PROPOSAL/secondaries/parametrization/annihilation/Annihilation.h
+++ b/include/PROPOSAL/secondaries/parametrization/annihilation/Annihilation.h
@@ -11,8 +11,8 @@ namespace secondaries {
         virtual ~Annihilation() = default;
 
         virtual double CalculateRho(double, double, const Component&) = 0;
-        virtual std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double)
+        virtual std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double)
             = 0;
         virtual std::tuple<double, double> CalculateEnergy(double, double) = 0;
 

--- a/include/PROPOSAL/secondaries/parametrization/annihilation/SingleDifferentialAnnihilation.h
+++ b/include/PROPOSAL/secondaries/parametrization/annihilation/SingleDifferentialAnnihilation.h
@@ -28,8 +28,8 @@ namespace secondaries {
         }
 
         double CalculateRho(double, double, const Component&) final;
-        std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double) final;
+        std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double) final;
         std::tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept { return n_rnd; }

--- a/include/PROPOSAL/secondaries/parametrization/compton/Compton.h
+++ b/include/PROPOSAL/secondaries/parametrization/compton/Compton.h
@@ -15,8 +15,8 @@ namespace secondaries {
         InteractionType GetInteractionType() const noexcept { return type; };
 
         virtual double CalculateRho(double, double) = 0;
-        virtual std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double)
+        virtual std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double)
             = 0;
         virtual std::tuple<double, double> CalculateEnergy(double, double) = 0;
     };

--- a/include/PROPOSAL/secondaries/parametrization/compton/NaivCompton.h
+++ b/include/PROPOSAL/secondaries/parametrization/compton/NaivCompton.h
@@ -15,8 +15,8 @@ namespace secondaries {
 
         double CalculateRho(double, double) final;
         enum { GAMMA, EMINUS };
-        std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double) final;
+        std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double) final;
         std::tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept { return n_rnd; }

--- a/include/PROPOSAL/secondaries/parametrization/epairproduction/KelnerKokoulinPetrukhinEpairProduction.h
+++ b/include/PROPOSAL/secondaries/parametrization/epairproduction/KelnerKokoulinPetrukhinEpairProduction.h
@@ -19,8 +19,8 @@ namespace PROPOSAL {
             static constexpr int n_rnd = 3;
 
             double CalculateRho(double, double, const Component&, double, double);
-            std::tuple<Vector3D, Vector3D> CalculateDirections(
-                    Vector3D, double, double, double);
+            std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+                    const Vector3D&, double, double, double);
             std::tuple<double, double> CalculateEnergy(double, double);
 
         public:

--- a/include/PROPOSAL/secondaries/parametrization/ionization/Ionization.h
+++ b/include/PROPOSAL/secondaries/parametrization/ionization/Ionization.h
@@ -12,8 +12,8 @@ namespace secondaries {
         static constexpr InteractionType type = PROPOSAL::InteractionType::Ioniz;
         InteractionType GetInteractionType() const noexcept { return type; };
 
-        virtual std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double)
+        virtual std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double)
             = 0;
         virtual std::tuple<double, double> CalculateEnergy(double, double) = 0;
     };

--- a/include/PROPOSAL/secondaries/parametrization/ionization/NaivIonization.h
+++ b/include/PROPOSAL/secondaries/parametrization/ionization/NaivIonization.h
@@ -17,8 +17,8 @@ namespace secondaries {
         NaivIonization(const ParticleDef& p, const Medium&) :
             primary_particle_type(p.particle_type) {}
 
-        std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double) final;
+        std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double) final;
         std::tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }

--- a/include/PROPOSAL/secondaries/parametrization/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.h
+++ b/include/PROPOSAL/secondaries/parametrization/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.h
@@ -27,8 +27,8 @@ namespace secondaries {
         }
 
         double CalculateRho(double, double, const Component&, double, double) final;
-        std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double) final;
+        std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double) final;
         std::tuple<double, double> CalculateEnergy(double, double) final;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }

--- a/include/PROPOSAL/secondaries/parametrization/mupairproduction/MupairProduction.h
+++ b/include/PROPOSAL/secondaries/parametrization/mupairproduction/MupairProduction.h
@@ -13,8 +13,8 @@ namespace secondaries {
 
         virtual double CalculateRho(double, double, const Component&, double,
                                     double) = 0;
-        virtual std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, double)
+        virtual std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, double)
             = 0;
         virtual std::tuple<double, double> CalculateEnergy(double, double) = 0;
     };

--- a/include/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoTsai.h
+++ b/include/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoTsai.h
@@ -32,8 +32,9 @@ namespace secondaries {
         }
 
         double CalculateRho(double, double, const Component&) override;
-        std::tuple<Vector3D, Vector3D> CalculateDirections(Vector3D, double, double,
-            const Component&, std::vector<double>) override;
+        std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+                const Vector3D&, double, double, const Component&,
+                std::vector<double>) override;
         std::tuple<double, double> CalculateEnergy(double, double, double) override;
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }

--- a/include/PROPOSAL/secondaries/parametrization/photopairproduction/PhotopairProduction.h
+++ b/include/PROPOSAL/secondaries/parametrization/photopairproduction/PhotopairProduction.h
@@ -17,8 +17,8 @@ namespace secondaries {
         InteractionType GetInteractionType() const noexcept { return type; };
 
         virtual double CalculateRho(double, double, const Component&) = 0;
-        virtual std::tuple<Vector3D, Vector3D> CalculateDirections(
-            Vector3D, double, double, const Component&, std::vector<double>)
+        virtual std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+            const Vector3D&, double, double, const Component&, std::vector<double>)
             = 0;
         virtual std::tuple<double, double> CalculateEnergy(double, double, double)
             = 0;

--- a/interface/python/density_distribution.cxx
+++ b/interface/python/density_distribution.cxx
@@ -140,9 +140,9 @@ void init_density_distribution(py::module& m) {
             )pbdoc");
 
     py::class_<CartesianAxis, Axis, std::shared_ptr<CartesianAxis>>(m_sub, "cartesian_axis")
-        .def(py::init<Vector3D, Vector3D>(), py::arg("axis"),
+        .def(py::init<const Vector3D&, const Vector3D&>(), py::arg("axis"),
              py::arg("reference_point"));
 
     py::class_<RadialAxis, Axis, std::shared_ptr<RadialAxis>>(m_sub, "radial_axis")
-            .def(py::init<Vector3D>(), py::arg("reference_point"));
+            .def(py::init<const Vector3D&>(), py::arg("reference_point"));
 }

--- a/interface/python/geometry.cxx
+++ b/interface/python/geometry.cxx
@@ -1,5 +1,4 @@
 
-#include "PROPOSAL/geometry/GeometryFactory.h"
 #include "PROPOSAL/geometry/Box.h"
 #include "PROPOSAL/geometry/Cylinder.h"
 #include "PROPOSAL/geometry/Sphere.h"
@@ -106,7 +105,7 @@ void init_geometry(py::module& m) {
         )pbdoc");
 
     py::class_<Sphere, std::shared_ptr<Sphere>, Geometry>(m_sub, "Sphere")
-        .def(py::init<Vector3D, double, double>(), py::arg("position"),
+        .def(py::init<const Vector3D&, double, double>(), py::arg("position"),
              py::arg("radius"), py::arg("inner_radius") = 0.)
         .def(py::init<const Sphere&>())
         .def_property("inner_radius", &Sphere::GetInnerRadius,
@@ -120,7 +119,7 @@ void init_geometry(py::module& m) {
             )pbdoc");
 
     py::class_<Box, std::shared_ptr<Box>, Geometry>(m_sub, "Box")
-        .def(py::init<Vector3D, double, double, double>())
+        .def(py::init<const Vector3D&, double, double, double>())
         .def(py::init<const Box&>())
         .def_property("length", &Box::GetX, &Box::SetX,
                       R"pbdoc(
@@ -143,7 +142,7 @@ void init_geometry(py::module& m) {
                 cylinder without a bore is equal to a bore radius
                 equal to zero.
             )pbdoc")
-        .def(py::init<Vector3D, double, double, double>())
+        .def(py::init<const Vector3D&, double, double, double>())
         .def(py::init<const Cylinder&>())
         .def_property("inner_radius", &Cylinder::GetInnerRadius,
                       &Cylinder::SetInnerRadius,

--- a/interface/python/particle.cxx
+++ b/interface/python/particle.cxx
@@ -3,6 +3,7 @@
 #include "PROPOSAL/particle/Particle.h"
 #include "PROPOSAL/particle/ParticleDef.h"
 #include "PROPOSAL/Secondaries.h"
+#include "PROPOSAL/geometry/Geometry.h"
 #include "pyBindings.h"
 
 #define PARTICLE_DEF(module, cls)                                                    \
@@ -275,7 +276,7 @@ void init_particle(py::module& m) {
             .def_readwrite("parent_particle_energy", &StochasticLoss::parent_particle_energy);
 
     py::class_<ContinuousLoss, Loss, std::shared_ptr<ContinuousLoss>>(m_sub, "ContinuousLoss")
-            .def(py::init<const std::pair<double, double>&, const std::pair<Vector3D, Vector3D>&, const std::pair<Vector3D, Vector3D>&, const std::pair<double, double>&>(),
+            .def(py::init<const std::pair<double, double>&, const std::pair<const Vector3D&, const Vector3D&>&, const std::pair<const Vector3D&, const Vector3D&>&, const std::pair<double, double>&>(),
                     py::arg("energies"), py::arg("positions"), py::arg("directions"), py::arg("times"))
             .def_readwrite("energies", &ContinuousLoss::energies)
             .def_readwrite("positions", &ContinuousLoss::positions)

--- a/interface/python/particle.cxx
+++ b/interface/python/particle.cxx
@@ -258,10 +258,11 @@ void init_particle(py::module& m) {
                 type and energy. More specific information are stored in the
                 derived classes.
             )pbdoc")
-            .def(py::init<const int&, const double&>(),
-                    py::arg("type"), py::arg("loss_energy"))
-            .def_readwrite("type", &Loss::type)
-            .def_readwrite("loss_energy", &Loss::loss_energy);
+            .def(py::init<const int&, const double&, const double&>(),
+                    py::arg("type"), py::arg("energy"), py::arg("parent_particle_energy"))
+            .def_readwrite("type", &Loss::type, R"pbdoc(Type of energy loss.)pbdoc")
+            .def_readwrite("energy", &Loss::energy, R"pbdoc(Total energy loss in MeV.)pbdoc")
+            .def_readwrite("parent_particle_energy", &Loss::parent_particle_energy, R"pbdoc(Particle energy in MeV at the time of the stochastic loss or at the beginning of the continuous loss.)pbdoc");
 
     py::class_<StochasticLoss, Loss, std::shared_ptr<StochasticLoss>>(m_sub, "StochasticLoss")
             .def(py::init<const int&, const double&, const Vector3D&, const Vector3D&, const double&, const double&, const double &>(),
@@ -269,19 +270,19 @@ void init_particle(py::module& m) {
                  py::arg("direction"), py::arg("time"),
                  py::arg("propagated_distance"),
                  py::arg("parent_particle_energy"))
-            .def_readwrite("position", &StochasticLoss::position)
-            .def_readwrite("direction", &StochasticLoss::direction)
-            .def_readwrite("time", &StochasticLoss::time)
-            .def_readwrite("propagated_distance", &StochasticLoss::propagated_distance)
-            .def_readwrite("parent_particle_energy", &StochasticLoss::parent_particle_energy);
+            .def_readwrite("position", &StochasticLoss::position, R"pbdoc(Position of stochastic interaction.)pbdoc")
+            .def_readwrite("direction", &StochasticLoss::direction, R"pbdoc(Direction of stochastic loss.)pbdoc")
+            .def_readwrite("time", &StochasticLoss::time, R"pbdoc(Time when stochastic loss occured.)pbdoc")
+            .def_readwrite("propagated_distance", &StochasticLoss::propagated_distance, R"pbdoc(Distance (in cm) the parent particle has propagated when the stochastic loss occured.)pbdoc");
 
     py::class_<ContinuousLoss, Loss, std::shared_ptr<ContinuousLoss>>(m_sub, "ContinuousLoss")
-            .def(py::init<const std::pair<double, double>&, const std::pair<const Vector3D&, const Vector3D&>&, const std::pair<const Vector3D&, const Vector3D&>&, const std::pair<double, double>&>(),
-                    py::arg("energies"), py::arg("positions"), py::arg("directions"), py::arg("times"))
-            .def_readwrite("energies", &ContinuousLoss::energies)
-            .def_readwrite("positions", &ContinuousLoss::positions)
-            .def_readwrite("directions", &ContinuousLoss::directions)
-            .def_readwrite("times", &ContinuousLoss::times);
+            .def(py::init<const double&, const double&, const Vector3D&, const double&, const Vector3D&, const Vector3D&, const double&, const double&>())
+            .def_readwrite("length", &ContinuousLoss::length, R"pbdoc(Length of continuous loss in cm.)pbdoc")
+            .def_readwrite("start_position", &ContinuousLoss::start_position, R"pbdoc(Position where the continuous energy loss started.)pbdoc")
+            .def_readwrite("direction_initial", &ContinuousLoss::direction_initial, R"pbdoc(Direction of the particle at the beginning of the continuous energy loss.)pbdoc")
+            .def_readwrite("direction_final", &ContinuousLoss::direction_final, R"pbdoc(Direction of the particle at the end of the continuous energy loss.)pbdoc")
+            .def_readwrite("time_initial", &ContinuousLoss::time_initial, R"pbdoc(Time when the continuous energy loss started.)pbdoc")
+            .def_readwrite("time_final", &ContinuousLoss::time_final, R"pbdoc(Time when the continuous energy loss ended.)pbdoc");
 
     py::class_<Secondaries, std::shared_ptr<Secondaries>>(m_sub, "Secondaries", R"pbdoc(Output of Propagator.)pbdoc")
             .def("ELost", &Secondaries::GetELost)

--- a/interface/python/pybindings.cxx
+++ b/interface/python/pybindings.cxx
@@ -1,5 +1,6 @@
 
 #include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/math/Spherical3D.h"
 #include "PROPOSAL/version.h"
 #include "PROPOSAL/crosssection/CrossSection.h"
 #include "PROPOSAL/propagation_utility/Interaction.h"
@@ -52,31 +53,42 @@ PYBIND11_MODULE(proposal, m)
     m.attr("__version__") = &PROPOSAL_VERSION;
 
     py::class_<Vector3D, std::shared_ptr<Vector3D>>(m, "Vector3D")
-        .def(py::init<>())
-        .def(py::init<double, double, double>(), py::arg("x"), py::arg("y"),
-                py::arg("z"))
-        .def(py::init<const Vector3D&>())
         .def("__str__", &py_print<Vector3D>)
+        .def("normalize", &Vector3D::normalize)
+        .def("__getitem__", [](Vector3D& v, size_t index) { return v[index];})
+        .def("__setitem__", [](Vector3D& v, size_t index, const double val) { v[index] = val;})
+        .def("__iter__", [](Vector3D& v) {return py::make_iterator(&v[0], &v[2]+1);}, py::keep_alive<0, 1>())
+        .def("set_coordinates", py::overload_cast<std::array<double, 3>>(&Vector3D::SetCoordinates))
+        .def("set_coordinates", py::overload_cast<double, double, double>(&Vector3D::SetCoordinates))
+        .def_property_readonly("magnitude", &Vector3D::magnitude)
+        .def_property_readonly("spherical_coordinates", &Vector3D::GetSphericalCoordinates)
+        .def_property_readonly("cartesian_coordinates", &Vector3D::GetCartesianCoordinates);
+
+    py::class_<Cartesian3D, std::shared_ptr<Cartesian3D>, Vector3D>(m, "Cartesian3D")
+        .def(py::init<>())
+        .def(py::init<double, double, double>(), py::arg("x"), py::arg("y"), py::arg("z"))
+        .def(py::init<std::array<double, 3>>(), py::arg("cartesian coordinates"))
+        .def(py::init<const Vector3D&>())
+        .def_property("x", &Cartesian3D::GetX, &Cartesian3D::SetX)
+        .def_property("y", &Cartesian3D::GetY, &Cartesian3D::SetY)
+        .def_property("z", &Cartesian3D::GetZ, &Cartesian3D::SetZ)
         .def(py::self + py::self)
+        .def(py::self += py::self)
         .def(py::self - py::self)
         .def(py::self * float())
         .def(float() * py::self)
         .def(py::self * py::self)
         .def(-py::self)
-        .def_property_readonly("x", &Vector3D::GetX)
-        .def_property_readonly("y", &Vector3D::GetY)
-        .def_property_readonly("z", &Vector3D::GetZ)
-        .def_property_readonly("radius", &Vector3D::GetRadius)
-        .def_property_readonly("phi", &Vector3D::GetPhi)
-        .def_property_readonly("theta", &Vector3D::GetTheta)
-        .def("set_cartesian_coordinates", &Vector3D::SetCartesianCoordinates)
-        .def("set_spherical_coordinates", &Vector3D::SetSphericalCoordinates)
-        .def("normalize", &Vector3D::normalise)
-        .def("magnitude", &Vector3D::magnitude)
-        .def("cartesian_from_spherical",
-                &Vector3D::CalculateCartesianFromSpherical)
-        .def("spherical_from_cartesian",
-                &Vector3D::CalculateSphericalCoordinates);
+        .def("deflect", &Cartesian3D::deflect);
+
+    py::class_<Spherical3D, std::shared_ptr<Spherical3D>, Vector3D>(m, "Spherical3D")
+        .def(py::init<>())
+        .def(py::init<double, double, double>(), py::arg("radius"), py::arg("azimuth"), py::arg("zenith"))
+        .def(py::init<std::array<double, 3>>(), py::arg("spherical coordinates"))
+        .def(py::init<const Vector3D&>())
+        .def_property("radius", &Spherical3D::GetRadius, &Spherical3D::SetRadius)
+        .def_property("azimuth", &Spherical3D::GetAzimuth, &Spherical3D::SetAzimuth)
+        .def_property("zenith", &Spherical3D::GetZenith, &Spherical3D::SetZenith);
 
     py::class_<EnergyCutSettings, std::shared_ptr<EnergyCutSettings>>(m,
             "EnergyCutSettings",

--- a/interface/python/pybindings.cxx
+++ b/interface/python/pybindings.cxx
@@ -1,5 +1,4 @@
 
-#include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/math/Spherical3D.h"
 #include "PROPOSAL/version.h"
 #include "PROPOSAL/crosssection/CrossSection.h"

--- a/src/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/Propagator.cxx
@@ -117,10 +117,10 @@ InteractionType Propagator::DoStochasticInteraction(ParticleState& p_cond,
     std::tie(loss_type, comp, loss_energy)
         = utility.EnergyStochasticloss(p_cond.energy, rnd());
 
-    auto stochastic_loss = StochasticLoss((int)loss_type, loss_energy,
+    /*auto stochastic_loss = StochasticLoss((int)loss_type, loss_energy,
                                           p_cond.position, p_cond.direction,
                                           p_cond.time, p_cond.propagated_distance,
-                                          p_cond.energy);
+                                          p_cond.energy);*/
     p_cond.direction = utility.DirectionDeflect(loss_type, p_cond.energy,
                                                 p_cond.energy - loss_energy,
                                                 p_cond.direction, rnd);
@@ -143,7 +143,7 @@ int Propagator::AdvanceParticle(ParticleState& state, double E_f,
     auto max_distance_left = max_distance - state.propagated_distance;
     assert(max_distance_left > 0);
 
-    Vector3D mean_direction, new_direction;
+    Cartesian3D mean_direction, new_direction;
     std::tie(mean_direction, new_direction) = utility.DirectionsScatter(
             grammage_next_interaction, state.energy, E_f, state.direction,
         rnd);
@@ -256,7 +256,9 @@ Sector Propagator::GetCurrentSector(
 
     if (potential_sec.empty())
         Logging::Get("proposal.propagator")->critical("No sector defined at particle position {}, {}, {}.",
-                                                      position.GetY(), position.GetY(), position.GetZ());
+                                                      position.GetSphericalCoordinates().at(0),
+                                                      position.GetSphericalCoordinates().at(1),
+                                                      position.GetSphericalCoordinates().at(2));
 
     auto highest_sector_iter = std::max_element(
         potential_sec.begin(), potential_sec.end(), [](Sector* a, Sector* b) {

--- a/src/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/Propagator.cxx
@@ -250,11 +250,14 @@ Sector Propagator::GetCurrentSector(
             potential_sec.push_back(&sector);
     }
 
-    if (potential_sec.empty())
+    if (potential_sec.empty()) {
+        auto spherical_position = Cartesian3D(position);
         Logging::Get("proposal.propagator")->critical("No sector defined at particle position {}, {}, {}.",
-                                                      position.GetSphericalCoordinates().at(0),
-                                                      position.GetSphericalCoordinates().at(1),
-                                                      position.GetSphericalCoordinates().at(2));
+                                                      spherical_position.GetX(),
+                                                      spherical_position.GetY(),
+                                                      spherical_position.GetZ());
+    }
+
 
     auto highest_sector_iter = std::max_element(
         potential_sec.begin(), potential_sec.end(), [](Sector* a, Sector* b) {

--- a/src/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/Propagator.cxx
@@ -117,10 +117,6 @@ InteractionType Propagator::DoStochasticInteraction(ParticleState& p_cond,
     std::tie(loss_type, comp, loss_energy)
         = utility.EnergyStochasticloss(p_cond.energy, rnd());
 
-    /*auto stochastic_loss = StochasticLoss((int)loss_type, loss_energy,
-                                          p_cond.position, p_cond.direction,
-                                          p_cond.time, p_cond.propagated_distance,
-                                          p_cond.energy);*/
     p_cond.direction = utility.DirectionDeflect(loss_type, p_cond.energy,
                                                 p_cond.energy - loss_energy,
                                                 p_cond.direction, rnd);

--- a/src/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/Secondaries.cxx
@@ -5,6 +5,7 @@
 #include "PROPOSAL/math/RandomGenerator.h"
 #include "PROPOSAL/Propagator.h"
 #include "PROPOSAL/Logging.h"
+#include "PROPOSAL/math/Cartesian3D.h"
 
 #include <memory>
 #include <vector>
@@ -109,17 +110,17 @@ ParticleState Secondaries::GetStateForDistance(double propagated_distance) const
     return track_.back();
 }
 
-std::vector<Vector3D> Secondaries::GetTrackPositions() const
+std::vector<Cartesian3D> Secondaries::GetTrackPositions() const
 {
-    std::vector<Vector3D> vec;
+    std::vector<Cartesian3D> vec;
     for (auto i : track_)
         vec.emplace_back(i.position);
     return vec;
 }
 
-std::vector<Vector3D> Secondaries::GetTrackDirections() const
+std::vector<Cartesian3D> Secondaries::GetTrackDirections() const
 {
-    std::vector<Vector3D> vec;
+    std::vector<Cartesian3D> vec;
     for (auto i : track_)
         vec.emplace_back(i.direction);
     return vec;

--- a/src/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/Secondaries.cxx
@@ -395,12 +395,11 @@ std::vector<ContinuousLoss> Secondaries::GetContinuousLosses() const
     std::vector<ContinuousLoss> losses;
     for (unsigned int i=1; i<track_.size(); i++) {
         if (types_[i] == InteractionType::ContinuousEnergyLoss) {
-            losses.emplace_back(
-                    std::make_pair(track_[i-1].energy, track_[i].energy),
-                    std::make_pair(track_[i-1].position, track_[i].position),
-                    std::make_pair(track_[i-1].direction, track_[i].direction),
-                    std::make_pair(track_[i-1].time, track_[i].time)
-                    );
+            losses.emplace_back( track_[i].energy - track_[i-1].energy,
+                                 track_[i-1].energy, track_[i-1].position,
+                                 (track_[i].position - track_[i-1].position).magnitude(),
+                                 track_[i-1].direction, track_[i].direction,
+                                 track_[i-1].time, track_[i].time);
         }
     }
     return losses;
@@ -417,11 +416,11 @@ std::vector<ContinuousLoss> Secondaries::GetContinuousLosses(const Geometry& geo
         if (geometry.IsInside(track_[i].position, track_[i].direction)) {
             if (types_[i] == InteractionType::ContinuousEnergyLoss) {
                 losses.emplace_back(
-                        std::make_pair(track_[i-1].energy, track_[i].energy),
-                        std::make_pair(track_[i-1].position, track_[i].position),
-                        std::make_pair(track_[i-1].direction, track_[i].direction),
-                        std::make_pair(track_[i-1].time, track_[i].time)
-                        );
+                        track_[i].energy - track_[i-1].energy,
+                        track_[i-1].energy, track_[i-1].position,
+                        (track_[i].position - track_[i-1].position).magnitude(),
+                        track_[i-1].direction, track_[i].direction,
+                        track_[i-1].time, track_[i].time);
             }
         }
     }

--- a/src/PROPOSAL/decay/DecayChannel.cxx
+++ b/src/PROPOSAL/decay/DecayChannel.cxx
@@ -1,5 +1,7 @@
 
 #include <cmath>
+#include <string>
+#include <sstream>
 #include <iostream>
 
 #include "PROPOSAL/decay/DecayChannel.h"
@@ -51,21 +53,20 @@ std::ostream& operator<<(std::ostream& os, DecayChannel const& channel)
 // ------------------------------------------------------------------------- //
 void DecayChannel::Boost(ParticleState& particle, const Vector3D& direction_unnormalized, double gamma, double betagamma)
 {
-    Vector3D direction = direction_unnormalized;
-    direction.normalise();
+    Cartesian3D direction = direction_unnormalized;
+    direction.normalize();
 
-    Vector3D momentum_vec(particle.GetMomentum() * particle.direction);
+    Cartesian3D momentum_vec(particle.GetMomentum() * particle.direction);
 
     double direction_correction =
-        (gamma - 1.0) * scalar_product(momentum_vec, direction) - betagamma * particle.energy;
+        (gamma - 1.0) * (momentum_vec * direction) - betagamma * particle.energy;
 
     momentum_vec = momentum_vec + direction_correction * direction;
 
     // Energy will be implicit corrected with respect to the mass:
     particle.SetMomentum(momentum_vec.magnitude());
 
-    momentum_vec.normalise();
-    momentum_vec.CalculateSphericalCoordinates();
+    momentum_vec.normalize();
     particle.direction = momentum_vec;
 }
 
@@ -105,14 +106,12 @@ double DecayChannel::Momentum(double m1, double m2, double m3)
 }
 
 // ------------------------------------------------------------------------- //
-Vector3D DecayChannel::GenerateRandomDirection()
+Cartesian3D DecayChannel::GenerateRandomDirection()
 {
     double phi       = 2.0 * PI * RandomGenerator::Get().RandomDouble();
     double cos_theta = 2.0 * RandomGenerator::Get().RandomDouble() - 1.0;
     double sin_theta = std::sqrt((1.0 - cos_theta) * (1.0 + cos_theta));
-    Vector3D direction = Vector3D(sin_theta * std::cos(phi), sin_theta * std::sin(phi), cos_theta);
-    direction.CalculateSphericalCoordinates();
-    // direction.SetSphericalCoordinates(1.0, phi, std::acos(cos_theta));
+    Cartesian3D direction(sin_theta * std::cos(phi), sin_theta * std::sin(phi), cos_theta);
     return direction;
 }
 

--- a/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
+++ b/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
@@ -127,7 +127,7 @@ std::vector<ParticleState> LeptonicDecayChannelApprox::Decay(const ParticleDef& 
     double momentum_neutrinos = 0.5 * virtual_mass;
 
 
-    Cartesian3D direction = GenerateRandomDirection();
+    auto direction = GenerateRandomDirection();
 
     ParticleState neutrino((ParticleType)neutrino_.particle_type,
                            p_condition.position,

--- a/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
+++ b/src/PROPOSAL/decay/LeptonicDecayChannel.cxx
@@ -127,8 +127,7 @@ std::vector<ParticleState> LeptonicDecayChannelApprox::Decay(const ParticleDef& 
     double momentum_neutrinos = 0.5 * virtual_mass;
 
 
-    Vector3D direction = GenerateRandomDirection();
-    direction.CalculateSphericalCoordinates();
+    Cartesian3D direction = GenerateRandomDirection();
 
     ParticleState neutrino((ParticleType)neutrino_.particle_type,
                            p_condition.position,
@@ -137,8 +136,7 @@ std::vector<ParticleState> LeptonicDecayChannelApprox::Decay(const ParticleDef& 
                            p_condition.time,
                            0.);
 
-    Vector3D opposite_direction = -direction;
-    opposite_direction.CalculateSphericalCoordinates();
+    Cartesian3D opposite_direction = -direction;
 
     ParticleState anti_neutrino((ParticleType)anti_neutrino_.particle_type,
                                 p_condition.position,

--- a/src/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
@@ -148,13 +148,12 @@ std::vector<ParticleState> ManyBodyPhaseSpace::Decay(const ParticleDef& p_def, c
 void ManyBodyPhaseSpace::GenerateEvent(std::vector<ParticleState>& products, const PhaseSpaceKinematics& kinematics)
 {
     // Calculate first momentum in R2
-    Vector3D direction = GenerateRandomDirection();
+    Cartesian3D direction = GenerateRandomDirection();
 
     products[1].direction = direction;
     products[1].SetMomentum(kinematics.momenta[0]);
 
-    Vector3D opposite_direction = -direction;
-    opposite_direction.CalculateSphericalCoordinates();
+    Cartesian3D opposite_direction = -direction;
     products[0].direction = opposite_direction;
     products[0].SetMomentum(kinematics.momenta[0]);
 

--- a/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
@@ -45,7 +45,7 @@ std::vector<ParticleState> TwoBodyPhaseSpace::Decay(const ParticleDef& p_def, co
     products.emplace_back((ParticleType)second_daughter_.particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
 
     double momentum    = Momentum(p_def.mass, first_daughter_.mass, second_daughter_.mass);
-    Cartesian3D direction = GenerateRandomDirection();
+    auto direction = GenerateRandomDirection();
 
     products[0].direction = direction;
     products[0].SetMomentum(momentum);

--- a/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
@@ -45,13 +45,12 @@ std::vector<ParticleState> TwoBodyPhaseSpace::Decay(const ParticleDef& p_def, co
     products.emplace_back((ParticleType)second_daughter_.particle_type, p_condition.position, p_condition.direction, p_condition.energy, p_condition.time, 0);
 
     double momentum    = Momentum(p_def.mass, first_daughter_.mass, second_daughter_.mass);
-    Vector3D direction = GenerateRandomDirection();
+    Cartesian3D direction = GenerateRandomDirection();
 
     products[0].direction = direction;
     products[0].SetMomentum(momentum);
 
-    Vector3D opposite_direction = -direction;
-    opposite_direction.CalculateSphericalCoordinates();
+    Cartesian3D opposite_direction = -direction;
     products[1].direction = opposite_direction;
     products[1].SetMomentum(momentum);
 

--- a/src/PROPOSAL/density_distr/density_distr.cxx
+++ b/src/PROPOSAL/density_distr/density_distr.cxx
@@ -7,6 +7,7 @@
 #include "PROPOSAL/density_distr/density_polynomial.h"
 #include "PROPOSAL/density_distr/density_splines.h"
 #include "PROPOSAL/medium/Medium.h"
+#include "PROPOSAL/math/Cartesian3D.h"
 
 using namespace PROPOSAL;
 
@@ -64,7 +65,7 @@ Axis::Axis(const Vector3D& fp0) : fp0_(fp0) {}
 
 Axis::Axis(const nlohmann::json& config) {
     if(not config.contains("fp0")) throw std::invalid_argument("Axis: No fp0 found.");
-    fp0_ = Vector3D(config.at("fp0"));
+    fp0_ = Cartesian3D(config.at("fp0"));
 }
 
 
@@ -85,7 +86,7 @@ bool Axis::operator!=(const Axis& axis) const {
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 RadialAxis::RadialAxis() : Axis() {
-    fp0_.SetCartesianCoordinates(0, 0, 0);
+    fp0_.SetCoordinates({0, 0, 0});
 }
 
 RadialAxis::RadialAxis(const Vector3D& fp0) : Axis(fp0) {}
@@ -97,8 +98,8 @@ double RadialAxis::GetDepth(const Vector3D& xi) const {
 }
 
 double RadialAxis::GetEffectiveDistance(const Vector3D& xi, const Vector3D& direction) const {
-    Vector3D aux{xi - fp0_};
-    aux.normalise();
+    Cartesian3D aux{Cartesian3D(xi) - fp0_};
+    aux.normalize();
 
     return -aux * direction;
 }
@@ -108,15 +109,15 @@ double RadialAxis::GetEffectiveDistance(const Vector3D& xi, const Vector3D& dire
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 CartesianAxis::CartesianAxis() : Axis() {
-    fAxis_.SetCartesianCoordinates(1, 0, 0);
-    fp0_.SetCartesianCoordinates(0, 0, 0);
+    fAxis_.SetCoordinates({1, 0, 0});
+    fp0_.SetCoordinates({0, 0, 0});
 }
 
 CartesianAxis::CartesianAxis(const Vector3D& fAxis, const Vector3D& fp0) :  Axis(fp0) , fAxis_(fAxis) {}
 
 CartesianAxis::CartesianAxis(const nlohmann::json& config) : Axis(config) {
     if(not config.contains("fAxis")) throw std::invalid_argument("Axis: No fAxis found.");
-    fAxis_ = Vector3D(config.at("fAxis"));
+    fAxis_ = Cartesian3D(config.at("fAxis"));
 }
 
 bool CartesianAxis::operator==(const CartesianAxis& axis) const {

--- a/src/PROPOSAL/density_distr/density_polynomial.cxx
+++ b/src/PROPOSAL/density_distr/density_polynomial.cxx
@@ -1,11 +1,9 @@
 
-#include <algorithm>
-#include <cmath>
 #include <functional>
-#include <iostream>
 #include "PROPOSAL/math/MathMethods.h"
 #include "PROPOSAL/density_distr/density_polynomial.h"
 #include "PROPOSAL/medium/Medium.h"
+#include "PROPOSAL/math/Cartesian3D.h"
 using namespace PROPOSAL;
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 // %%%%%%%%%%%%%%%%%%% Polynomial-Density %%%%%%%%%%%%%%%%%%%%
@@ -58,8 +56,8 @@ double Density_polynomial::helper_function(const Vector3D& xi,
                                            double res,
                                            double l) const {
     (void)res;
-
-    return Evaluate(xi) - Evaluate(xi + l * direction);
+    Cartesian3D dir_cartesian(direction);
+    return Evaluate(xi) - Evaluate(xi + l * dir_cartesian);
 }
 
 double Density_polynomial::Correct(const Vector3D& xi,
@@ -67,12 +65,12 @@ double Density_polynomial::Correct(const Vector3D& xi,
                                    double res,
                                    double distance_to_border) const {
     std::function<double(double)> F =
-        std::bind(&Density_polynomial::Helper_function, this, xi, direction,
-                  res, std::placeholders::_1);
+        std::bind(&Density_polynomial::Helper_function, this, std::ref(xi),
+                  std::ref(direction), res, std::placeholders::_1);
 
     std::function<double(double)> dF =
-        std::bind(&Density_polynomial::helper_function, this, xi, direction,
-                  res, std::placeholders::_1);
+        std::bind(&Density_polynomial::helper_function, this, std::ref(xi),
+                  std::ref(direction), res, std::placeholders::_1);
 
     // check if direction * axis larger or less than zero
     // direction * fAxis_

--- a/src/PROPOSAL/density_distr/density_polynomial.cxx
+++ b/src/PROPOSAL/density_distr/density_polynomial.cxx
@@ -64,13 +64,8 @@ double Density_polynomial::Correct(const Vector3D& xi,
                                    const Vector3D& direction,
                                    double res,
                                    double distance_to_border) const {
-    std::function<double(double)> F =
-        std::bind(&Density_polynomial::Helper_function, this, std::ref(xi),
-                  std::ref(direction), res, std::placeholders::_1);
-
-    std::function<double(double)> dF =
-        std::bind(&Density_polynomial::helper_function, this, std::ref(xi),
-                  std::ref(direction), res, std::placeholders::_1);
+    auto F = [&](double l) {return Helper_function(xi, direction, res, l);};
+    auto dF = [&](double l) {return helper_function(xi, direction, res, l);};
 
     // check if direction * axis larger or less than zero
     // direction * fAxis_

--- a/src/PROPOSAL/density_distr/density_splines.cxx
+++ b/src/PROPOSAL/density_distr/density_splines.cxx
@@ -1,9 +1,8 @@
 
-#include <algorithm>
 #include <functional>
-#include <iostream>
 #include "PROPOSAL/density_distr/density_splines.h"
 #include "PROPOSAL/medium/Medium.h"
+#include "PROPOSAL/math/Cartesian3D.h"
 using namespace PROPOSAL;
 
 Density_splines::Density_splines(const Axis& axis, const Spline& splines, double massDensity)
@@ -61,7 +60,8 @@ double Density_splines::helper_function(const Vector3D& xi,
                                         double res,
                                         double l) const {
     (void)res;
-    return Evaluate(xi) - Evaluate(xi + l * direction);
+    auto dir_cartesian = Cartesian3D(direction);
+    return Evaluate(xi) - Evaluate(xi + l * dir_cartesian);
 }
 
 double Density_splines::Correct(const Vector3D& xi,
@@ -69,12 +69,12 @@ double Density_splines::Correct(const Vector3D& xi,
                                 double res,
                                 double distance_to_border) const {
     std::function<double(double)> F =
-        std::bind(&Density_splines::Helper_function, this, xi, direction, res,
-                  std::placeholders::_1);
+        std::bind(&Density_splines::Helper_function, this, std::ref(xi),
+                  std::ref(direction), res, std::placeholders::_1);
 
     std::function<double(double)> dF =
-        std::bind(&Density_splines::helper_function, this, xi, direction, res,
-                  std::placeholders::_1);
+        std::bind(&Density_splines::helper_function, this, std::ref(xi),
+                  std::ref(direction), res, std::placeholders::_1);
 
     try {
         res =

--- a/src/PROPOSAL/density_distr/density_splines.cxx
+++ b/src/PROPOSAL/density_distr/density_splines.cxx
@@ -68,13 +68,8 @@ double Density_splines::Correct(const Vector3D& xi,
                                 const Vector3D& direction,
                                 double res,
                                 double distance_to_border) const {
-    std::function<double(double)> F =
-        std::bind(&Density_splines::Helper_function, this, std::ref(xi),
-                  std::ref(direction), res, std::placeholders::_1);
-
-    std::function<double(double)> dF =
-        std::bind(&Density_splines::helper_function, this, std::ref(xi),
-                  std::ref(direction), res, std::placeholders::_1);
+    auto F = [&](double l) {return Helper_function(xi, direction, res, l);};
+    auto dF = [&](double l) {return helper_function(xi, direction, res, l);};
 
     try {
         res =

--- a/src/PROPOSAL/geometry/Box.cxx
+++ b/src/PROPOSAL/geometry/Box.cxx
@@ -9,7 +9,7 @@
 using namespace PROPOSAL;
 
 
-Box::Box(const Vector3D position, double x, double y, double z)
+Box::Box(const Vector3D& position, double x, double y, double z)
     : Geometry("Box", position)
     , x_(x)
     , y_(y)
@@ -63,21 +63,20 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
 {
     // Calculate intersection of particle trajectory and the box
     // Surface of the box is defined by six planes:
-    // E1: x1   =   position.GetX() + 0.5*x
-    // E2: x1   =   position.GetX() - 0.5*x
-    // E3: x2   =   position.GetY() + 0.5*y
-    // E4: x2   =   position.GetY() - 0.5*y
-    // E5: x3   =   position.GetZ() + 0.5*z
-    // E6: x3   =   position.GetZ() - 0.5*z
+    // E1: x1   =   pos_vec[0] + 0.5*x
+    // E2: x1   =   pos_vec[0] - 0.5*x
+    // E3: x2   =   pos_vec[1] + 0.5*y
+    // E4: x2   =   pos_vec[1] - 0.5*y
+    // E5: x3   =   pos_vec[2] + 0.5*z
+    // E6: x3   =   pos_vec[2] - 0.5*z
     // straight line (particle trajectory) g = vec(x,y,z) + t * dir_vec( cosph
     // *sinth, sinph *sinth , costh)
     // We are only interested in postive values of t
     // ( we want to find the intersection in direction of the particle
     // trajectory)
 
-    double dir_vec_x = direction.GetX();
-    double dir_vec_y = direction.GetY();
-    double dir_vec_z = direction.GetZ();
+    auto dir_vec = direction.GetCartesianCoordinates();
+    auto pos_vec = position.GetCartesianCoordinates();
 
     std::pair<double, double> distance;
     double t;
@@ -95,9 +94,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     double z_calc_neg = position_.GetZ() - 0.5 * z_;
 
     // intersection with E1
-    if (dir_vec_x != 0) // if dir_vec == 0 particle trajectory is parallel to E1
+    if (dir_vec[0] != 0) // if dir_vec == 0 particle trajectory is parallel to E1
     {
-        t = (x_calc_pos - position.GetX()) / dir_vec_x;
+        t = (x_calc_pos - pos_vec[0]) / dir_vec[0];
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -106,8 +105,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_y = position.GetY() + t * dir_vec_y;
-            intersection_z = position.GetZ() + t * dir_vec_z;
+            intersection_y = pos_vec[1] + t * dir_vec[1];
+            intersection_z = pos_vec[2] + t * dir_vec[2];
             if (intersection_y >= y_calc_neg && intersection_y <= y_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -117,9 +116,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E2
-    if (dir_vec_x != 0) // if dir_vec == 0 particle trajectory is parallel to E2
+    if (dir_vec[0] != 0) // if dir_vec == 0 particle trajectory is parallel to E2
     {
-        t = (x_calc_neg - position.GetX()) / dir_vec_x;
+        t = (x_calc_neg - pos_vec[0]) / dir_vec[0];
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -128,8 +127,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_y = position.GetY() + t * dir_vec_y;
-            intersection_z = position.GetZ() + t * dir_vec_z;
+            intersection_y = pos_vec[1] + t * dir_vec[1];
+            intersection_z = pos_vec[2] + t * dir_vec[2];
             if (intersection_y >= y_calc_neg && intersection_y <= y_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -139,9 +138,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E3
-    if (dir_vec_y != 0) // if dir_vec == 0 particle trajectory is parallel to E3
+    if (dir_vec[1] != 0) // if dir_vec == 0 particle trajectory is parallel to E3
     {
-        t = (y_calc_pos - position.GetY()) / dir_vec_y;
+        t = (y_calc_pos - pos_vec[1]) / dir_vec[1];
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -150,8 +149,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = position.GetX() + t * dir_vec_x;
-            intersection_z = position.GetZ() + t * dir_vec_z;
+            intersection_x = pos_vec[0] + t * dir_vec[0];
+            intersection_z = pos_vec[2] + t * dir_vec[2];
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -161,9 +160,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E4
-    if (dir_vec_y != 0) // if dir_vec == 0 particle trajectory is parallel to E4
+    if (dir_vec[1] != 0) // if dir_vec == 0 particle trajectory is parallel to E4
     {
-        t = (y_calc_neg - position.GetY()) / dir_vec_y;
+        t = (y_calc_neg - pos_vec[1]) / dir_vec[1];
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -172,8 +171,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = position.GetX() + t * dir_vec_x;
-            intersection_z = position.GetZ() + t * dir_vec_z;
+            intersection_x = pos_vec[0] + t * dir_vec[0];
+            intersection_z = pos_vec[2] + t * dir_vec[2];
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -183,9 +182,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E5
-    if (dir_vec_z != 0) // if dir_vec == 0 particle trajectory is parallel to E5
+    if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel to E5
     {
-        t = (z_calc_pos - position.GetZ()) / dir_vec_z;
+        t = (z_calc_pos - pos_vec[2]) / dir_vec[2];
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -194,8 +193,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = position.GetX() + t * dir_vec_x;
-            intersection_y = position.GetY() + t * dir_vec_y;
+            intersection_x = pos_vec[0] + t * dir_vec[0];
+            intersection_y = pos_vec[1] + t * dir_vec[1];
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_y >= y_calc_neg &&
                 intersection_y <= y_calc_pos)
             {
@@ -205,9 +204,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E6
-    if (dir_vec_z != 0) // if dir_vec == 0 particle trajectory is parallel to E6
+    if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel to E6
     {
-        t = (z_calc_neg - position.GetZ()) / dir_vec_z;
+        t = (z_calc_neg - pos_vec[2]) / dir_vec[2];
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -216,8 +215,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = position.GetX() + t * dir_vec_x;
-            intersection_y = position.GetY() + t * dir_vec_y;
+            intersection_x = pos_vec[0] + t * dir_vec[0];
+            intersection_y = pos_vec[1] + t * dir_vec[1];
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_y >= y_calc_neg &&
                 intersection_y <= y_calc_pos)
             {

--- a/src/PROPOSAL/geometry/Box.cxx
+++ b/src/PROPOSAL/geometry/Box.cxx
@@ -63,20 +63,20 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
 {
     // Calculate intersection of particle trajectory and the box
     // Surface of the box is defined by six planes:
-    // E1: x1   =   pos_vec[0] + 0.5*x
-    // E2: x1   =   pos_vec[0] - 0.5*x
-    // E3: x2   =   pos_vec[1] + 0.5*y
-    // E4: x2   =   pos_vec[1] - 0.5*y
-    // E5: x3   =   pos_vec[2] + 0.5*z
-    // E6: x3   =   pos_vec[2] - 0.5*z
+    // E1: x1   =   pos_vec.GetX() + 0.5*x
+    // E2: x1   =   pos_vec.GetX() - 0.5*x
+    // E3: x2   =   pos_vec.GetY() + 0.5*y
+    // E4: x2   =   pos_vec.GetY() - 0.5*y
+    // E5: x3   =   pos_vec.GetZ() + 0.5*z
+    // E6: x3   =   pos_vec.GetZ() - 0.5*z
     // straight line (particle trajectory) g = vec(x,y,z) + t * dir_vec( cosph
     // *sinth, sinph *sinth , costh)
     // We are only interested in postive values of t
     // ( we want to find the intersection in direction of the particle
     // trajectory)
 
-    auto dir_vec = direction.GetCartesianCoordinates();
-    auto pos_vec = position.GetCartesianCoordinates();
+    auto dir_vec = Cartesian3D(direction);
+    auto pos_vec = Cartesian3D(position);
 
     std::pair<double, double> distance;
     double t;
@@ -94,9 +94,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     double z_calc_neg = position_.GetZ() - 0.5 * z_;
 
     // intersection with E1
-    if (dir_vec[0] != 0) // if dir_vec == 0 particle trajectory is parallel to E1
+    if (dir_vec.GetX() != 0) // if dir_vec == 0 particle trajectory is parallel to E1
     {
-        t = (x_calc_pos - pos_vec[0]) / dir_vec[0];
+        t = (x_calc_pos - pos_vec.GetX()) / dir_vec.GetX();
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -105,8 +105,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_y = pos_vec[1] + t * dir_vec[1];
-            intersection_z = pos_vec[2] + t * dir_vec[2];
+            intersection_y = pos_vec.GetY() + t * dir_vec.GetY();
+            intersection_z = pos_vec.GetZ() + t * dir_vec.GetZ();
             if (intersection_y >= y_calc_neg && intersection_y <= y_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -116,9 +116,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E2
-    if (dir_vec[0] != 0) // if dir_vec == 0 particle trajectory is parallel to E2
+    if (dir_vec.GetX() != 0) // if dir_vec == 0 particle trajectory is parallel to E2
     {
-        t = (x_calc_neg - pos_vec[0]) / dir_vec[0];
+        t = (x_calc_neg - pos_vec.GetX()) / dir_vec.GetX();
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -127,8 +127,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_y = pos_vec[1] + t * dir_vec[1];
-            intersection_z = pos_vec[2] + t * dir_vec[2];
+            intersection_y = pos_vec.GetY() + t * dir_vec.GetY();
+            intersection_z = pos_vec.GetZ() + t * dir_vec.GetZ();
             if (intersection_y >= y_calc_neg && intersection_y <= y_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -138,9 +138,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E3
-    if (dir_vec[1] != 0) // if dir_vec == 0 particle trajectory is parallel to E3
+    if (dir_vec.GetY() != 0) // if dir_vec == 0 particle trajectory is parallel to E3
     {
-        t = (y_calc_pos - pos_vec[1]) / dir_vec[1];
+        t = (y_calc_pos - pos_vec.GetY()) / dir_vec.GetY();
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -149,8 +149,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = pos_vec[0] + t * dir_vec[0];
-            intersection_z = pos_vec[2] + t * dir_vec[2];
+            intersection_x = pos_vec.GetX() + t * dir_vec.GetX();
+            intersection_z = pos_vec.GetZ() + t * dir_vec.GetZ();
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -160,9 +160,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E4
-    if (dir_vec[1] != 0) // if dir_vec == 0 particle trajectory is parallel to E4
+    if (dir_vec.GetY() != 0) // if dir_vec == 0 particle trajectory is parallel to E4
     {
-        t = (y_calc_neg - pos_vec[1]) / dir_vec[1];
+        t = (y_calc_neg - pos_vec.GetY()) / dir_vec.GetY();
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -171,8 +171,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = pos_vec[0] + t * dir_vec[0];
-            intersection_z = pos_vec[2] + t * dir_vec[2];
+            intersection_x = pos_vec.GetX() + t * dir_vec.GetX();
+            intersection_z = pos_vec.GetZ() + t * dir_vec.GetZ();
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_z >= z_calc_neg &&
                 intersection_z <= z_calc_pos)
             {
@@ -182,9 +182,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E5
-    if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel to E5
+    if (dir_vec.GetZ() != 0) // if dir_vec == 0 particle trajectory is parallel to E5
     {
-        t = (z_calc_pos - pos_vec[2]) / dir_vec[2];
+        t = (z_calc_pos - pos_vec.GetZ()) / dir_vec.GetZ();
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -193,8 +193,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = pos_vec[0] + t * dir_vec[0];
-            intersection_y = pos_vec[1] + t * dir_vec[1];
+            intersection_x = pos_vec.GetX() + t * dir_vec.GetX();
+            intersection_y = pos_vec.GetY() + t * dir_vec.GetY();
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_y >= y_calc_neg &&
                 intersection_y <= y_calc_pos)
             {
@@ -204,9 +204,9 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
     }
 
     // intersection with E6
-    if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel to E6
+    if (dir_vec.GetZ() != 0) // if dir_vec == 0 particle trajectory is parallel to E6
     {
-        t = (z_calc_neg - pos_vec[2]) / dir_vec[2];
+        t = (z_calc_neg - pos_vec.GetZ()) / dir_vec.GetZ();
 
         // Computer precision controll
         if (t > 0 && t < GEOMETRY_PRECISION)
@@ -215,8 +215,8 @@ std::pair<double, double> Box::DistanceToBorder(const Vector3D& position, const 
         if (t > 0) // Interection is in particle trajectory direction
         {
             // Check if intersection is inside the box borders
-            intersection_x = pos_vec[0] + t * dir_vec[0];
-            intersection_y = pos_vec[1] + t * dir_vec[1];
+            intersection_x = pos_vec.GetX() + t * dir_vec.GetX();
+            intersection_y = pos_vec.GetY() + t * dir_vec.GetY();
             if (intersection_x >= x_calc_neg && intersection_x <= x_calc_pos && intersection_y >= y_calc_neg &&
                 intersection_y <= y_calc_pos)
             {

--- a/src/PROPOSAL/geometry/Cylinder.cxx
+++ b/src/PROPOSAL/geometry/Cylinder.cxx
@@ -9,7 +9,7 @@
 using namespace PROPOSAL;
 
 
-Cylinder::Cylinder(const Vector3D position, double z, double radius, double inner_radius)
+Cylinder::Cylinder(const Vector3D& position, double z, double radius, double inner_radius)
     : Geometry("Cylinder", position)
     , radius_(radius)
     , inner_radius_(inner_radius)
@@ -87,9 +87,8 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
     // inside
 
     double A, B, C, t1, t2, t;
-    double dir_vec_x = direction.GetX();
-    double dir_vec_y = direction.GetY();
-    double dir_vec_z = direction.GetZ();
+    auto dir_vec = direction.GetCartesianCoordinates();
+    auto pos_vec = position.GetCartesianCoordinates();
 
     double determinant;
 
@@ -104,18 +103,18 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
     double z_calc_pos = position_.GetZ() + 0.5 * z_;
     double z_calc_neg = position_.GetZ() - 0.5 * z_;
 
-    if (!(dir_vec_x == 0 && dir_vec_y == 0)) // Otherwise the particle
+    if (!(dir_vec[0] == 0 && dir_vec[1] == 0)) // Otherwise the particle
                                              // trajectory is parallel to
                                              // cylinder barrel
     {
 
-        A = std::pow((position.GetX() - position_.GetX()), 2) +
-            std::pow((position.GetY() - position_.GetY()), 2) -
+        A = std::pow((pos_vec[0] - position_.GetX()), 2) +
+            std::pow((pos_vec[1] - position_.GetY()), 2) -
             radius_*radius_;
 
-        B = 2 * ((position.GetX() - position_.GetX()) * dir_vec_x + (position.GetY() - position_.GetY()) * dir_vec_y);
+        B = 2 * ((pos_vec[0] - position_.GetX()) * dir_vec[0] + (pos_vec[1] - position_.GetY()) * dir_vec[1]);
 
-        C = dir_vec_x * dir_vec_x + dir_vec_y * dir_vec_y;
+        C = dir_vec[0] * dir_vec[0] + dir_vec[1] * dir_vec[1];
 
         B /= C;
         A /= C;
@@ -135,7 +134,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
             if (t1 > 0)
             {
-                intersection_z = position.GetZ() + t1 * dir_vec_z;
+                intersection_z = pos_vec[2] + t1 * dir_vec[2];
                 // is inside the borders
                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                 {
@@ -145,7 +144,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
             if (t2 > 0)
             {
-                intersection_z = position.GetZ() + t2 * dir_vec_z;
+                intersection_z = pos_vec[2] + t2 * dir_vec[2];
                 // is inside the borders
                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                 {
@@ -161,18 +160,18 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
     if (dist.size() < 2)
     {
         // intersection with E1
-        if (dir_vec_z != 0) // if dir_vec == 0 particle trajectory is parallel
+        if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel
                             // to E1 (Should not happen)
         {
-            t = (z_calc_pos - position.GetZ()) / dir_vec_z;
+            t = (z_calc_pos - pos_vec[2]) / dir_vec[2];
             // Computer precision controll
             if (t > 0 && t < GEOMETRY_PRECISION)
                 t = 0;
 
             if (t > 0) // Interection is in particle trajectory direction
             {
-                intersection_x = position.GetX() + t * dir_vec_x;
-                intersection_y = position.GetY() + t * dir_vec_y;
+                intersection_x = pos_vec[0] + t * dir_vec[0];
+                intersection_y = pos_vec[1] + t * dir_vec[1];
 
                 if (std::sqrt(std::pow((intersection_x - position_.GetX()), 2) +
                     std::pow((intersection_y - position_.GetY()), 2)) <=
@@ -187,10 +186,10 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
         }
 
         // intersection with E2
-        if (dir_vec_z != 0) // if dir_vec == 0 particle trajectory is parallel
+        if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel
                             // to E2 (Should not happen)
         {
-            t = (z_calc_neg - position.GetZ()) / dir_vec_z;
+            t = (z_calc_neg - pos_vec[2]) / dir_vec[2];
 
             // Computer precision controll
             if (t > 0 && t < GEOMETRY_PRECISION)
@@ -198,8 +197,8 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
             if (t > 0) // Interection is in particle trajectory direction
             {
-                intersection_x = position.GetX() + t * dir_vec_x;
-                intersection_y = position.GetY() + t * dir_vec_y;
+                intersection_x = pos_vec[0] + t * dir_vec[0];
+                intersection_y = pos_vec[1] + t * dir_vec[1];
 
                 if (std::sqrt(std::pow((intersection_x - position_.GetX()), 2) +
                     std::pow((intersection_y - position_.GetY()), 2)) <=
@@ -244,17 +243,17 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
     if (inner_radius_ > 0)
     {
-        if (!(dir_vec_x == 0 && dir_vec_y == 0))
+        if (!(dir_vec[0] == 0 && dir_vec[1] == 0))
         {
 
-            A = std::pow((position.GetX() - position_.GetX()), 2) +
-                std::pow((position.GetY() - position_.GetY()), 2) -
+            A = std::pow((pos_vec[0] - position_.GetX()), 2) +
+                std::pow((pos_vec[1] - position_.GetY()), 2) -
                 inner_radius_*inner_radius_;
 
             B = 2 *
-                ((position.GetX() - position_.GetX()) * dir_vec_x + (position.GetY() - position_.GetY()) * dir_vec_y);
+                ((pos_vec[0] - position_.GetX()) * dir_vec[0] + (pos_vec[1] - position_.GetY()) * dir_vec[1]);
 
-            C = dir_vec_x * dir_vec_x + dir_vec_y * dir_vec_y;
+            C = dir_vec[0] * dir_vec[0] + dir_vec[1] * dir_vec[1];
 
             B /= C;
             A /= C;
@@ -284,7 +283,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                 {
                     if (t1 > 0)
                     {
-                        intersection_z = position.GetZ() + t1 * dir_vec_z;
+                        intersection_z = pos_vec[2] + t1 * dir_vec[2];
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -295,7 +294,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
                     if (t2 > 0)
                     {
-                        intersection_z = position.GetZ() + t2 * dir_vec_z;
+                        intersection_z = pos_vec[2] + t2 * dir_vec[2];
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -321,7 +320,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                 {
                     if (t1 > 0)
                     {
-                        intersection_z = position.GetZ() + t1 * dir_vec_z;
+                        intersection_z = pos_vec[2] + t1 * dir_vec[2];
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -330,7 +329,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                     }
                     if (t2 > 0)
                     {
-                        intersection_z = position.GetZ() + t2 * dir_vec_z;
+                        intersection_z = pos_vec[2] + t2 * dir_vec[2];
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -358,17 +357,17 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         // |     |      |     |
                         // |_____|      |_____|
                         //
-                        if (position.GetZ() >= z_calc_neg && position.GetZ() <= z_calc_pos &&
-                            std::sqrt(std::pow((position.GetX() - position_.GetX()), 2) +
-                            std::pow((position.GetY() - position_.GetY()), 2)) <=
+                        if (pos_vec[2] >= z_calc_neg && pos_vec[2] <= z_calc_pos &&
+                            std::sqrt(std::pow((pos_vec[0] - position_.GetX()), 2) +
+                            std::pow((pos_vec[1] - position_.GetY()), 2)) <=
                                 radius_ + GEOMETRY_PRECISION &&
-                            std::sqrt(std::pow((position.GetX() - position_.GetX()), 2) +
-                            std::pow((position.GetY() - position_.GetY()), 2)) >=
+                            std::sqrt(std::pow((pos_vec[0] - position_.GetX()), 2) +
+                            std::pow((pos_vec[1] - position_.GetY()), 2)) >=
                                 inner_radius_ - GEOMETRY_PRECISION)
                         {
                             if (t1 < distance.first)
                             {
-                                intersection_z = position.GetZ() + t1 * dir_vec_z;
+                                intersection_z = pos_vec[2] + t1 * dir_vec[2];
                                 // is inside the borders
                                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                                 {
@@ -380,7 +379,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                             }
                             if (t2 < distance.first)
                             {
-                                intersection_z = position.GetZ() + t2 * dir_vec_z;
+                                intersection_z = pos_vec[2] + t2 * dir_vec[2];
                                 // is inside the borders
                                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                                 {
@@ -406,7 +405,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         //   x
                         else
                         {
-                            intersection_z = position.GetZ() + t1 * dir_vec_z;
+                            intersection_z = pos_vec[2] + t1 * dir_vec[2];
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -417,7 +416,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
                             if (distance.second < 0)
                             {
-                                intersection_z = position.GetZ() + t2 * dir_vec_z;
+                                intersection_z = pos_vec[2] + t2 * dir_vec[2];
                                 // is inside the borders
                                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                                 {
@@ -449,7 +448,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                     {
                         if (t1 > 0)
                         {
-                            intersection_z = position.GetZ() + t1 * dir_vec_z;
+                            intersection_z = pos_vec[2] + t1 * dir_vec[2];
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -458,7 +457,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                             }
                         } else
                         {
-                            intersection_z = position.GetZ() + t2 * dir_vec_z;
+                            intersection_z = pos_vec[2] + t2 * dir_vec[2];
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -474,7 +473,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         // The particle is moving into the inner cylinder
                         if (t2 > 0)
                         {
-                            intersection_z = position.GetZ() + t2 * dir_vec_z;
+                            intersection_z = pos_vec[2] + t2 * dir_vec[2];
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -489,7 +488,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         // The particle is moving into the inner sphere
                         if (t1 > 0)
                         {
-                            intersection_z = position.GetZ() + t1 * dir_vec_z;
+                            intersection_z = pos_vec[2] + t1 * dir_vec[2];
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {

--- a/src/PROPOSAL/geometry/Cylinder.cxx
+++ b/src/PROPOSAL/geometry/Cylinder.cxx
@@ -87,8 +87,8 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
     // inside
 
     double A, B, C, t1, t2, t;
-    auto dir_vec = direction.GetCartesianCoordinates();
-    auto pos_vec = position.GetCartesianCoordinates();
+    auto dir_vec = Cartesian3D(direction);
+    auto pos_vec = Cartesian3D(position);
 
     double determinant;
 
@@ -103,18 +103,18 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
     double z_calc_pos = position_.GetZ() + 0.5 * z_;
     double z_calc_neg = position_.GetZ() - 0.5 * z_;
 
-    if (!(dir_vec[0] == 0 && dir_vec[1] == 0)) // Otherwise the particle
+    if (!(dir_vec.GetX() == 0 && dir_vec.GetY() == 0)) // Otherwise the particle
                                              // trajectory is parallel to
                                              // cylinder barrel
     {
 
-        A = std::pow((pos_vec[0] - position_.GetX()), 2) +
-            std::pow((pos_vec[1] - position_.GetY()), 2) -
+        A = std::pow((pos_vec.GetX() - position_.GetX()), 2) +
+            std::pow((pos_vec.GetY() - position_.GetY()), 2) -
             radius_*radius_;
 
-        B = 2 * ((pos_vec[0] - position_.GetX()) * dir_vec[0] + (pos_vec[1] - position_.GetY()) * dir_vec[1]);
+        B = 2 * ((pos_vec.GetX() - position_.GetX()) * dir_vec.GetX() + (pos_vec.GetY() - position_.GetY()) * dir_vec.GetY());
 
-        C = dir_vec[0] * dir_vec[0] + dir_vec[1] * dir_vec[1];
+        C = dir_vec.GetX() * dir_vec.GetX() + dir_vec.GetY() * dir_vec.GetY();
 
         B /= C;
         A /= C;
@@ -134,7 +134,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
             if (t1 > 0)
             {
-                intersection_z = pos_vec[2] + t1 * dir_vec[2];
+                intersection_z = pos_vec.GetZ() + t1 * dir_vec.GetZ();
                 // is inside the borders
                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                 {
@@ -144,7 +144,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
             if (t2 > 0)
             {
-                intersection_z = pos_vec[2] + t2 * dir_vec[2];
+                intersection_z = pos_vec.GetZ() + t2 * dir_vec.GetZ();
                 // is inside the borders
                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                 {
@@ -160,18 +160,18 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
     if (dist.size() < 2)
     {
         // intersection with E1
-        if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel
+        if (dir_vec.GetZ() != 0) // if dir_vec == 0 particle trajectory is parallel
                             // to E1 (Should not happen)
         {
-            t = (z_calc_pos - pos_vec[2]) / dir_vec[2];
+            t = (z_calc_pos - pos_vec.GetZ()) / dir_vec.GetZ();
             // Computer precision controll
             if (t > 0 && t < GEOMETRY_PRECISION)
                 t = 0;
 
             if (t > 0) // Interection is in particle trajectory direction
             {
-                intersection_x = pos_vec[0] + t * dir_vec[0];
-                intersection_y = pos_vec[1] + t * dir_vec[1];
+                intersection_x = pos_vec.GetX() + t * dir_vec.GetX();
+                intersection_y = pos_vec.GetY() + t * dir_vec.GetY();
 
                 if (std::sqrt(std::pow((intersection_x - position_.GetX()), 2) +
                     std::pow((intersection_y - position_.GetY()), 2)) <=
@@ -186,10 +186,10 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
         }
 
         // intersection with E2
-        if (dir_vec[2] != 0) // if dir_vec == 0 particle trajectory is parallel
+        if (dir_vec.GetZ() != 0) // if dir_vec == 0 particle trajectory is parallel
                             // to E2 (Should not happen)
         {
-            t = (z_calc_neg - pos_vec[2]) / dir_vec[2];
+            t = (z_calc_neg - pos_vec.GetZ()) / dir_vec.GetZ();
 
             // Computer precision controll
             if (t > 0 && t < GEOMETRY_PRECISION)
@@ -197,8 +197,8 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
             if (t > 0) // Interection is in particle trajectory direction
             {
-                intersection_x = pos_vec[0] + t * dir_vec[0];
-                intersection_y = pos_vec[1] + t * dir_vec[1];
+                intersection_x = pos_vec.GetX() + t * dir_vec.GetX();
+                intersection_y = pos_vec.GetY() + t * dir_vec.GetY();
 
                 if (std::sqrt(std::pow((intersection_x - position_.GetX()), 2) +
                     std::pow((intersection_y - position_.GetY()), 2)) <=
@@ -243,17 +243,17 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
     if (inner_radius_ > 0)
     {
-        if (!(dir_vec[0] == 0 && dir_vec[1] == 0))
+        if (!(dir_vec.GetX() == 0 && dir_vec.GetY() == 0))
         {
 
-            A = std::pow((pos_vec[0] - position_.GetX()), 2) +
-                std::pow((pos_vec[1] - position_.GetY()), 2) -
+            A = std::pow((pos_vec.GetX() - position_.GetX()), 2) +
+                std::pow((pos_vec.GetY() - position_.GetY()), 2) -
                 inner_radius_*inner_radius_;
 
             B = 2 *
-                ((pos_vec[0] - position_.GetX()) * dir_vec[0] + (pos_vec[1] - position_.GetY()) * dir_vec[1]);
+                ((pos_vec.GetX() - position_.GetX()) * dir_vec.GetX() + (pos_vec.GetY() - position_.GetY()) * dir_vec.GetY());
 
-            C = dir_vec[0] * dir_vec[0] + dir_vec[1] * dir_vec[1];
+            C = dir_vec.GetX() * dir_vec.GetX() + dir_vec.GetY() * dir_vec.GetY();
 
             B /= C;
             A /= C;
@@ -283,7 +283,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                 {
                     if (t1 > 0)
                     {
-                        intersection_z = pos_vec[2] + t1 * dir_vec[2];
+                        intersection_z = pos_vec.GetZ() + t1 * dir_vec.GetZ();
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -294,7 +294,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
                     if (t2 > 0)
                     {
-                        intersection_z = pos_vec[2] + t2 * dir_vec[2];
+                        intersection_z = pos_vec.GetZ() + t2 * dir_vec.GetZ();
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -320,7 +320,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                 {
                     if (t1 > 0)
                     {
-                        intersection_z = pos_vec[2] + t1 * dir_vec[2];
+                        intersection_z = pos_vec.GetZ() + t1 * dir_vec.GetZ();
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -329,7 +329,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                     }
                     if (t2 > 0)
                     {
-                        intersection_z = pos_vec[2] + t2 * dir_vec[2];
+                        intersection_z = pos_vec.GetZ() + t2 * dir_vec.GetZ();
                         // is inside the borders
                         if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                         {
@@ -357,17 +357,17 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         // |     |      |     |
                         // |_____|      |_____|
                         //
-                        if (pos_vec[2] >= z_calc_neg && pos_vec[2] <= z_calc_pos &&
-                            std::sqrt(std::pow((pos_vec[0] - position_.GetX()), 2) +
-                            std::pow((pos_vec[1] - position_.GetY()), 2)) <=
+                        if (pos_vec.GetZ() >= z_calc_neg && pos_vec.GetZ() <= z_calc_pos &&
+                            std::sqrt(std::pow((pos_vec.GetX() - position_.GetX()), 2) +
+                            std::pow((pos_vec.GetY() - position_.GetY()), 2)) <=
                                 radius_ + GEOMETRY_PRECISION &&
-                            std::sqrt(std::pow((pos_vec[0] - position_.GetX()), 2) +
-                            std::pow((pos_vec[1] - position_.GetY()), 2)) >=
+                            std::sqrt(std::pow((pos_vec.GetX() - position_.GetX()), 2) +
+                            std::pow((pos_vec.GetY() - position_.GetY()), 2)) >=
                                 inner_radius_ - GEOMETRY_PRECISION)
                         {
                             if (t1 < distance.first)
                             {
-                                intersection_z = pos_vec[2] + t1 * dir_vec[2];
+                                intersection_z = pos_vec.GetZ() + t1 * dir_vec.GetZ();
                                 // is inside the borders
                                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                                 {
@@ -379,7 +379,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                             }
                             if (t2 < distance.first)
                             {
-                                intersection_z = pos_vec[2] + t2 * dir_vec[2];
+                                intersection_z = pos_vec.GetZ() + t2 * dir_vec.GetZ();
                                 // is inside the borders
                                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                                 {
@@ -405,7 +405,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         //   x
                         else
                         {
-                            intersection_z = pos_vec[2] + t1 * dir_vec[2];
+                            intersection_z = pos_vec.GetZ() + t1 * dir_vec.GetZ();
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -416,7 +416,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
 
                             if (distance.second < 0)
                             {
-                                intersection_z = pos_vec[2] + t2 * dir_vec[2];
+                                intersection_z = pos_vec.GetZ() + t2 * dir_vec.GetZ();
                                 // is inside the borders
                                 if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                                 {
@@ -448,7 +448,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                     {
                         if (t1 > 0)
                         {
-                            intersection_z = pos_vec[2] + t1 * dir_vec[2];
+                            intersection_z = pos_vec.GetZ() + t1 * dir_vec.GetZ();
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -457,7 +457,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                             }
                         } else
                         {
-                            intersection_z = pos_vec[2] + t2 * dir_vec[2];
+                            intersection_z = pos_vec.GetZ() + t2 * dir_vec.GetZ();
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -473,7 +473,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         // The particle is moving into the inner cylinder
                         if (t2 > 0)
                         {
-                            intersection_z = pos_vec[2] + t2 * dir_vec[2];
+                            intersection_z = pos_vec.GetZ() + t2 * dir_vec.GetZ();
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {
@@ -488,7 +488,7 @@ std::pair<double, double> Cylinder::DistanceToBorder(const Vector3D& position, c
                         // The particle is moving into the inner sphere
                         if (t1 > 0)
                         {
-                            intersection_z = pos_vec[2] + t1 * dir_vec[2];
+                            intersection_z = pos_vec.GetZ() + t1 * dir_vec.GetZ();
                             // is inside the borders
                             if (intersection_z > z_calc_neg && intersection_z < z_calc_pos)
                             {

--- a/src/PROPOSAL/geometry/Geometry.cxx
+++ b/src/PROPOSAL/geometry/Geometry.cxx
@@ -5,7 +5,6 @@
  *      Author: koehne
  */
 
-#include <string>
 #include <sstream>
 #include "PROPOSAL/geometry/Geometry.h"
 

--- a/src/PROPOSAL/geometry/Geometry.cxx
+++ b/src/PROPOSAL/geometry/Geometry.cxx
@@ -5,12 +5,11 @@
  *      Author: koehne
  */
 
-#include <cmath>
-#include "PROPOSAL/Constants.h"
+#include <string>
+#include <sstream>
 #include "PROPOSAL/geometry/Geometry.h"
 
 #include "PROPOSAL/methods.h"
-#include "PROPOSAL/Logging.h"
 
 using namespace PROPOSAL;
 
@@ -43,7 +42,7 @@ std::ostream& operator<<(std::ostream& os, Geometry const& geometry)
  *                                  Geometry                                   *
  ******************************************************************************/
 
-Geometry::Geometry(const std::string name, const Vector3D position)
+Geometry::Geometry(const std::string name, const Vector3D& position)
     : position_(position)
     , name_(name)
     , hierarchy_(0)
@@ -59,7 +58,7 @@ Geometry::Geometry(const nlohmann::json& config)
 
     if(not config.contains("origin"))
         throw std::invalid_argument("No geometry origin found.");
-    position_ = Vector3D(config.at("origin"));
+    position_ = Cartesian3D(config.at("origin"));
 }
 
 
@@ -130,7 +129,7 @@ bool Geometry::IsBehind(const Vector3D& position, const Vector3D& direction) con
 // ------------------------------------------------------------------------- //
 bool Geometry::IsEntering(const Vector3D &position, const Vector3D &direction) const {
     auto dist_forward = DistanceToBorder(position, direction);
-    auto dist_backward = DistanceToBorder(position, -direction);
+    auto dist_backward = DistanceToBorder(position, -Cartesian3D(direction));
     if (dist_forward.first >= 0 and dist_forward.second == -1) {
         if (dist_backward.first == -1 and dist_backward.second == -1) {
             return true;
@@ -142,7 +141,7 @@ bool Geometry::IsEntering(const Vector3D &position, const Vector3D &direction) c
 // ------------------------------------------------------------------------- //
 bool Geometry::IsLeaving(const Vector3D &position, const Vector3D &direction) const {
     auto dist_forward = DistanceToBorder(position, direction);
-    auto dist_backward = DistanceToBorder(position, -direction);
+    auto dist_backward = DistanceToBorder(position, -Cartesian3D(direction));
     if (dist_forward.first == -1 and dist_forward.second == -1) {
         if (dist_backward.first >= 0 and dist_backward.second == -1) {
             return true;
@@ -163,5 +162,5 @@ Geometry::ParticleLocation::Enum Geometry::GetLocation(const Vector3D& position,
 // ------------------------------------------------------------------------- //
 double Geometry::DistanceToClosestApproach(const Vector3D& position, const Vector3D& direction) const
 {
-    return scalar_product(position_ - position, direction);
+    return (position_ - position) * direction;
 }

--- a/src/PROPOSAL/geometry/Sphere.cxx
+++ b/src/PROPOSAL/geometry/Sphere.cxx
@@ -5,7 +5,7 @@
 #include "PROPOSAL/geometry/Sphere.h"
 using namespace PROPOSAL;
 
-Sphere::Sphere(const Vector3D position, double radius, double inner_radius)
+Sphere::Sphere(const Vector3D& position, double radius, double inner_radius)
     : Geometry("Sphere", position)
     , radius_(radius)
     , inner_radius_(inner_radius)
@@ -79,7 +79,7 @@ std::pair<double, double> Sphere::DistanceToBorder(const Vector3D& position, con
     difference_length_squared = std::pow((position - position_).magnitude(), 2);
     A                         = difference_length_squared - radius_ * radius_;
 
-    B = scalar_product(position - position_, direction);
+    B = (position - position_) * direction;
 
     determinant = B * B - A;
 

--- a/src/PROPOSAL/math/Cartesian3D.cxx
+++ b/src/PROPOSAL/math/Cartesian3D.cxx
@@ -18,13 +18,13 @@ Cartesian3D::Cartesian3D(const nlohmann::json& config) {
 }
 
 void Cartesian3D::print(std::ostream& os) const {
-    os << "x: " << coordinates[0] << "\t";
-    os << "y: " << coordinates[1] << "\t";
-    os << "z: " << coordinates[2] << "\n";
+    os << "x: " << GetX() << "\t";
+    os << "y: " << GetY() << "\t";
+    os << "z: " << GetZ() << "\n";
 }
 
 double Cartesian3D::magnitude() const {
-    double sum = 0;
+    auto sum = 0.;
     for (auto& c : coordinates) {
         sum += c * c;
     }
@@ -32,7 +32,7 @@ double Cartesian3D::magnitude() const {
 }
 
 void Cartesian3D::normalize() {
-    double length = magnitude();
+    auto length = magnitude();
     for (size_t i = 0; i<3; i++) {
         coordinates[i] /= length;
     }
@@ -57,7 +57,7 @@ namespace PROPOSAL {
     }
 
     double operator*(const Cartesian3D &lhs, const Cartesian3D &rhs) {
-        double sum = 0.;
+        auto sum = 0.;
         for (size_t i = 0; i < 3; i++) {
             sum += lhs[i] * rhs[i];
         }
@@ -97,9 +97,9 @@ namespace PROPOSAL {
 
     Cartesian3D vector_product(const Cartesian3D& lhs, const Cartesian3D& rhs) {
         Cartesian3D product;
-        product[0] = lhs[1] * rhs[2] - lhs[2] * rhs[1];
-        product[1] = lhs[2] * rhs[0] - lhs[0] * rhs[2];
-        product[2] = lhs[0] * rhs[1] - lhs[1] * rhs[0];
+        product.SetX(lhs.GetY() * rhs.GetZ() - lhs.GetZ() * rhs.GetY());
+        product.SetY(lhs.GetZ() * rhs.GetX() - lhs.GetX() * rhs.GetZ());
+        product.SetZ(lhs.GetX() * rhs.GetY() - lhs.GetY() * rhs.GetX());
         return product;
     }
 }
@@ -107,21 +107,20 @@ namespace PROPOSAL {
 void Cartesian3D::deflect(double cosphi_deflect, double theta_deflect) {
     if(cosphi_deflect != 1 || theta_deflect != 0)
     {
-        double sinphi_deflect = std::sqrt( std::max(0., (1. - cosphi_deflect) * (1. + cosphi_deflect) ));
-        double tx = sinphi_deflect * std::cos(theta_deflect);
-        double ty = sinphi_deflect * std::sin(theta_deflect);
-        double tz = std::sqrt(std::max(1. - tx * tx - ty * ty, 0.));
+        auto sinphi_deflect = std::sqrt( std::max(0., (1. - cosphi_deflect) * (1. + cosphi_deflect) ));
+        auto tx = sinphi_deflect * std::cos(theta_deflect);
+        auto ty = sinphi_deflect * std::sin(theta_deflect);
+        auto tz = std::sqrt(std::max(1. - tx * tx - ty * ty, 0.));
         if(cosphi_deflect < 0. ){
             // Backward deflection
             tz = -tz;
         }
 
-        double sinth, costh, sinph, cosph;
-        auto spherical = this->GetSphericalCoordinates();
-        sinth = std::sin(spherical[Spherical3D::SphericalCoordinate::Zenith]);
-        costh = std::cos(spherical[Spherical3D::SphericalCoordinate::Zenith]);
-        sinph = std::sin(spherical[Spherical3D::SphericalCoordinate::Azimuth]);
-        cosph = std::cos(spherical[Spherical3D::SphericalCoordinate::Azimuth]);
+        auto spherical = Spherical3D(*this);
+        auto sinth = std::sin(spherical.GetZenith());
+        auto costh = std::cos(spherical.GetZenith());
+        auto sinph = std::sin(spherical.GetAzimuth());
+        auto cosph = std::cos(spherical.GetAzimuth());
 
         auto rotate_vector_x = Cartesian3D(costh * cosph, costh * sinph, -sinth);
         auto rotate_vector_y = Cartesian3D(-sinph, cosph, 0.);
@@ -143,8 +142,8 @@ std::array<double, 3> Cartesian3D::GetSphericalCoordinates() const {
     if (r == 0)
         return {0., 0., 0.};
 
-    auto azimuth = std::atan2(coordinates[1], coordinates[0]);
-    auto zenith = std::acos(coordinates[2] / r);
+    auto azimuth = std::atan2(GetY(), GetX());
+    auto zenith = std::acos(GetZ() / r);
 
     return {r, azimuth, zenith};
 }

--- a/src/PROPOSAL/math/Cartesian3D.cxx
+++ b/src/PROPOSAL/math/Cartesian3D.cxx
@@ -1,0 +1,151 @@
+#include "PROPOSAL/math/Cartesian3D.h"
+#include "PROPOSAL/math/Spherical3D.h"
+#include <cmath>
+
+using namespace PROPOSAL;
+
+Cartesian3D::Cartesian3D(const nlohmann::json& config) {
+    if (not config.is_array() or not(config.size() == 3))
+        throw std::invalid_argument("Json array for Cartesian3D is not a 3 "
+                                    "component array.");
+
+    if (!config[0].is_number() or !config[1].is_number() or !config[2].is_number())
+        throw std::invalid_argument("Json array for Cartesian3D must contain "
+                                    "three numbers (x, y, z).");
+
+    for (size_t i = 0; i<3; i++)
+        config[i].get_to(coordinates[i]);
+}
+
+void Cartesian3D::print(std::ostream& os) const {
+    os << "x: " << coordinates[0] << "\t";
+    os << "y: " << coordinates[1] << "\t";
+    os << "z: " << coordinates[2] << "\n";
+}
+
+double Cartesian3D::magnitude() const {
+    double sum = 0;
+    for (auto& c : coordinates) {
+        sum += c * c;
+    }
+    return std::sqrt(sum);
+}
+
+void Cartesian3D::normalize() {
+    double length = magnitude();
+    for (size_t i = 0; i<3; i++) {
+        coordinates[i] /= length;
+    }
+}
+
+namespace PROPOSAL {
+
+    Cartesian3D operator+(const Cartesian3D &lhs, const Cartesian3D &rhs) {
+        Cartesian3D sum;
+        for (size_t i = 0; i < 3; i++) {
+            sum[i] = lhs[i] + rhs[i];
+        }
+        return sum;
+    }
+
+    Cartesian3D operator-(const Cartesian3D &lhs, const Cartesian3D &rhs) {
+        Cartesian3D diff;
+        for (size_t i = 0; i < 3; i++) {
+            diff[i] = lhs[i] - rhs[i];
+        }
+        return diff;
+    }
+
+    double operator*(const Cartesian3D &lhs, const Cartesian3D &rhs) {
+        double sum = 0.;
+        for (size_t i = 0; i < 3; i++) {
+            sum += lhs[i] * rhs[i];
+        }
+        return sum;
+    }
+
+    Cartesian3D operator*(const Cartesian3D &lhs, double val) {
+        Cartesian3D product;
+        for (size_t i = 0; i < 3; i++) {
+            product[i] = lhs[i] * val;
+        }
+        return product;
+    }
+
+    Cartesian3D operator*(double val, const Cartesian3D &rhs) {
+        Cartesian3D product;
+        for (size_t i = 0; i < 3; i++) {
+            product[i] = rhs[i] * val;
+        }
+        return product;
+    }
+
+    Cartesian3D Cartesian3D::operator-() const {
+        Cartesian3D negative;
+        for (size_t i = 0; i < 3; i++) {
+            negative[i] = -coordinates[i];
+        }
+        return negative;
+    }
+
+    Cartesian3D &Cartesian3D::operator+=(const Cartesian3D &rhs) {
+        for (size_t i = 0; i < 3; i++) {
+            coordinates[i] += rhs[i];
+        }
+        return *this;
+    }
+
+    Cartesian3D vector_product(const Cartesian3D& lhs, const Cartesian3D& rhs) {
+        Cartesian3D product;
+        product[0] = lhs[1] * rhs[2] - lhs[2] * rhs[1];
+        product[1] = lhs[2] * rhs[0] - lhs[0] * rhs[2];
+        product[2] = lhs[0] * rhs[1] - lhs[1] * rhs[0];
+        return product;
+    }
+}
+
+void Cartesian3D::deflect(double cosphi_deflect, double theta_deflect) {
+    if(cosphi_deflect != 1 || theta_deflect != 0)
+    {
+        double sinphi_deflect = std::sqrt( std::max(0., (1. - cosphi_deflect) * (1. + cosphi_deflect) ));
+        double tx = sinphi_deflect * std::cos(theta_deflect);
+        double ty = sinphi_deflect * std::sin(theta_deflect);
+        double tz = std::sqrt(std::max(1. - tx * tx - ty * ty, 0.));
+        if(cosphi_deflect < 0. ){
+            // Backward deflection
+            tz = -tz;
+        }
+
+        double sinth, costh, sinph, cosph;
+        auto spherical = this->GetSphericalCoordinates();
+        sinth = std::sin(spherical[Spherical3D::SphericalCoordinate::Zenith]);
+        costh = std::cos(spherical[Spherical3D::SphericalCoordinate::Zenith]);
+        sinph = std::sin(spherical[Spherical3D::SphericalCoordinate::Azimuth]);
+        cosph = std::cos(spherical[Spherical3D::SphericalCoordinate::Azimuth]);
+
+        auto rotate_vector_x = Cartesian3D(costh * cosph, costh * sinph, -sinth);
+        auto rotate_vector_y = Cartesian3D(-sinph, cosph, 0.);
+
+        // Rotation towards all tree axes
+        for (size_t i = 0; i < 3; i++) {
+            coordinates[i] = tz * coordinates[i] + tx * rotate_vector_x[i] + ty * rotate_vector_y[i];
+        }
+    }
+}
+
+std::array<double, 3> Cartesian3D::GetCartesianCoordinates() const {
+    return coordinates;
+}
+
+std::array<double, 3> Cartesian3D::GetSphericalCoordinates() const {
+    auto r = magnitude();
+
+    if (r == 0)
+        return {0., 0., 0.};
+
+    auto azimuth = std::atan2(coordinates[1], coordinates[0]);
+    auto zenith = std::acos(coordinates[2] / r);
+
+    return {r, azimuth, zenith};
+}
+

--- a/src/PROPOSAL/math/Spherical3D.cxx
+++ b/src/PROPOSAL/math/Spherical3D.cxx
@@ -1,0 +1,49 @@
+#include "PROPOSAL/math/Spherical3D.h"
+#include "PROPOSAL/math/Cartesian3D.h"
+
+using namespace PROPOSAL;
+
+Spherical3D::Spherical3D(const nlohmann::json& config) {
+    if (not config.is_array() or not(config.size() == 3))
+        throw std::invalid_argument("Json array for Spherical3D is not a 3 "
+                                    "component array.");
+
+    if (!config[0].is_number() or !config[1].is_number() or !config[2].is_number())
+        throw std::invalid_argument("Json array for Spherical3D must contain "
+                                    "three numbers (radius, azimuth, theta).");
+
+    for (size_t i = 0; i<3; i++)
+        config[i].get_to(coordinates[i]);
+}
+
+void Spherical3D::print(std::ostream& os) const {
+    os << "radius: " << coordinates[SphericalCoordinate::Radius] << "\t";
+    os << "azimuth: " << coordinates[SphericalCoordinate::Azimuth] << "\t";
+    os << "zenith: " << coordinates[SphericalCoordinate::Zenith] << "\n";
+}
+
+double Spherical3D::magnitude() const {
+    return coordinates[SphericalCoordinate::Radius];
+}
+
+void Spherical3D::normalize() {
+    coordinates[SphericalCoordinate::Radius] = 1.;
+}
+
+std::array<double, 3> Spherical3D::GetSphericalCoordinates() const {
+    return coordinates;
+}
+
+std::array<double, 3> Spherical3D::GetCartesianCoordinates() const {
+    auto cos_a = cos(coordinates[SphericalCoordinate::Azimuth]);
+    auto sin_a = sin(coordinates[SphericalCoordinate::Azimuth]);
+    auto cos_z = cos(coordinates[SphericalCoordinate::Zenith]);
+    auto sin_z = sin(coordinates[SphericalCoordinate::Zenith]);
+    auto r = coordinates[SphericalCoordinate::Radius];
+
+    auto x = r * cos_a * sin_z;
+    auto y = r * sin_a * sin_z;
+    auto z = r * cos_z;
+
+    return {x, y, z};
+}

--- a/src/PROPOSAL/math/Spherical3D.cxx
+++ b/src/PROPOSAL/math/Spherical3D.cxx
@@ -17,17 +17,17 @@ Spherical3D::Spherical3D(const nlohmann::json& config) {
 }
 
 void Spherical3D::print(std::ostream& os) const {
-    os << "radius: " << coordinates[SphericalCoordinate::Radius] << "\t";
-    os << "azimuth: " << coordinates[SphericalCoordinate::Azimuth] << "\t";
-    os << "zenith: " << coordinates[SphericalCoordinate::Zenith] << "\n";
+    os << "radius: " << GetRadius() << "\t";
+    os << "azimuth: " << GetAzimuth() << "\t";
+    os << "zenith: " << GetZenith() << "\n";
 }
 
 double Spherical3D::magnitude() const {
-    return coordinates[SphericalCoordinate::Radius];
+    return GetRadius();
 }
 
 void Spherical3D::normalize() {
-    coordinates[SphericalCoordinate::Radius] = 1.;
+    SetRadius(1.);
 }
 
 std::array<double, 3> Spherical3D::GetSphericalCoordinates() const {
@@ -35,11 +35,11 @@ std::array<double, 3> Spherical3D::GetSphericalCoordinates() const {
 }
 
 std::array<double, 3> Spherical3D::GetCartesianCoordinates() const {
-    auto cos_a = cos(coordinates[SphericalCoordinate::Azimuth]);
-    auto sin_a = sin(coordinates[SphericalCoordinate::Azimuth]);
-    auto cos_z = cos(coordinates[SphericalCoordinate::Zenith]);
-    auto sin_z = sin(coordinates[SphericalCoordinate::Zenith]);
-    auto r = coordinates[SphericalCoordinate::Radius];
+    auto cos_a = cos(GetAzimuth());
+    auto sin_a = sin(GetAzimuth());
+    auto cos_z = cos(GetZenith());
+    auto sin_z = sin(GetZenith());
+    auto r = GetRadius();
 
     auto x = r * cos_a * sin_z;
     auto y = r * sin_a * sin_z;

--- a/src/PROPOSAL/math/Vector3D.cxx
+++ b/src/PROPOSAL/math/Vector3D.cxx
@@ -1,350 +1,43 @@
 
 #include <cmath>
-#include <iostream>
+#include <sstream>
 
-#include "PROPOSAL/Constants.h"
 #include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/methods.h"
 
 using namespace PROPOSAL;
 
-//----------------------------------------------------------------------//
-//------------------------- Constructors -------------------------------//
-//----------------------------------------------------------------------//
-
-// default constructor
-Vector3D::Vector3D()
-    : cartesian_(0, 0, 0)
-    , spherical_(0, 0, 0)
-// , cylindric_radius_  (0)
-// , cylindric_azimuth_ (0)
-// , cylindric_height_  (0)
-{
+void Vector3D::SetCoordinates(double val1, double val2, double val3) {
+    coordinates = {val1, val2, val3};
 }
 
-Vector3D::Vector3D(const double x, const double y, const double z)
-    : cartesian_(x, y, z)
-    , spherical_(0, 0, 0)
-// , cylindric_radius_  (0)
-// , cylindric_azimuth_ (0)
-// , cylindric_height_  (0)
-{
-}
-
-// copy constructor
-Vector3D::Vector3D(const Vector3D& vector_3d)
-    : cartesian_(vector_3d.cartesian_)
-    , spherical_(vector_3d.spherical_)
-// , cylindric_radius_  (vector_3d.cylindric_radius_)
-// , cylindric_azimuth_ (vector_3d.cylindric_azimuth_)
-// , cylindric_height_  (vector_3d.cylindric_height_)
-{
-}
-
-Vector3D::Vector3D(Vector3D&& other)
-    : cartesian_(std::move(other.cartesian_))
-    , spherical_(std::move(other.spherical_))
-{
-}
-
-Vector3D::Vector3D(const nlohmann::json& config)
-    : spherical_(0, 0, 0)
-{
-    if (not config.is_array())
-        throw std::invalid_argument("Vector3D is not a 3 component array.");
-    if (not(config.size() == 3))
-        throw std::invalid_argument("Vector3D is not 3.");
-    if (not config[0].is_number())
-        throw std::invalid_argument("x is not a number");
-    if (not config[1].is_number())
-        throw std::invalid_argument("y is not a number");
-    if (not config[2].is_number())
-        throw std::invalid_argument("z is not a number");
-
-    config[0].get_to(cartesian_.x_);
-    config[1].get_to(cartesian_.y_);
-    config[2].get_to(cartesian_.z_);
-}
-
-// destructor
-Vector3D::~Vector3D() {}
-
-//----------------------------------------------------------------------//
-//-----------------------operator functions and swap--------------------//
-//----------------------------------------------------------------------//
-
-Vector3D& Vector3D::operator=(const Vector3D& vector_3d)
-{
-    if (this != &vector_3d) {
-        Vector3D tmp(vector_3d);
-        swap(tmp);
+bool Vector3D::operator==(const Vector3D& rhs) const {
+    for (size_t i = 0; i<3; i++) {
+        if (coordinates[i] != rhs.coordinates[i] )
+            return false;
     }
-    return *this;
-}
-
-bool Vector3D::operator==(const Vector3D& vector_3d) const
-{
-    if (cartesian_.x_ != vector_3d.cartesian_.x_)
-        return false;
-    else if (cartesian_.y_ != vector_3d.cartesian_.y_)
-        return false;
-    else if (cartesian_.z_ != vector_3d.cartesian_.z_)
-        return false;
-    else if (spherical_.radius_ != vector_3d.spherical_.radius_)
-        return false;
-    else if (spherical_.azimuth_ != vector_3d.spherical_.azimuth_)
-        return false;
-    else if (spherical_.zenith_ != vector_3d.spherical_.zenith_)
-        return false;
-    // else if (cylindric_radius_  != vector_3d.cylindric_radius_)  return
-    // false; else if (cylindric_azimuth_ != vector_3d.cylindric_azimuth_)
-    // return false; else if (cylindric_height_  != vector_3d.cylindric_height_)
-    // return false;
-
     return true;
 }
 
-bool Vector3D::operator!=(const Vector3D& vector_3d) const
-{
-    return !(*this == vector_3d);
+bool Vector3D::operator!=(const Vector3D& rhs) const {
+    return !(*this == rhs);
 }
 
-Vector3D& Vector3D::operator+=(const Vector3D& vector_3d)
-{
-    cartesian_.x_ += vector_3d.cartesian_.x_;
-    cartesian_.y_ += vector_3d.cartesian_.y_;
-    cartesian_.z_ += vector_3d.cartesian_.z_;
-
-    return *this;
+double& Vector3D::operator[](size_t idx) {
+    return coordinates.at(idx);
 }
 
-void Vector3D::swap(Vector3D& vector_3d)
-{
-    using std::swap;
-
-    swap(cartesian_.x_, vector_3d.cartesian_.x_);
-    swap(cartesian_.y_, vector_3d.cartesian_.y_);
-    swap(cartesian_.z_, vector_3d.cartesian_.z_);
-    swap(spherical_.radius_, vector_3d.spherical_.radius_);
-    swap(spherical_.azimuth_, vector_3d.spherical_.azimuth_);
-    swap(spherical_.zenith_, vector_3d.spherical_.zenith_);
-    // swap(cylindric_radius_,  vector_3d.cylindric_radius_);
-    // swap(cylindric_azimuth_, vector_3d.cylindric_azimuth_);
-    // swap(cylindric_height_,  vector_3d.cylindric_height_);
+const double& Vector3D::operator[](size_t idx) const {
+    return coordinates.at(idx);
 }
 
 namespace PROPOSAL {
-std::ostream& operator<<(std::ostream& os, Vector3D const& vector_3d)
-{
-    std::stringstream ss;
-    ss << " Vector3D (" << &vector_3d << ") ";
-    os << Helper::Centered(60, ss.str()) << '\n';
-
-    os << "Cartesian Coordinates (x[cm],y[cm],z[cm]):\n"
-       << vector_3d.cartesian_.x_ << "\t" << vector_3d.cartesian_.y_ << "\t"
-       << vector_3d.cartesian_.z_ << std::endl;
-    os << "Spherical Coordinates (radius[cm],azimut[rad],zenith[rad]):\n"
-       << vector_3d.spherical_.radius_ << "\t" << vector_3d.spherical_.azimuth_
-       << "\t" << vector_3d.spherical_.zenith_ << std::endl;
-    // os<<"\tCylindrical Coordinates
-    // (radius,azimut,height):\t"<<vector_3d.cylindric_radius_<<"\t"<<vector_3d.cylindric_azimuth_<<"\t"<<vector_3d.cylindric_height_<<std::endl;
-
-    os << Helper::Centered(60, "");
-    return os;
-}
-} // namespace PROPOSAL
-
-//----------------------------------------------------------------------//
-//-----------------------operator basic arithmetic ---------------------//
-//----------------------------------------------------------------------//
-
-namespace PROPOSAL {
-
-Vector3D operator+(const Vector3D& vec1, const Vector3D& vec2)
-{
-    Vector3D vector_sum;
-    vector_sum.cartesian_.x_ = vec1.cartesian_.x_ + vec2.cartesian_.x_;
-    vector_sum.cartesian_.y_ = vec1.cartesian_.y_ + vec2.cartesian_.y_;
-    vector_sum.cartesian_.z_ = vec1.cartesian_.z_ + vec2.cartesian_.z_;
-    return vector_sum;
-}
-
-Vector3D operator-(const Vector3D& vec1, const Vector3D& vec2)
-{
-    Vector3D vector_diff;
-    vector_diff.cartesian_.x_ = vec1.cartesian_.x_ - vec2.cartesian_.x_;
-    vector_diff.cartesian_.y_ = vec1.cartesian_.y_ - vec2.cartesian_.y_;
-    vector_diff.cartesian_.z_ = vec1.cartesian_.z_ - vec2.cartesian_.z_;
-    return vector_diff;
-}
-
-Vector3D operator*(const double factor1, const Vector3D& vec1)
-{
-    Vector3D product;
-    product.cartesian_.x_ = factor1 * vec1.cartesian_.x_;
-    product.cartesian_.y_ = factor1 * vec1.cartesian_.y_;
-    product.cartesian_.z_ = factor1 * vec1.cartesian_.z_;
-    return product;
-}
-
-Vector3D operator*(const Vector3D& vec1, const double factor1)
-{
-    Vector3D product;
-    product.cartesian_.x_ = factor1 * vec1.cartesian_.x_;
-    product.cartesian_.y_ = factor1 * vec1.cartesian_.y_;
-    product.cartesian_.z_ = factor1 * vec1.cartesian_.z_;
-    return product;
-}
-
-double operator*(const Vector3D& vec1, const Vector3D& vec2)
-{
-    return scalar_product(vec1, vec2);
-}
-
-double scalar_product(const Vector3D& vec1, const Vector3D& vec2)
-{
-    return vec1.cartesian_.x_ * vec2.cartesian_.x_
-        + vec1.cartesian_.y_ * vec2.cartesian_.y_
-        + vec1.cartesian_.z_ * vec2.cartesian_.z_;
-}
-
-Vector3D vector_product(const Vector3D& vec1, const Vector3D& vec2)
-{
-    Vector3D product;
-    product.cartesian_.x_ = vec1.cartesian_.y_ * vec2.cartesian_.z_
-        - vec1.cartesian_.z_ * vec2.cartesian_.y_;
-    product.cartesian_.y_ = vec1.cartesian_.z_ * vec2.cartesian_.x_
-        - vec1.cartesian_.x_ * vec2.cartesian_.z_;
-    product.cartesian_.z_ = vec1.cartesian_.x_ * vec2.cartesian_.y_
-        - vec1.cartesian_.y_ * vec2.cartesian_.x_;
-    return product;
-}
-
-} // namespace PROPOSAL
-
-Vector3D Vector3D::operator-() const
-{
-    Vector3D vector_3d;
-    vector_3d.cartesian_.x_ = -cartesian_.x_;
-    vector_3d.cartesian_.y_ = -cartesian_.y_;
-    vector_3d.cartesian_.z_ = -cartesian_.z_;
-    return vector_3d;
-}
-
-double Vector3D::magnitude() const
-{
-    return std::sqrt(cartesian_.x_ * cartesian_.x_
-        + cartesian_.y_ * cartesian_.y_ + cartesian_.z_ * cartesian_.z_);
-}
-
-void Vector3D::normalise()
-{
-    double length = std::sqrt(cartesian_.x_ * cartesian_.x_
-        + cartesian_.y_ * cartesian_.y_ + cartesian_.z_ * cartesian_.z_);
-    cartesian_.x_ = cartesian_.x_ / length;
-    cartesian_.y_ = cartesian_.y_ / length;
-    cartesian_.z_ = cartesian_.z_ / length;
-    spherical_.radius_ = 1;
-}
-
-void Vector3D::deflect(double cosphi_deflect, double theta_deflect) {
-    if (cosphi_deflect != 1. || theta_deflect != 0.) {
-        CalculateSphericalCoordinates();
-        double sinphi_deflect = std::sqrt(
-                std::max(0., (1. - cosphi_deflect) * (1. + cosphi_deflect)));
-        double tx = sinphi_deflect * std::cos(theta_deflect);
-        double ty = sinphi_deflect * std::sin(theta_deflect);
-        double tz = std::sqrt(std::max(1. - tx * tx - ty * ty, 0.));
-        if (cosphi_deflect < 0.)
-            tz = -tz; // Backward deflection
-
-        auto spherical = GetSphericalCoordinates();
-        auto sinth = std::sin(spherical.zenith_);
-        auto costh = std::cos(spherical.zenith_);
-        auto sinph = std::sin(spherical.azimuth_);
-        auto cosph = std::cos(spherical.azimuth_);
-
-        // Rotation towards all tree axes
-        cartesian_.x_ = tz * cartesian_.x_ + tx * costh * cosph - ty * sinph;
-        cartesian_.y_ = tz * cartesian_.y_ + tx * costh * sinph + ty * cosph;
-        cartesian_.z_ = tz * cartesian_.z_ - tx * sinth;
-
-        CalculateSphericalCoordinates();
+    std::ostream &operator<<(std::ostream &os, const Vector3D &vector) {
+        std::stringstream ss;
+        ss << " Vector3D (" << &vector << ") ";
+        os << Helper::Centered(60, ss.str()) << '\n';
+        vector.print(os);
+        os << Helper::Centered(60, "");
+        return os;
     }
-}
-
-
-//----------------------------------------------------------------------//
-//---------------Spherical and cylindrical coordinates------------------//
-//----------------------------------------------------------------------//
-
-void Vector3D::CalculateCartesianFromSpherical()
-{
-    cartesian_.x_ = spherical_.radius_ * std::cos(spherical_.azimuth_)
-        * std::sin(spherical_.zenith_);
-    cartesian_.y_ = spherical_.radius_ * std::sin(spherical_.azimuth_)
-        * std::sin(spherical_.zenith_);
-    cartesian_.z_ = spherical_.radius_ * std::cos(spherical_.zenith_);
-}
-
-void Vector3D::CalculateSphericalCoordinates()
-{
-    spherical_.radius_ = std::sqrt(cartesian_.x_ * cartesian_.x_
-        + cartesian_.y_ * cartesian_.y_ + cartesian_.z_ * cartesian_.z_);
-    spherical_.azimuth_ = std::atan2(cartesian_.y_, cartesian_.x_);
-    if (spherical_.radius_ > 0.) {
-        spherical_.zenith_ = std::acos(cartesian_.z_ / spherical_.radius_);
-    } else if (spherical_.radius_ == 0.) {
-        // log_warn("If the radius is zero, the zenith is not defined! Zero is
-        // returned!");
-        spherical_.zenith_ = 0.;
-    } else {
-        // log_fatal("The radius is negativ, which is not possible!");
-    }
-}
-
-// void Vector3D::CalculateCartesianFromCylindrical()
-// {
-//     x_ = cylindric_radius_*std::cos(cylindric_azimuth_);
-//     y_ = cylindric_radius_*std::sin(cylindric_azimuth_);
-//     z_ = cylindric_height_;
-// }
-
-// void Vector3D::CalculateZylindricalCoordinates()
-// {
-//     cylindric_radius_  = std::sqrt(x_*x_ + y_*y_);
-//     cylindric_azimuth_ = std::atan2(y_, x_);
-//     cylindric_height_  = z_;
-// }
-
-Vector3D::CartesianCoordinates::CartesianCoordinates(
-    double x, double y, double z)
-    : x_(x)
-    , y_(y)
-    , z_(z)
-{
-}
-
-Vector3D::CartesianCoordinates::CartesianCoordinates(
-    const CartesianCoordinates& coordinates)
-    : x_(coordinates.x_)
-    , y_(coordinates.y_)
-    , z_(coordinates.z_)
-{
-}
-
-Vector3D::SphericalCoordinates::SphericalCoordinates(
-    double radius, double azimuth, double zenith)
-    : radius_(radius)
-    , azimuth_(azimuth)
-    , zenith_(zenith)
-{
-}
-
-Vector3D::SphericalCoordinates::SphericalCoordinates(
-    const SphericalCoordinates& coordinates)
-    : radius_(coordinates.radius_)
-    , azimuth_(coordinates.azimuth_)
-    , zenith_(coordinates.zenith_)
-{
 }

--- a/src/PROPOSAL/particle/Particle.cxx
+++ b/src/PROPOSAL/particle/Particle.cxx
@@ -131,18 +131,21 @@ double ParticleState::GetMomentum() const
 StochasticLoss::StochasticLoss(int type, double loss_energy, const Vector3D& position,
                                const Vector3D& direction, double time,
                                double propagated_distance,
-                               double parent_particle_energy) : Loss(type, loss_energy),
+                               double parent_particle_energy)
+                               : Loss(type, loss_energy, parent_particle_energy),
                                position(position), direction(direction), time(time),
-                               propagated_distance(propagated_distance),
-                               parent_particle_energy(parent_particle_energy) {}
+                               propagated_distance(propagated_distance) {}
 
-ContinuousLoss::ContinuousLoss(std::pair<double, double> energies,
-                               std::pair<const Vector3D&, const Vector3D&> positions,
-                               std::pair<const Vector3D&, const Vector3D&> directions,
-                               std::pair<double, double> times)
+ContinuousLoss::ContinuousLoss(double energy, double parent_particle_energy,
+                               const Vector3D& start_position, double length,
+                               const Vector3D& direction_initial,
+                               const Vector3D& direction_final,
+                               double time_initial, double time_final)
                                : Loss((int)InteractionType::ContinuousEnergyLoss,
-                                      std::abs(energies.second - energies.first)),
-                                      energies(energies),
-                                      positions(positions),
-                                      directions(directions),
-                                      times(times) {}
+                                      energy, parent_particle_energy),
+                                      start_position(start_position),
+                                      length(length),
+                                      direction_initial(direction_initial),
+                                      direction_final(direction_final),
+                                      time_initial(time_initial),
+                                      time_final(time_final) {}

--- a/src/PROPOSAL/particle/Particle.cxx
+++ b/src/PROPOSAL/particle/Particle.cxx
@@ -12,6 +12,7 @@
 #include "PROPOSAL/particle/ParticleDef.h"
 #include <cmath>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 using namespace PROPOSAL;
@@ -43,8 +44,8 @@ std::ostream& operator<<(std::ostream& os, ParticleState const& data)
 
 ParticleState::ParticleState()
     : type(0)
-    , position(Vector3D())
-    , direction(Vector3D())
+    , position(Cartesian3D())
+    , direction(Cartesian3D())
     , energy(0)
     , time(0)
     , propagated_distance(0)
@@ -127,8 +128,8 @@ double ParticleState::GetMomentum() const
     return energy;
 }
 
-StochasticLoss::StochasticLoss(int type, double loss_energy, Vector3D position,
-                               Vector3D direction, double time,
+StochasticLoss::StochasticLoss(int type, double loss_energy, const Vector3D& position,
+                               const Vector3D& direction, double time,
                                double propagated_distance,
                                double parent_particle_energy) : Loss(type, loss_energy),
                                position(position), direction(direction), time(time),
@@ -136,8 +137,8 @@ StochasticLoss::StochasticLoss(int type, double loss_energy, Vector3D position,
                                parent_particle_energy(parent_particle_energy) {}
 
 ContinuousLoss::ContinuousLoss(std::pair<double, double> energies,
-                               std::pair<Vector3D, Vector3D> positions,
-                               std::pair<Vector3D, Vector3D> directions,
+                               std::pair<const Vector3D&, const Vector3D&> positions,
+                               std::pair<const Vector3D&, const Vector3D&> directions,
                                std::pair<double, double> times)
                                : Loss((int)InteractionType::ContinuousEnergyLoss,
                                       std::abs(energies.second - energies.first)),

--- a/src/PROPOSAL/propagation_utility/PropagationUtility.cxx
+++ b/src/PROPOSAL/propagation_utility/PropagationUtility.cxx
@@ -151,17 +151,17 @@ std::tuple<Cartesian3D, Cartesian3D> PropagationUtility::DirectionsScatter(
         auto sz = std::sqrt(std::max(1. - (sx * sx + sy * sy), 0.));
         auto tz = std::sqrt(std::max(1. - (tx * tx + ty * ty), 0.));
 
-        auto direction_spherical = direction.GetSphericalCoordinates();
-        auto sinth = std::sin(direction_spherical[Spherical3D::SphericalCoordinate::Zenith]);
-        auto costh = std::cos(direction_spherical[Spherical3D::SphericalCoordinate::Zenith]);
-        auto sinph = std::sin(direction_spherical[Spherical3D::SphericalCoordinate::Azimuth]);
-        auto cosph = std::cos(direction_spherical[Spherical3D::SphericalCoordinate::Azimuth]);
+        auto direction_spherical = Spherical3D(direction);
+        auto sinth = std::sin(direction_spherical.GetZenith());
+        auto costh = std::cos(direction_spherical.GetZenith());
+        auto sinph = std::sin(direction_spherical.GetAzimuth());
+        auto cosph = std::cos(direction_spherical.GetAzimuth());
 
         auto rotate_vector_x = Cartesian3D(costh * cosph, costh * sinph, -sinth);
         auto rotate_vector_y = Cartesian3D(-sinph, cosph, 0.);
 
         // Rotation towards all tree axes
-        auto direction_cartesian = Cartesian3D(direction.GetCartesianCoordinates());
+        auto direction_cartesian = Cartesian3D(direction);
         auto mean_direction = sz * direction_cartesian;
         mean_direction += sx * rotate_vector_x;
         mean_direction += sy * rotate_vector_y;

--- a/src/PROPOSAL/propagation_utility/PropagationUtility.cxx
+++ b/src/PROPOSAL/propagation_utility/PropagationUtility.cxx
@@ -1,6 +1,7 @@
 
 #include "PROPOSAL/propagation_utility/PropagationUtility.h"
 #include "PROPOSAL/crosssection/CrossSection.h"
+#include "PROPOSAL/math/Spherical3D.h"
 #include "PROPOSAL/math/MathMethods.h"
 
 using namespace PROPOSAL;
@@ -132,7 +133,7 @@ double PropagationUtility::TimeElapsed(
         initial_energy, final_energy, distance, density);
 }
 
-std::tuple<Vector3D, Vector3D> PropagationUtility::DirectionsScatter(
+std::tuple<Cartesian3D, Cartesian3D> PropagationUtility::DirectionsScatter(
     double displacement, double initial_energy, double final_energy,
     const Vector3D& direction, std::function<double()> rnd)
 {
@@ -150,34 +151,34 @@ std::tuple<Vector3D, Vector3D> PropagationUtility::DirectionsScatter(
         auto sz = std::sqrt(std::max(1. - (sx * sx + sy * sy), 0.));
         auto tz = std::sqrt(std::max(1. - (tx * tx + ty * ty), 0.));
 
-        auto sinth = std::sin(direction.GetTheta());
-        auto costh = std::cos(direction.GetTheta());
-        auto sinph = std::sin(direction.GetPhi());
-        auto cosph = std::cos(direction.GetPhi());
+        auto direction_spherical = direction.GetSphericalCoordinates();
+        auto sinth = std::sin(direction_spherical[Spherical3D::SphericalCoordinate::Zenith]);
+        auto costh = std::cos(direction_spherical[Spherical3D::SphericalCoordinate::Zenith]);
+        auto sinph = std::sin(direction_spherical[Spherical3D::SphericalCoordinate::Azimuth]);
+        auto cosph = std::cos(direction_spherical[Spherical3D::SphericalCoordinate::Azimuth]);
 
-        auto rotate_vector_x
-            = PROPOSAL::Vector3D(costh * cosph, costh * sinph, -sinth);
-        auto rotate_vector_y = PROPOSAL::Vector3D(-sinph, cosph, 0.);
+        auto rotate_vector_x = Cartesian3D(costh * cosph, costh * sinph, -sinth);
+        auto rotate_vector_y = Cartesian3D(-sinph, cosph, 0.);
 
         // Rotation towards all tree axes
-        auto mean_direction = sz * direction;
+        auto direction_cartesian = Cartesian3D(direction.GetCartesianCoordinates());
+        auto mean_direction = sz * direction_cartesian;
         mean_direction += sx * rotate_vector_x;
         mean_direction += sy * rotate_vector_y;
-        mean_direction.CalculateSphericalCoordinates();
 
         // Rotation towards all tree axes
-        auto final_direction = tz * direction;
+        auto final_direction = tz * direction_cartesian;
         final_direction += tx * rotate_vector_x;
         final_direction += ty * rotate_vector_y;
-        final_direction.CalculateSphericalCoordinates();
 
         return std::make_tuple(mean_direction, final_direction);
     }
-    return std::make_tuple(direction, direction); // no scattering
+    auto dir = Cartesian3D(direction.GetCartesianCoordinates());
+    return std::make_tuple(dir, dir); // no scattering
 }
 
-Vector3D PropagationUtility::DirectionDeflect(InteractionType type,
-    double initial_energy, double final_energy, Vector3D direction,
+Cartesian3D PropagationUtility::DirectionDeflect(InteractionType type,
+    double initial_energy, double final_energy, const Vector3D& direction,
     std::function<double()> rnd) const
 {
     if (collection.scattering) {
@@ -187,7 +188,8 @@ Vector3D PropagationUtility::DirectionDeflect(InteractionType type,
             r = rnd();
         auto angles = collection.scattering->CalculateStochasticDeflection(
             type, initial_energy, final_energy, v_rnd);
-        direction.deflect(std::cos(angles[0]), angles[1]);
+        auto direction_new = Cartesian3D(direction);
+        direction_new.deflect(std::cos(angles[0]), angles[1]);
     }
     return direction;
 }

--- a/src/PROPOSAL/scattering/multiple_scattering/Parametrization.cxx
+++ b/src/PROPOSAL/scattering/multiple_scattering/Parametrization.cxx
@@ -9,6 +9,10 @@
 
 #include <cmath>
 #include <tuple>
+#include <string>
+#include <sstream>
+#include <iostream>
+
 
 #include "PROPOSAL/methods.h"
 #include "PROPOSAL/scattering/multiple_scattering/Parametrization.h"

--- a/src/PROPOSAL/secondaries/parametrization/annihilation/SingleDifferentialAnnihilation.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/annihilation/SingleDifferentialAnnihilation.cxx
@@ -27,9 +27,9 @@ double secondaries::SingleDifferentialAnnihilation::CalculateRho(
     throw std::out_of_range(s.str());
 }
 
-std::tuple<Vector3D, Vector3D>
+std::tuple<Cartesian3D, Cartesian3D>
 secondaries::SingleDifferentialAnnihilation::CalculateDirections(
-    Vector3D primary_dir, double energy, double rho, double rnd)
+    const Vector3D& primary_dir, double energy, double rho, double rnd)
 {
     auto com_energy = energy + ME; // center of mass energy
     auto kin_energy = energy - ME; // kinetic energy
@@ -38,8 +38,8 @@ secondaries::SingleDifferentialAnnihilation::CalculateDirections(
     auto cosphi1
         = (com_energy * rho - ME) / (rho * sqrt(com_energy * kin_energy));
     auto rnd_theta = rnd * 2. * PI;
-    auto dir_1 = primary_dir;
-    auto dir_2 = primary_dir;
+    auto dir_1 = Cartesian3D(primary_dir);
+    auto dir_2 = Cartesian3D(primary_dir);
     dir_1.deflect(cosphi0, rnd_theta);
     dir_2.deflect(cosphi1, fmod(rnd_theta + PI, 2. * PI));
     return make_tuple(dir_1, dir_2);

--- a/src/PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.cxx
@@ -11,7 +11,7 @@ std::vector<ParticleState> secondaries::NaivBremsstrahlung::CalculateSecondaries
     StochasticLoss loss, const Component&, std::vector<double>&)
 {
     auto primary_lepton = ParticleState();
-    primary_lepton.energy = loss.parent_particle_energy - loss.loss_energy;
+    primary_lepton.energy = loss.parent_particle_energy - loss.energy;
     primary_lepton.type = primary_lepton_type;
     primary_lepton.time = loss.time;
     primary_lepton.position = loss.position;
@@ -19,7 +19,7 @@ std::vector<ParticleState> secondaries::NaivBremsstrahlung::CalculateSecondaries
     primary_lepton.propagated_distance = 0.;
 
     auto brems_photon = ParticleState();
-    brems_photon.energy = loss.loss_energy;
+    brems_photon.energy = loss.energy;
     brems_photon.SetType(PROPOSAL::ParticleType::Gamma);
     brems_photon.time = loss.time;
     brems_photon.position = loss.position;

--- a/src/PROPOSAL/secondaries/parametrization/compton/NaivCompton.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/compton/NaivCompton.cxx
@@ -38,10 +38,10 @@ std::tuple<double, double> secondaries::NaivCompton::CalculateEnergy(
 std::vector<ParticleState> secondaries::NaivCompton::CalculateSecondaries(
         StochasticLoss loss, const Component&, std::vector<double> &rnd)
 {
-    auto v = loss.loss_energy /  loss.parent_particle_energy;
+    auto v = loss.energy /  loss.parent_particle_energy;
     auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, v);
-    auto secondary_dir = CalculateDirections(loss.direction, loss.loss_energy,
-                                             v, rnd[1]);
+    auto secondary_dir = CalculateDirections(loss.direction, loss.energy, v,
+                                             rnd[1]);
 
     auto sec = std::vector<ParticleState>();
     sec.emplace_back(ParticleType::Gamma, loss.position,

--- a/src/PROPOSAL/secondaries/parametrization/compton/NaivCompton.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/compton/NaivCompton.cxx
@@ -12,8 +12,8 @@ double secondaries::NaivCompton::CalculateRho(
     return loss_energy / primary_energy;
 }
 
-std::tuple<Vector3D, Vector3D> secondaries::NaivCompton::CalculateDirections(
-    Vector3D primary_dir, double energy, double v, double rnd)
+std::tuple<Cartesian3D, Cartesian3D> secondaries::NaivCompton::CalculateDirections(
+    const Vector3D& primary_dir, double energy, double v, double rnd)
 {
     auto com_energy = energy + ME; // center of mass energy
     auto kin_energy = energy;      // kinetic energy
@@ -22,9 +22,9 @@ std::tuple<Vector3D, Vector3D> secondaries::NaivCompton::CalculateDirections(
     auto cosphi_electron
         = (com_energy * v - ME) / (v * std::sqrt(com_energy * kin_energy));
     auto rnd_theta = rnd * 2. * PI;
-    auto dir_gamma = primary_dir;
+    auto dir_gamma = Cartesian3D(primary_dir);
     dir_gamma.deflect(cosphi_gamma, rnd_theta);
-    auto dir_electron = primary_dir;
+    auto dir_electron = Cartesian3D(primary_dir);
     dir_electron.deflect(cosphi_electron, std::fmod(rnd_theta + PI, 2. * PI));
     return std::make_tuple(dir_gamma, dir_electron);
 }

--- a/src/PROPOSAL/secondaries/parametrization/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
@@ -61,16 +61,16 @@ std::vector<ParticleState>
 secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateSecondaries(
         StochasticLoss loss, const Component& comp, std::vector<double> &rnd)
 {
-    auto v = loss.loss_energy / loss.parent_particle_energy;
+    auto v = loss.energy / loss.parent_particle_energy;
     auto rho = CalculateRho(loss.parent_particle_energy, v, comp, rnd[0], rnd[1]);
-    auto secondary_energies = CalculateEnergy(loss.loss_energy, rho);
-    auto secondary_dir = CalculateDirections(loss.direction, loss.loss_energy,
+    auto secondary_energies = CalculateEnergy(loss.energy, rho);
+    auto secondary_dir = CalculateDirections(loss.direction, loss.energy,
                                              rho, rnd[2]);
 
     auto sec = std::vector<ParticleState>();
     sec.emplace_back(static_cast<const ParticleType>(p_def.particle_type),
                      loss.position, loss.direction,
-                     loss.parent_particle_energy - loss.loss_energy, loss.time,
+                     loss.parent_particle_energy - loss.energy, loss.time,
                      loss.propagated_distance);
 
     sec.emplace_back(ParticleType::EMinus, loss.position, get<0>(secondary_dir),

--- a/src/PROPOSAL/secondaries/parametrization/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/epairproduction/KelnerKokoulinPetrukhinEpairProduction.cxx
@@ -41,11 +41,11 @@ double secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateRho(
     }
 }
 
-std::tuple<Vector3D, Vector3D>
+std::tuple<Cartesian3D, Cartesian3D>
 secondaries::KelnerKokoulinPetrukhinEpairProduction::CalculateDirections(
-        Vector3D primary_dir, double, double, double)
+        const Vector3D& primary_dir, double, double, double)
 {
-    return make_tuple(primary_dir, primary_dir);
+    return make_tuple(Cartesian3D(primary_dir), Cartesian3D(primary_dir));
 }
 
 std::tuple<double, double>

--- a/src/PROPOSAL/secondaries/parametrization/ionization/NaivIonization.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/ionization/NaivIonization.cxx
@@ -28,9 +28,9 @@ std::tuple<double, double> secondaries::NaivIonization::CalculateEnergy(
 std::vector<ParticleState> secondaries::NaivIonization::CalculateSecondaries(
     StochasticLoss loss, const Component&, std::vector<double> &rnd)
 {
-    auto v = loss.loss_energy / loss.parent_particle_energy;
+    auto v = loss.energy / loss.parent_particle_energy;
     auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, v);
-    auto secondary_dir = CalculateDirections( loss.direction, loss.loss_energy,
+    auto secondary_dir = CalculateDirections( loss.direction, loss.energy,
                                               v, rnd[1]);
 
     auto sec = std::vector<ParticleState>();

--- a/src/PROPOSAL/secondaries/parametrization/ionization/NaivIonization.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/ionization/NaivIonization.cxx
@@ -13,10 +13,10 @@ using namespace PROPOSAL;
 
 
 
-std::tuple<Vector3D, Vector3D> secondaries::NaivIonization::CalculateDirections(
-    Vector3D dir, double, double, double)
+std::tuple<Cartesian3D, Cartesian3D> secondaries::NaivIonization::CalculateDirections(
+    const Vector3D& dir, double, double, double)
 {
-    return make_tuple(dir, dir);
+    return make_tuple(Cartesian3D(dir), Cartesian3D(dir));
 }
 
 std::tuple<double, double> secondaries::NaivIonization::CalculateEnergy(

--- a/src/PROPOSAL/secondaries/parametrization/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.cxx
@@ -56,17 +56,17 @@ vector<ParticleState>
 secondaries::KelnerKokoulinPetrukhinMupairProduction::CalculateSecondaries(
     StochasticLoss loss, const Component& comp, vector<double> &rnd)
 {
-    auto v = loss.loss_energy / loss.parent_particle_energy;
+    auto v = loss.energy / loss.parent_particle_energy;
     auto rho = CalculateRho(loss.parent_particle_energy, v, comp, rnd[0], rnd[1]);
-    auto secondary_energies = CalculateEnergy(loss.loss_energy, rho);
+    auto secondary_energies = CalculateEnergy(loss.energy, rho);
     auto secondary_dir = CalculateDirections(
-        loss.direction, loss.loss_energy, rho, rnd[2]);
+        loss.direction, loss.energy, rho, rnd[2]);
 
     auto sec = std::vector<ParticleState>();
 
     sec.emplace_back(static_cast<ParticleType>(p_def.particle_type),
                      loss.position, loss.direction,
-                     loss.parent_particle_energy - loss.loss_energy,
+                     loss.parent_particle_energy - loss.energy,
                      loss.time, loss.propagated_distance);
 
     sec.emplace_back(ParticleType::MuMinus, loss.position, get<0>(secondary_dir),

--- a/src/PROPOSAL/secondaries/parametrization/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/mupairproduction/KelnerKokoulinPetrukhinMupairProduction.cxx
@@ -36,11 +36,11 @@ double secondaries::KelnerKokoulinPetrukhinMupairProduction::CalculateRho(
     }
 }
 
-tuple<Vector3D, Vector3D>
+tuple<Cartesian3D, Cartesian3D>
 secondaries::KelnerKokoulinPetrukhinMupairProduction::CalculateDirections(
-    Vector3D primary_dir, double, double, double)
+    const Vector3D& primary_dir, double, double, double)
 {
-    return make_tuple(primary_dir, primary_dir);
+    return make_tuple(Cartesian3D(primary_dir), Cartesian3D(primary_dir));
 }
 
 tuple<double, double>

--- a/src/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoTsai.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoTsai.cxx
@@ -123,8 +123,8 @@ double secondaries::PhotoTsai::CalculateRho(
     throw std::out_of_range(s.str());
 }
 
-std::tuple<Vector3D, Vector3D> secondaries::PhotoTsai::CalculateDirections(
-    Vector3D dir, double energy, double rho, const Component& comp,
+std::tuple<Cartesian3D, Cartesian3D> secondaries::PhotoTsai::CalculateDirections(
+    const Vector3D& dir, double energy, double rho, const Component& comp,
     std::vector<double> rnd)
 {
     auto subst = std::max(1., std::log10(energy));
@@ -147,9 +147,9 @@ std::tuple<Vector3D, Vector3D> secondaries::PhotoTsai::CalculateDirections(
         cosphi0 *= (-1);
     if (cosphi1 == -1.)
         cosphi1 *= (-1);
-    auto dir_0 = dir;
+    auto dir_0 = Cartesian3D(dir);
     dir_0.deflect(cosphi0, theta0);
-    auto dir_1 = dir;
+    auto dir_1 = Cartesian3D(dir);
     dir_1.deflect(cosphi1, theta1);
     return make_tuple(dir_0, dir_1);
 }

--- a/src/PROPOSAL/secondaries/parametrization/weakinteraction/NaivWeakInteraction.cxx
+++ b/src/PROPOSAL/secondaries/parametrization/weakinteraction/NaivWeakInteraction.cxx
@@ -15,7 +15,7 @@ secondaries::NaivWeakInteraction::CalculateSecondaries(StochasticLoss loss,
     // TODO: Treatment of hadronic parts of interaction
     auto sec = std::vector<ParticleState>();
     sec.emplace_back(static_cast<ParticleType>(weak_partner_type),
-                     loss.position, loss.direction, loss.loss_energy, loss.time,
+                     loss.position, loss.direction, loss.energy, loss.time,
                      0.);
     return sec;
 }

--- a/tests/DecayChannel_TEST.cxx
+++ b/tests/DecayChannel_TEST.cxx
@@ -183,8 +183,8 @@ TEST(DecaySpectrum, MuMinus_Rest){
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0.;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
@@ -236,8 +236,8 @@ TEST(DecaySpectrum, MuMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
@@ -294,8 +294,8 @@ TEST(DecaySpectrum, MuMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
@@ -384,8 +384,8 @@ TEST(DecaySpectrum, MuMinus_Energy){
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
@@ -438,8 +438,8 @@ TEST(DecaySpectrum, MuMinus_Energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
@@ -496,8 +496,8 @@ TEST(DecaySpectrum, MuMinus_Energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
@@ -585,8 +585,8 @@ TEST(DecaySpectrum, TauMinus_Rest){
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
@@ -638,8 +638,8 @@ TEST(DecaySpectrum, TauMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
@@ -696,8 +696,8 @@ TEST(DecaySpectrum, TauMinus_Rest){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);
@@ -786,8 +786,8 @@ TEST(DecaySpectrum, TauMinus_energy){
     double max_energy = gamma * v_max + betagamma * std::sqrt( std::pow(v_max, 2) - std::pow(p0.mass,2));
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = lep_approx.Decay(init_particle_def, init_particle);
@@ -839,8 +839,8 @@ TEST(DecaySpectrum, TauMinus_energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = lep.Decay(init_particle_def, init_particle);
@@ -897,8 +897,8 @@ TEST(DecaySpectrum, TauMinus_energy){
     std::fill(prod_2.begin(), prod_2.end(), 0);
 
     for(int i=0; i<statistic; i++){
-        init_particle.direction = Vector3D(0, 0, -1);
-        init_particle.position = Vector3D(0, 0, -1);
+        init_particle.direction = Cartesian3D(0, 0, -1);
+        init_particle.position = Cartesian3D(0, 0, -1);
         init_particle.energy = init_energy;
         init_particle.propagated_distance = 0;
         auto aux = many_body.Decay(init_particle_def, init_particle);

--- a/tests/Density_distribution_TEST.cxx
+++ b/tests/Density_distribution_TEST.cxx
@@ -42,10 +42,10 @@ TEST(Comparison, Comparison_equal)
 
 TEST(Comparison, Comparison_not_equal)
 {
-    Vector3D faxis_default(1,0,0);
-    Vector3D faxis_new(0,1,0);
-    Vector3D fp0_default(0,0,0);
-    Vector3D fp0_new(1,1,1);
+    Cartesian3D faxis_default(1,0,0);
+    Cartesian3D faxis_new(0,1,0);
+    Cartesian3D fp0_default(0,0,0);
+    Cartesian3D fp0_new(1,1,1);
     CartesianAxis ax_A;
     CartesianAxis ax_B(faxis_default, fp0_new);
     CartesianAxis ax_C(faxis_new, fp0_default);

--- a/tests/Geometry_TEST.cxx
+++ b/tests/Geometry_TEST.cxx
@@ -11,10 +11,11 @@
 #include "PROPOSAL/geometry/Geometry.h"
 #include "PROPOSAL/geometry/Sphere.h"
 #include "PROPOSAL/math/RandomGenerator.h"
+#include "PROPOSAL/math/Spherical3D.h"
 
 using namespace PROPOSAL;
 
-Vector3D posi = Vector3D(0,0,0);
+Cartesian3D posi = Cartesian3D(0,0,0);
 double rad_i = 0;
 double rad_o = 1e3;
 double x_len = 1;
@@ -63,7 +64,7 @@ TEST(Assignment, Copyconstructor)
 
     EXPECT_FALSE(*C == *D);
 
-    auto E = std::make_shared<Sphere>(Vector3D(1.0, 0.0, 0.0), 20.0, 10.0);
+    auto E = std::make_shared<Sphere>(Cartesian3D(1.0, 0.0, 0.0), 20.0, 10.0);
     auto F = ::std::make_shared<Sphere>(posi, rad_o, rad_i);
 
     *F = *E;
@@ -82,7 +83,7 @@ TEST(Assignment, Copyconstructor2)
 TEST(Assignment, Operator)
 {
     Sphere A(posi, rad_o, rad_i);
-    Sphere B(Vector3D(0.0, 0.0, 0.0), 2.0, 1.0);
+    Sphere B(Cartesian3D(0.0, 0.0, 0.0), 2.0, 1.0);
 
     EXPECT_TRUE(A != B);
 
@@ -94,9 +95,8 @@ TEST(Assignment, Operator)
 TEST(DistanceToClosestApproach, Method)
 {
     Sphere A(posi, rad_o, rad_i);
-    Vector3D position = Vector3D(1, -1, 0);
-    Vector3D direction = Vector3D(0, 1, 0);
-    direction.CalculateSphericalCoordinates();
+    Cartesian3D position = Cartesian3D(1, -1, 0);
+    Cartesian3D direction = Cartesian3D(0, 1, 0);
 
     double distance_closest_approach = A.DistanceToClosestApproach(position, direction);
 
@@ -105,8 +105,8 @@ TEST(DistanceToClosestApproach, Method)
 
 TEST(IsInside, Box)
 {
-    Vector3D particle_position(0, 0, 0);
-    Vector3D particle_direction(0, 0, 0);
+    Cartesian3D particle_position(0, 0, 0);
+    Spherical3D particle_direction(0, 0, 0);
 
     double rnd_x;
     double rnd_y;
@@ -127,7 +127,7 @@ TEST(IsInside, Box)
     double big_width_y = 4 * width_y;
     double big_height  = 4 * height;
 
-    Vector3D position_geometry(0, 0, 0);
+    Cartesian3D position_geometry(0, 0, 0);
 
     int is_inside  = 0;
     int is_outside = 0;
@@ -148,9 +148,9 @@ TEST(IsInside, Box)
         rnd_y0 = RandomGenerator::Get().RandomDouble();
         rnd_z0 = RandomGenerator::Get().RandomDouble();
 
-        position_geometry.SetCartesianCoordinates((2 * rnd_x0 - 1) * 0.5 * (big_width_x - width_x),
-                                                  (2 * rnd_y0 - 1) * 0.5 * (big_width_y - width_y),
-                                                  (2 * rnd_z0 - 1) * 0.5 * (big_height - height));
+        position_geometry.SetCoordinates({(2 * rnd_x0 - 1) * 0.5 * (big_width_x - width_x),
+                                          (2 * rnd_y0 - 1) * 0.5 * (big_width_y - width_y),
+                                          (2 * rnd_z0 - 1) * 0.5 * (big_height - height)});
 
         Box A(position_geometry, width_x, width_y, height);
 
@@ -166,12 +166,10 @@ TEST(IsInside, Box)
             rnd_theta = RandomGenerator::Get().RandomDouble();
             rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-            particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-            particle_direction.CalculateCartesianFromSpherical();
-
-            particle_position.SetCartesianCoordinates((2 * rnd_x - 1) * 0.5 * big_width_x,
-                                                      (2 * rnd_y - 1) * 0.5 * big_width_y,
-                                                      (2 * rnd_z - 1) * 0.5 * big_height);
+            particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
+            particle_position.SetCoordinates({(2 * rnd_x - 1) * 0.5 * big_width_x,
+                                              (2 * rnd_y - 1) * 0.5 * big_width_y,
+                                              (2 * rnd_z - 1) * 0.5 * big_height});
 
             // if this constraints are true the particle is inside the box geometry
             if (particle_position.GetX() > position_geometry.GetX() - 0.5 * width_x &&
@@ -195,123 +193,119 @@ TEST(IsInside, Box)
     }
     // Check what happens if particles are on the border of the box
 
-    Box A(Vector3D(0, 0, 0), width_x, width_y, height);
+    Box A(Cartesian3D(0, 0, 0), width_x, width_y, height);
 
     // Particle is on the top surface.
     // Theta 0° - 90° means particle is moving outside
     // This should be treated as outside
     // Theta 90° - 180° means particle is moving inside (should be treated as inside)
     // The value of phi does not matter
-    particle_position.SetCartesianCoordinates(0, 0, 0.5 * height);
+    particle_position.SetCoordinates({0, 0, 0.5 * height});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
-        if (particle_direction.GetTheta() < 0.5 * PI)
+        if (particle_direction.GetZenith() < 0.5 * PI)
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
-        if (particle_direction.GetTheta() > 0.5 * PI)
+        if (particle_direction.GetZenith() > 0.5 * PI)
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
     }
 
     // Make this test for every surface of the box
 
     // bottom
-    particle_position.SetCartesianCoordinates(0, 0, -0.5 * height);
+    particle_position.SetCoordinates({0, 0, -0.5 * height});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
-        if (particle_direction.GetTheta() > 0.5 * PI)
+        if (particle_direction.GetZenith() > 0.5 * PI)
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
-        if (particle_direction.GetTheta() < 0.5 * PI)
+        if (particle_direction.GetZenith() < 0.5 * PI)
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
     }
 
     // Surface in positiv x direction
-    particle_position.SetCartesianCoordinates(0.5 * width_x, 0, 0);
+    particle_position.SetCoordinates({0.5 * width_x, 0, 0});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
         // phi = 0 is in positive x direction
-        if (particle_direction.GetPhi() < 0.5 * PI || particle_direction.GetPhi() > 1.5 * PI)
+        if (particle_direction.GetAzimuth() < 0.5 * PI ||
+            particle_direction.GetAzimuth() > 1.5 * PI)
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
         else
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
     }
     // Surface in negativ x direction
-    particle_position.SetCartesianCoordinates(-0.5 * width_x, 0, 0);
+    particle_position.SetCoordinates({-0.5 * width_x, 0, 0});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
         // phi = 0 is in positive x direction
-        if (particle_direction.GetPhi() < 0.5 * PI || particle_direction.GetPhi() > 1.5 * PI)
+        if (particle_direction.GetAzimuth() < 0.5 * PI ||
+            particle_direction.GetAzimuth() > 1.5 * PI)
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
         else
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
     }
     // Surface in positiv y direction
-    particle_position.SetCartesianCoordinates(0, 0.5 * width_y, 0);
+    particle_position.SetCoordinates({0, 0.5 * width_y, 0});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
         // phi = 0 is in positive x direction
-        if (particle_direction.GetPhi() < PI)
+        if (particle_direction.GetAzimuth() < PI)
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
         else
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
     }
     // Surface in negativ y direction
-    particle_position.SetCartesianCoordinates(0, -0.5 * width_y, 0);
+    particle_position.SetCoordinates({0, -0.5 * width_y, 0});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
         // phi = 0 is in positive x direction
-        if (particle_direction.GetPhi() < PI)
+        if (particle_direction.GetAzimuth() < PI)
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
         else
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
     }
 
     // For completness check one corner
-    particle_position.SetCartesianCoordinates(0.5 * width_x, 0.5 * width_y, 0.5 * height);
+    particle_position.SetCoordinates({0.5 * width_x, 0.5 * width_y, 0.5 * height});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
-        if (particle_direction.GetTheta() < 0.5 * PI || particle_direction.GetPhi() < PI ||
-            particle_direction.GetPhi() > 1.5 * PI)
+        if (particle_direction.GetZenith() < 0.5 * PI ||
+            particle_direction.GetAzimuth() < PI ||
+            particle_direction.GetAzimuth() > 1.5 * PI)
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
         else
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
@@ -321,8 +315,8 @@ TEST(IsInside, Box)
 TEST(IsInside, Cylinder)
 {
 
-    Vector3D particle_position(0, 0, 0);
-    Vector3D particle_direction(0, 0, 0);
+    Cartesian3D particle_position(0, 0, 0);
+    Spherical3D particle_direction(0, 0, 0);
 
     double rnd_x;
     double rnd_y;
@@ -344,7 +338,7 @@ TEST(IsInside, Cylinder)
     double big_width_y = 4 * radius;
     double big_height  = 4 * height;
 
-    Vector3D position_geometry(0, 0, 0);
+    Cartesian3D position_geometry(0, 0, 0);
 
     int is_inside  = 0;
     int is_outside = 0;
@@ -365,9 +359,9 @@ TEST(IsInside, Cylinder)
         rnd_y0 = RandomGenerator::Get().RandomDouble();
         rnd_z0 = RandomGenerator::Get().RandomDouble();
 
-        position_geometry.SetCartesianCoordinates((2 * rnd_x0 - 1) * (0.5 * big_width_x - radius),
-                                                  (2 * rnd_y0 - 1) * (0.5 * big_width_y - radius),
-                                                  (2 * rnd_z0 - 1) * 0.5 * (big_height - height));
+        position_geometry.SetCoordinates({(2 * rnd_x0 - 1) * (0.5 * big_width_x - radius),
+                                          (2 * rnd_y0 - 1) * (0.5 * big_width_y - radius),
+                                          (2 * rnd_z0 - 1) * 0.5 * (big_height - height)});
 
         // position_geometry.SetCartesianCoordinates(0,0,0);
 
@@ -390,12 +384,11 @@ TEST(IsInside, Cylinder)
             rnd_theta = RandomGenerator::Get().RandomDouble();
             rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-            particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-            particle_direction.CalculateCartesianFromSpherical();
+            particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
-            particle_position.SetCartesianCoordinates((2 * rnd_x - 1) * 0.5 * big_width_x,
-                                                      (2 * rnd_y - 1) * 0.5 * big_width_y,
-                                                      (2 * rnd_z - 1) * 0.5 * big_height);
+            particle_position.SetCoordinates({(2 * rnd_x - 1) * 0.5 * big_width_x,
+                                              (2 * rnd_y - 1) * 0.5 * big_width_y,
+                                              (2 * rnd_z - 1) * 0.5 * big_height});
 
             // if this constraints are true the particle is inside the cylinder geometry
             if (sqrt(pow((particle_position.GetX() - position_geometry.GetX()), 2) +
@@ -422,7 +415,7 @@ TEST(IsInside, Cylinder)
 
     // Test borders
 
-    Sphere B(Vector3D(0, 0, 0), radius, 0);
+    Sphere B(Cartesian3D(0, 0, 0), radius, 0);
 
     double cos;
 
@@ -431,16 +424,15 @@ TEST(IsInside, Cylinder)
     {
         rnd_x = RandomGenerator::Get().RandomDouble();
 
-        particle_position.SetCartesianCoordinates(radius * rnd_x, radius * sqrt(1 - rnd_x * rnd_x), 0);
+        particle_position.SetCoordinates({radius * rnd_x, radius * sqrt(1 - rnd_x * rnd_x), 0});
 
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
         // cosine of angle between direction vector and position vector
-        cos = -scalar_product(particle_position, particle_direction) / radius;
+        cos = -(particle_position * particle_direction) / radius;
 
         if (cos < 1 && cos > 0)
             EXPECT_TRUE(B.IsInside(particle_position, particle_direction));
@@ -453,25 +445,24 @@ TEST(IsInside, Cylinder)
     // This should be treated as outside
     // Theta 90° - 180° means particle is moving inside (should be treated as inside)
     // The value of phi does not matter
-    particle_position.SetCartesianCoordinates(0, 0, 0.5 * height);
+    particle_position.SetCoordinates({0, 0, 0.5 * height});
 
-    Cylinder C(Vector3D(0, 0, 0), height, radius, 0);
+    Cylinder C(Cartesian3D(0, 0, 0), height, radius, 0);
 
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
         // Computer precision controll
         if (particle_position.GetX() * particle_position.GetX() + particle_position.GetY() * particle_position.GetY() -
                 inner_radius * inner_radius ==
             0)
         {
-            if (particle_direction.GetTheta() < PI / 2.)
+            if (particle_direction.GetZenith() < PI / 2.)
                 EXPECT_FALSE(C.IsInside(particle_position, particle_direction));
-            if (particle_direction.GetTheta() > PI / 2.)
+            if (particle_direction.GetZenith() > PI / 2.)
                 EXPECT_TRUE(C.IsInside(particle_position, particle_direction));
         }
     }
@@ -479,25 +470,24 @@ TEST(IsInside, Cylinder)
     // Make this test for every surface of the box
 
     // bottom
-    particle_position.SetCartesianCoordinates(0, 0, -0.5 * height);
+    particle_position.SetCoordinates({0, 0, -0.5 * height});
     for (int i = 0; i < 1e4; i++)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
-        if (particle_direction.GetTheta() > PI / 2.)
+        if (particle_direction.GetZenith() > PI / 2.)
             EXPECT_FALSE(C.IsInside(particle_position, particle_direction));
-        if (particle_direction.GetTheta() < PI / 2.)
+        if (particle_direction.GetZenith() < PI / 2.)
             EXPECT_TRUE(C.IsInside(particle_position, particle_direction));
     }
 
     // Test inner border
     inner_radius = 5;
 
-    Cylinder A(Vector3D(0, 0, 0), height, radius, inner_radius);
+    Cylinder A(Cartesian3D(0, 0, 0), height, radius, inner_radius);
 
     excluded = 0;
 
@@ -505,16 +495,15 @@ TEST(IsInside, Cylinder)
     {
         rnd_x = RandomGenerator::Get().RandomDouble();
 
-        particle_position.SetCartesianCoordinates(inner_radius * rnd_x, inner_radius * sqrt(1 - rnd_x * rnd_x), 0);
+        particle_position.SetCoordinates({inner_radius * rnd_x, inner_radius * sqrt(1 - rnd_x * rnd_x), 0});
 
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates(Spherical3D(1, rnd_phi * 2 * PI, rnd_theta * PI).GetCartesianCoordinates());
 
         // cosine of angle between direction vector and position vector
-        cos = -scalar_product(particle_position, particle_direction) / radius;
+        cos = -(particle_position * particle_direction) / radius;
 
         if (cos < 1 && cos > 0)
             EXPECT_FALSE(A.IsInside(particle_position, particle_direction));
@@ -526,8 +515,8 @@ TEST(IsInside, Cylinder)
 TEST(IsInside, Sphere)
 {
 
-    Vector3D particle_position(0, 0, 0);
-    Vector3D particle_direction(0, 0, 0);
+    Cartesian3D particle_position(0, 0, 0);
+    Cartesian3D particle_direction(0, 0, 0);
 
     double rnd_x;
     double rnd_y;
@@ -548,7 +537,7 @@ TEST(IsInside, Sphere)
     double big_width_y = 4 * radius;
     double big_height  = 4 * radius;
 
-    Vector3D position_geometry(0, 0, 0);
+    Cartesian3D position_geometry(0, 0, 0);
 
     int is_inside  = 0;
     int is_outside = 0;
@@ -570,9 +559,9 @@ TEST(IsInside, Sphere)
 
         rnd_inner_radius = RandomGenerator::Get().RandomDouble();
 
-        position_geometry.SetCartesianCoordinates((2 * rnd_x0 - 1) * (0.5 * big_width_x - radius),
-                                                  (2 * rnd_y0 - 1) * (0.5 * big_width_y - radius),
-                                                  (2 * rnd_z0 - 1) * (0.5 * big_height - radius));
+        position_geometry.SetCoordinates({(2 * rnd_x0 - 1) * (0.5 * big_width_x - radius),
+                                          (2 * rnd_y0 - 1) * (0.5 * big_width_y - radius),
+                                          (2 * rnd_z0 - 1) * (0.5 * big_height - radius)});
 
         inner_radius = radius * rnd_inner_radius;
 
@@ -592,12 +581,11 @@ TEST(IsInside, Sphere)
             rnd_theta = RandomGenerator::Get().RandomDouble();
             rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-            particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-            particle_direction.CalculateCartesianFromSpherical();
+            particle_direction.SetCoordinates(Spherical3D(1, rnd_phi * 2 * PI, rnd_theta * PI).GetCartesianCoordinates());
 
-            particle_position.SetCartesianCoordinates((2 * rnd_x - 1) * 0.5 * big_width_x,
-                                                      (2 * rnd_y - 1) * 0.5 * big_width_y,
-                                                      (2 * rnd_z - 1) * 0.5 * big_height);
+            particle_position.SetCoordinates({(2 * rnd_x - 1) * 0.5 * big_width_x,
+                                              (2 * rnd_y - 1) * 0.5 * big_width_y,
+                                              (2 * rnd_z - 1) * 0.5 * big_height});
 
             if ((particle_position - position_geometry).magnitude() < radius &&
                 (particle_position - position_geometry).magnitude() > inner_radius)
@@ -617,7 +605,7 @@ TEST(IsInside, Sphere)
 
     // Test borders
 
-    Sphere A(Vector3D(0, 0, 0), radius);
+    Sphere A(Cartesian3D(0, 0, 0), radius);
 
     double cos;
 
@@ -626,16 +614,15 @@ TEST(IsInside, Sphere)
     {
         rnd_x = RandomGenerator::Get().RandomDouble();
 
-        particle_position.SetCartesianCoordinates(radius * rnd_x, radius * sqrt(1 - rnd_x * rnd_x), 0);
+        particle_position.SetCoordinates({radius * rnd_x, radius * sqrt(1 - rnd_x * rnd_x), 0});
 
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates(Spherical3D(1, rnd_phi * 2 * PI, rnd_theta * PI).GetCartesianCoordinates());
 
         // cosine of angle between direction vector and position vector
-        cos = -scalar_product(particle_position, particle_direction) / radius;
+        cos = -(particle_position * particle_direction) / radius;
 
         if (cos < 1 && cos > 0)
             EXPECT_TRUE(A.IsInside(particle_position, particle_direction));
@@ -646,7 +633,7 @@ TEST(IsInside, Sphere)
     // Test inner border
     inner_radius = 5;
 
-    Sphere B(Vector3D(0, 0, 0), radius, inner_radius);
+    Sphere B(Cartesian3D(0, 0, 0), radius, inner_radius);
 
     excluded = 0;
 
@@ -654,16 +641,15 @@ TEST(IsInside, Sphere)
     {
         rnd_x = RandomGenerator::Get().RandomDouble();
 
-        particle_position.SetCartesianCoordinates(inner_radius * rnd_x, inner_radius * sqrt(1 - rnd_x * rnd_x), 0);
+        particle_position.SetCoordinates({inner_radius * rnd_x, inner_radius * sqrt(1 - rnd_x * rnd_x), 0});
 
         rnd_theta = RandomGenerator::Get().RandomDouble();
         rnd_phi   = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates(Spherical3D(1, rnd_phi * 2 * PI, rnd_theta * PI).GetCartesianCoordinates());
 
         // cosine of angle between direction vector and position vector
-        cos = -scalar_product(particle_position, particle_direction) / radius;
+        cos = -(particle_position * particle_direction) / radius;
 
         if (cos < 1 && cos > 0)
             EXPECT_FALSE(B.IsInside(particle_position, particle_direction));
@@ -674,8 +660,8 @@ TEST(IsInside, Sphere)
 
 TEST(DistanceTo, Sphere)
 {
-    Vector3D particle_position(0, 0, 0);
-    Vector3D particle_direction(0, 0, 0);
+    Cartesian3D particle_position(0, 0, 0);
+    Spherical3D particle_direction(0, 0, 0);
 
     double radius          = 10;
     double inner_radius    = 0;
@@ -703,17 +689,15 @@ TEST(DistanceTo, Sphere)
             rnd_inner_radius = RandomGenerator::Get().RandomDouble();
             inner_radius     = radius * rnd_inner_radius;
 
-            Sphere A(Vector3D(0, 0, 0), radius, inner_radius);
+            Sphere A(Cartesian3D(0, 0, 0), radius, inner_radius);
 
             rnd_phi   = RandomGenerator::Get().RandomDouble();
             rnd_theta = RandomGenerator::Get().RandomDouble();
 
-            particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, rnd_theta * PI);
-            particle_direction.CalculateCartesianFromSpherical();
+            particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, rnd_theta * PI});
 
             // Chose particle location and angle
-            particle_position.SetSphericalCoordinates(particle_radius, rnd_phi * 2 * PI, rnd_theta * PI);
-            particle_position.CalculateCartesianFromSpherical();
+            particle_position.SetCoordinates(Spherical3D(particle_radius, rnd_phi * 2 * PI, rnd_theta * PI).GetCartesianCoordinates());
             particle_position = -particle_position;
 
             distance = A.DistanceToBorder(particle_position, particle_direction);
@@ -750,8 +734,7 @@ TEST(DistanceTo, Sphere)
             }
             if (particle_radius > 20)
             {
-                particle_position.SetSphericalCoordinates(inner_radius, rnd_phi * 2 * PI, rnd_theta * PI);
-                particle_position.CalculateCartesianFromSpherical();
+                particle_position.SetCoordinates(Spherical3D(inner_radius, rnd_phi * 2 * PI, rnd_theta * PI).GetCartesianCoordinates());
                 particle_position = -particle_position;
 
                 distance = A.DistanceToBorder(particle_position, particle_direction);
@@ -765,8 +748,8 @@ TEST(DistanceTo, Sphere)
 //
 TEST(DistanceTo, Cylinder)
 {
-    Vector3D particle_position(0, 0, 0);
-    Vector3D particle_direction(0, 0, 0);
+    Cartesian3D particle_position(0, 0, 0);
+    Spherical3D particle_direction(0, 0, 0);
 
     double height          = 10;
     double radius          = 10;
@@ -796,20 +779,18 @@ TEST(DistanceTo, Cylinder)
             rnd_inner_radius = RandomGenerator::Get().RandomDouble();
             inner_radius     = radius * rnd_inner_radius;
 
-            Cylinder A(Vector3D(0, 0, 0), height, radius, inner_radius);
+            Cylinder A(Cartesian3D(0, 0, 0), height, radius, inner_radius);
 
             rnd_phi = RandomGenerator::Get().RandomDouble();
 
             // Chose particle location and angle
-            particle_position.SetSphericalCoordinates(1, rnd_phi * 2 * PI, 0.5 * PI);
-            particle_position.CalculateCartesianFromSpherical();
-            particle_position.SetCartesianCoordinates(particle_radius * particle_position.GetX(),
-                                                      particle_radius * particle_position.GetY(),
-                                                      0.5 * height * particle_position.GetZ());
+            particle_position.SetCoordinates(Spherical3D(1, rnd_phi * 2 * PI, 0.5 * PI).GetCartesianCoordinates());
+            particle_position.SetCoordinates({particle_radius * particle_position.GetX(),
+                                              particle_radius * particle_position.GetY(),
+                                              0.5 * height * particle_position.GetZ()});
             particle_position = -particle_position;
 
-            particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, 0.5 * PI);
-            particle_direction.CalculateCartesianFromSpherical();
+            particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, 0.5 * PI});
 
             distance = A.DistanceToBorder(particle_position, particle_direction);
 
@@ -847,8 +828,7 @@ TEST(DistanceTo, Cylinder)
             {
                 particle_radius = inner_radius;
 
-                particle_position.SetSphericalCoordinates(particle_radius, rnd_phi * 2 * PI, 0.5 * PI);
-                particle_position.CalculateCartesianFromSpherical();
+                particle_position.SetCoordinates(Spherical3D(particle_radius, rnd_phi * 2 * PI, 0.5 * PI).GetCartesianCoordinates());
                 particle_position = -particle_position;
 
                 distance = A.DistanceToBorder(particle_position, particle_direction);
@@ -861,14 +841,13 @@ TEST(DistanceTo, Cylinder)
     // One test for inner_radius =0
     inner_radius = 0;
 
-    Cylinder B(Vector3D(0, 0, 0), height, radius, inner_radius);
+    Cylinder B(Cartesian3D(0, 0, 0), height, radius, inner_radius);
 
     // Chose particle location and angle
 
-    particle_position.SetCartesianCoordinates(0, 0, height + 10);
+    particle_position.SetCoordinates({0, 0, height + 10});
 
-    particle_direction.SetSphericalCoordinates(1, 0, PI);
-    particle_direction.CalculateCartesianFromSpherical();
+    particle_direction.SetCoordinates({1, 0, PI});
 
     z = particle_position.GetZ();
 
@@ -882,7 +861,7 @@ TEST(DistanceTo, Cylinder)
 
     inner_radius = 6;
 
-    Cylinder A(Vector3D(0, 0, 0), height, radius, inner_radius);
+    Cylinder A(Cartesian3D(0, 0, 0), height, radius, inner_radius);
 
     for (int j = 0; j < number_particles; j++)
     {
@@ -895,11 +874,10 @@ TEST(DistanceTo, Cylinder)
 
         // Chose particle location and angle
 
-        particle_position.SetCartesianCoordinates(0, 0, height + 0.5 * height);
+        particle_position.SetCoordinates({0, 0, height + 0.5 * height});
         z = particle_position.GetZ();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi, PI - alpha);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi, PI - alpha});
 
         double dist1 = inner_radius / std::sin(alpha);
         double dist2 = radius / std::sin(alpha);
@@ -991,8 +969,8 @@ TEST(DistanceTo, Cylinder)
 
 TEST(DistanceTo, Box)
 {
-    Vector3D particle_position(0, 0, 0);
-    Vector3D particle_direction(0, 0, 0);
+    Cartesian3D particle_position(0, 0, 0);
+    Spherical3D particle_direction(0, 0, 0);
 
     double width  = 10;
     double height = width;
@@ -1017,14 +995,13 @@ TEST(DistanceTo, Box)
     {
         rnd_phi = RandomGenerator::Get().RandomDouble();
 
-        Box A(Vector3D(0, 0, 0), width, width, height);
+        Box A(Cartesian3D(0, 0, 0), width, width, height);
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 2 * PI, 0.5 * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 2 * PI, 0.5 * PI});
 
         distance = A.DistanceToBorder(particle_position, particle_direction);
 
-        phi = particle_direction.GetPhi() * 180. / PI;
+        phi = particle_direction.GetAzimuth() * 180. / PI;
         if (phi < 45)
         {
             dist = 0.5 * width / std::cos(phi / 180 * PI);
@@ -1075,18 +1052,16 @@ TEST(DistanceTo, Box)
         }
     }
 
-    Box A(Vector3D(0, 0, 0), width, width, height);
+    Box A(Cartesian3D(0, 0, 0), width, width, height);
 
     for (int i = 0; i < number_particles; i++)
     {
         rnd_phi = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, rnd_phi * 0.5 * PI, 0.5 * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, rnd_phi * 0.5 * PI, 0.5 * PI});
+        particle_position.SetCoordinates({-1 * width, 0, 0});
 
-        particle_position.SetCartesianCoordinates(-1 * width, 0, 0);
-
-        phi      = particle_direction.GetPhi();
+        phi      = particle_direction.GetAzimuth();
         distance = A.DistanceToBorder(particle_position, particle_direction);
 
         //                       ________________           z|
@@ -1152,10 +1127,9 @@ TEST(DistanceTo, Box)
     {
         rnd_theta = RandomGenerator::Get().RandomDouble();
 
-        particle_direction.SetSphericalCoordinates(1, 0, rnd_theta * 0.5 * PI);
-        particle_direction.CalculateCartesianFromSpherical();
+        particle_direction.SetCoordinates({1, 0, rnd_theta * 0.5 * PI});
 
-        particle_position.SetCartesianCoordinates(0, 0, -1 * height);
+        particle_position.SetCoordinates({0, 0, -1 * height});
 
         distance = A.DistanceToBorder(particle_position, particle_direction);
 
@@ -1169,10 +1143,10 @@ TEST(DistanceTo, Box)
         //                      |               |
         //                      |_______________|
 
-        if (particle_direction.GetTheta() < std::atan(0.5 * height / (0.5 * height - particle_position.GetZ())))
+        if (particle_direction.GetZenith() < std::atan(0.5 * height / (0.5 * height - particle_position.GetZ())))
         {
-            dist1 = (-particle_position.GetZ() - 0.5 * height) / std::cos(particle_direction.GetTheta());
-            dist2 = (0.5 * height - particle_position.GetZ()) / std::cos(particle_direction.GetTheta());
+            dist1 = (-particle_position.GetZ() - 0.5 * height) / std::cos(particle_direction.GetZenith());
+            dist2 = (0.5 * height - particle_position.GetZ()) / std::cos(particle_direction.GetZenith());
             ASSERT_NEAR(distance.first, dist1, 1e-8 * (dist1));
             ASSERT_NEAR(distance.second, dist2, 1e-8 * (dist2));
 
@@ -1190,10 +1164,10 @@ TEST(DistanceTo, Box)
         //                      |               |
         //                      |_______________|
 
-        else if (particle_direction.GetTheta() < std::atan(height * 0.5 / (-particle_position.GetZ() - 0.5 * height)))
+        else if (particle_direction.GetZenith() < std::atan(height * 0.5 / (-particle_position.GetZ() - 0.5 * height)))
         {
-            dist1 = (-particle_position.GetZ() - 0.5 * height) / std::cos(particle_direction.GetTheta());
-            dist2 = 0.5 * height / std::sin(particle_direction.GetTheta());
+            dist1 = (-particle_position.GetZ() - 0.5 * height) / std::cos(particle_direction.GetZenith());
+            dist2 = 0.5 * height / std::sin(particle_direction.GetZenith());
             ASSERT_NEAR(distance.first, dist1, 1e-8 * (dist1));
             ASSERT_NEAR(distance.second, dist2, 1e-8 * (dist2));
         }

--- a/tests/Particle_TEST.cxx
+++ b/tests/Particle_TEST.cxx
@@ -4,17 +4,17 @@
 
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/particle/Particle.h"
-#include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/math/Cartesian3D.h"
+#include "PROPOSAL/math/Spherical3D.h"
 
 using namespace PROPOSAL;
 
-Vector3D position(1., 1., 1.);
-Vector3D direction(0., 0., 0.);
+Cartesian3D position(1., 1., 1.);
+Spherical3D direction(0., 0., 0.);
 
 TEST(Comparison, Comparison_equal)
 {
-    direction.SetSphericalCoordinates(1, 20 * PI / 180., 20 * PI / 180.);
-    direction.CalculateCartesianFromSpherical();
+    direction.SetCoordinates({1, 20 * PI / 180., 20 * PI / 180.});
 
     ParticleState A;
     ParticleState B;
@@ -31,8 +31,8 @@ TEST(Comparison, Comparison_equal)
     D->energy = 1e6;
     EXPECT_TRUE(*C == *D);
 
-    position    = Vector3D();
-    direction   = Vector3D();
+    position    = Cartesian3D();
+    direction   = Cartesian3D();
     ParticleState* E = new ParticleState();
     E->position = position;
     E->direction = direction;
@@ -41,8 +41,7 @@ TEST(Comparison, Comparison_equal)
 
 TEST(Comparison, Comparison_not_equal)
 {
-    direction.SetSphericalCoordinates(1, 20 * PI / 180., 20 * PI / 180.);
-    direction.CalculateCartesianFromSpherical();
+    direction.SetCoordinates({1, 20 * PI / 180., 20 * PI / 180.});
 
     ParticleState A;
     ParticleState B;
@@ -71,8 +70,7 @@ TEST(Assignment, Copyconstructor)
 
 TEST(Assignment, Copyconstructor2)
 {
-    direction.SetSphericalCoordinates(1, 20 * PI / 180., 20 * PI / 180.);
-    direction.CalculateCartesianFromSpherical();
+    direction.SetCoordinates({1, 20 * PI / 180., 20 * PI / 180.});
     ParticleState A;
     A.SetType(ParticleType::TauMinus);
     A.position = position;

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -9,6 +9,7 @@
 #include "PROPOSAL/particle/Particle.h"
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/math/Vector3D.h"
+#include "PROPOSAL/math/Spherical3D.h"
 
 #include "PROPOSAL/scattering/multiple_scattering/ScatteringFactory.h"
 #include "PROPOSAL/scattering/multiple_scattering/Highland.h"
@@ -52,7 +53,7 @@ auto GetCrossSections(const ParticleDef& p_def, const Medium& med, std::shared_p
 }
 
 // Borrow this function from PropagationUtility
-std::tuple<Vector3D, Vector3D> DirectionsScatter(const Vector3D& direction,
+std::tuple<Cartesian3D, Cartesian3D> DirectionsScatter(const Vector3D& direction,
                                                  std::array<double, 4>& coords)
 {
     auto& sx = coords[multiple_scattering::Parametrization::SX];
@@ -62,25 +63,25 @@ std::tuple<Vector3D, Vector3D> DirectionsScatter(const Vector3D& direction,
     auto sz = std::sqrt(std::max(1. - (sx * sx + sy * sy), 0.));
     auto tz = std::sqrt(std::max(1. - (tx * tx + ty * ty), 0.));
 
-    auto sinth = std::sin(direction.GetTheta());
-    auto costh = std::cos(direction.GetTheta());
-    auto sinph = std::sin(direction.GetPhi());
-    auto cosph = std::cos(direction.GetPhi());
+    auto direction_spherical = direction.GetSphericalCoordinates();
+    auto sinth = std::sin(direction_spherical[Spherical3D::Zenith]);
+    auto costh = std::cos(direction_spherical[Spherical3D::Zenith]);
+    auto sinph = std::sin(direction_spherical[Spherical3D::Azimuth]);
+    auto cosph = std::cos(direction_spherical[Spherical3D::Azimuth]);
 
-    auto rotate_vector_x = PROPOSAL::Vector3D(costh * cosph, costh * sinph, -sinth);
-    auto rotate_vector_y = PROPOSAL::Vector3D(-sinph, cosph, 0.);
+    auto rotate_vector_x = Cartesian3D(costh * cosph, costh * sinph, -sinth);
+    auto rotate_vector_y = Cartesian3D(-sinph, cosph, 0.);
 
+    auto direction_cartesian = Cartesian3D(direction);
     // Rotation towards all tree axes
-    auto mean_direction = sz * direction;
+    auto mean_direction = sz * direction_cartesian;
     mean_direction += sx * rotate_vector_x;
     mean_direction += sy * rotate_vector_y;
-    mean_direction.CalculateSphericalCoordinates();
 
     // Rotation towards all tree axes
-    auto final_direction = tz * direction;
+    auto final_direction = tz * direction_cartesian;
     final_direction += tx * rotate_vector_x;
     final_direction += ty * rotate_vector_y;
-    final_direction.CalculateSphericalCoordinates();
 
     return std::make_tuple(mean_direction, final_direction);
 }
@@ -178,18 +179,17 @@ TEST(Scattering, Scatter){
     std::array<std::pair<double, double>, 5> pairs{{{0,0}, {PI/4, PI/4},
                                                     {PI/2, PI/2.}, {PI/4, -PI/2.}}} ;
 
-    std::vector<Vector3D> direction_list;
+    std::vector<Cartesian3D> direction_list;
     direction_list.emplace_back(1.,0.,0.);
     direction_list.emplace_back(0.,-1.,0.);
     direction_list.emplace_back(1./SQRT2,0.,-1/SQRT2);
 
     ScatterDummy* dummy3 = new ScatterDummy(MuMinusDef());
-    Vector3D position_init  = Vector3D(0, 0, 0);
+    auto position_init = Cartesian3D(0, 0, 0);
 
     for(const std::pair<double, double> & offset: pairs) {
         for (const std::pair<double, double> &scatter: pairs) {
-            for(Vector3D &direction_init: direction_list) {
-                direction_init.CalculateSphericalCoordinates();
+            for(auto direction_init: direction_list) {
                 dummy3->SetOffset(offset);
                 dummy3->SetScatteringAngle(scatter);
 
@@ -199,9 +199,9 @@ TEST(Scattering, Scatter){
                 ASSERT_DOUBLE_EQ(std::get<0>(directions).magnitude(), 1.);
                 ASSERT_DOUBLE_EQ(std::get<1>(directions).magnitude(), 1.);
                 // Expect input polar angles to be equal to angles between input direction and output directions
-                ASSERT_NEAR(std::acos(std::min(scalar_product(direction_init, std::get<0>(directions)), 1.)), offset.first,
+                ASSERT_NEAR(std::acos(std::min((direction_init * std::get<0>(directions)), 1.)), offset.first,
                             offset.first * 1e-10);
-                ASSERT_NEAR(std::acos(std::min(scalar_product(direction_init, std::get<1>(directions)), 1.)), scatter.first,
+                ASSERT_NEAR(std::acos(std::min((direction_init * std::get<1>(directions)), 1.)), scatter.first,
                             scatter.first * 1e-10);
             }
         }
@@ -211,9 +211,8 @@ TEST(Scattering, Scatter){
 
 TEST(Scattering, BorderCases){
     auto medium = StandardRock();
-    Vector3D position_init  = Vector3D(0, 0, 0);
-    Vector3D direction_init = Vector3D(1, 0, 0);
-    direction_init.CalculateSphericalCoordinates();
+    auto position_init  = Cartesian3D(0, 0, 0);
+    auto direction_init = Cartesian3D(1, 0, 0);
 
     std::array<multiple_scattering::Parametrization*, 2> scatter_list = {new multiple_scattering::Moliere(MuMinusDef(), medium),
                                                new multiple_scattering::Highland(MuMinusDef(), medium)};
@@ -238,9 +237,8 @@ TEST(Scattering, BorderCases){
 TEST(Scattering, FirstMomentum){
     RandomGenerator::Get().SetSeed(24601);
     auto medium = StandardRock();
-    Vector3D position_init  = Vector3D(0, 0, 0);
-    Vector3D direction_init = Vector3D(0, 0, 1);
-    direction_init.CalculateSphericalCoordinates();
+    auto position_init  = Cartesian3D(0, 0, 0);
+    auto direction_init = Cartesian3D(0, 0, 1);
     auto cuts = std::make_shared<EnergyCutSettings>(INF, 1, false);
 
     int statistics = 1e7;
@@ -249,12 +247,12 @@ TEST(Scattering, FirstMomentum){
     std::array<std::unique_ptr<multiple_scattering::Parametrization>, 3> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
                                                                make_multiple_scattering("highland", MuMinusDef(), medium),
                                                                make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross)};
-    Vector3D scatter_sum;
-    Vector3D offset_sum;
+    Cartesian3D scatter_sum;
+    Cartesian3D offset_sum;
 
     for(auto const& scatter: scatter_list){
-        Vector3D scatter_sum = Vector3D(0., 0., 0.);
-        Vector3D offset_sum = Vector3D(0., 0., 0.);
+        scatter_sum.SetCoordinates({0., 0., 0.});
+        offset_sum.SetCoordinates({0., 0., 0.});
 
         for (int n=1; n<=statistics; ++n) {
             auto coords = scatter->CalculateRandomAngle(
@@ -280,9 +278,8 @@ TEST(Scattering, FirstMomentum){
 TEST(Scattering, SecondMomentum){
     RandomGenerator::Get().SetSeed(24601);
     auto medium = StandardRock();
-    Vector3D position_init  = Vector3D(0, 0, 0);
-    Vector3D direction_init = Vector3D(0, 0, 1);
-    direction_init.CalculateSphericalCoordinates();
+    auto position_init  = Cartesian3D(0, 0, 0);
+    auto direction_init = Cartesian3D(0, 0, 1);
     auto cuts = std::make_shared<EnergyCutSettings>(INF, 1, false);
 
     int statistics = 1e5;
@@ -333,9 +330,8 @@ TEST(Scattering, SecondMomentum){
 TEST(Scattering, compare_integral_interpolant) {
     RandomGenerator::Get().SetSeed(24601);
     auto medium = StandardRock();
-    Vector3D position_init  = Vector3D(0, 0, 0);
-    Vector3D direction_init = Vector3D(0, 0, 1);
-    direction_init.CalculateSphericalCoordinates();
+    auto position_init  = Cartesian3D(0, 0, 0);
+    auto direction_init = Cartesian3D(0, 0, 1);
 
     std::vector<ParticleDef> particles = {EMinusDef(), MuMinusDef()};
     auto cut1 = std::make_shared<EnergyCutSettings>(500, 0.05, false);
@@ -395,11 +391,10 @@ TEST(Scattering, ScatterReproducibilityTest)
     double rnd1, rnd2, rnd3, rnd4;
     double energy_previous = -1;
     double ecut, vcut;
-    Vector3D position_init  = Vector3D(0, 0, 0);
-    Vector3D direction_init = Vector3D(1, 0, 0);
-    Vector3D position_out;
-    Vector3D direction_out;
-    direction_init.CalculateSphericalCoordinates();
+    Cartesian3D position_init  = Cartesian3D(0, 0, 0);
+    Cartesian3D direction_init = Cartesian3D(1, 0, 0);
+    Cartesian3D position_out;
+    Cartesian3D direction_out;
     double x_f, y_f, z_f;
     double radius_f, phi_f, theta_f;
 
@@ -455,9 +450,10 @@ TEST(Scattering, ScatterReproducibilityTest)
                 EXPECT_NEAR(position_out.GetY(), y_f, std::abs(error * y_f));
                 EXPECT_NEAR(position_out.GetZ(), z_f, std::abs(error * z_f));
 
-                EXPECT_NEAR(direction_out.GetRadius(), radius_f, std::abs(error * radius_f));
-                EXPECT_NEAR(direction_out.GetPhi(), phi_f, std::abs(error * phi_f));
-                EXPECT_NEAR(direction_out.GetTheta(), theta_f, std::abs(error * theta_f));
+                auto direction_out_spherical = Spherical3D(direction_out);
+                EXPECT_NEAR(direction_out_spherical.GetRadius(), radius_f, std::abs(error * radius_f));
+                EXPECT_NEAR(direction_out_spherical.GetAzimuth(), phi_f, std::abs(error * phi_f));
+                EXPECT_NEAR(direction_out_spherical.GetZenith(), theta_f, std::abs(error * theta_f));
             }
             in >> particleName >> mediumName >> parametrization >> ecut >> vcut >> energy_init >> energy_final >>
                 distance >> rnd1 >> rnd2 >> rnd3 >> rnd4 >> x_f >> y_f >> z_f >> radius_f >> phi_f >> theta_f;

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -63,11 +63,11 @@ std::tuple<Cartesian3D, Cartesian3D> DirectionsScatter(const Vector3D& direction
     auto sz = std::sqrt(std::max(1. - (sx * sx + sy * sy), 0.));
     auto tz = std::sqrt(std::max(1. - (tx * tx + ty * ty), 0.));
 
-    auto direction_spherical = direction.GetSphericalCoordinates();
-    auto sinth = std::sin(direction_spherical[Spherical3D::Zenith]);
-    auto costh = std::cos(direction_spherical[Spherical3D::Zenith]);
-    auto sinph = std::sin(direction_spherical[Spherical3D::Azimuth]);
-    auto cosph = std::cos(direction_spherical[Spherical3D::Azimuth]);
+    auto direction_spherical = Spherical3D(direction);
+    auto sinth = std::sin(direction_spherical.GetZenith());
+    auto costh = std::cos(direction_spherical.GetZenith());
+    auto sinph = std::sin(direction_spherical.GetAzimuth());
+    auto cosph = std::cos(direction_spherical.GetAzimuth());
 
     auto rotate_vector_x = Cartesian3D(costh * cosph, costh * sinph, -sinth);
     auto rotate_vector_y = Cartesian3D(-sinph, cosph, 0.);

--- a/tests/Secondaries_TEST.cxx
+++ b/tests/Secondaries_TEST.cxx
@@ -25,8 +25,8 @@ std::shared_ptr<Propagator> GetPropagator() {
         auto prop_utility = PropagationUtility(collection);
 
         auto density_distr = std::make_shared<Density_homogeneous>(medium);
-        auto world = std::make_shared<Sphere>(Vector3D(0, 0, 0), 1e20);
-        auto sphere = std::make_shared<Sphere>(Vector3D(0, 0, 10000), 1000);
+        auto world = std::make_shared<Sphere>(Cartesian3D(0, 0, 0), 1e20);
+        auto sphere = std::make_shared<Sphere>(Cartesian3D(0, 0, 10000), 1000);
 
         auto sector1 = std::make_tuple(world, prop_utility, density_distr);
         auto sector2 = std::make_tuple(sphere, prop_utility, density_distr);
@@ -41,36 +41,36 @@ TEST(SecondaryVector, EntryPointExitPoint)
 {
     auto prop = GetPropagator();
 
-    Vector3D position(0, 0, 0);
-    Vector3D direction(0, 0, 1);
+    Cartesian3D position(0, 0, 0);
+    Cartesian3D direction(0, 0, 1);
     auto energy = 1e8; // MeV
     auto init_state = ParticleState(position, direction, energy, 0., 0.);
 
     auto secondaries = prop->Propagate(init_state, 50000);
 
     // Test for geometry in front of track
-    auto sphere_infront = Sphere(Vector3D(0, 0, -1000), 10);
+    auto sphere_infront = Sphere(Cartesian3D(0, 0, -1000), 10);
     EXPECT_TRUE(secondaries.GetEntryPoint(sphere_infront) == nullptr);
     EXPECT_TRUE(secondaries.GetExitPoint(sphere_infront) == nullptr);
 
     // Test for geometry behin track
-    auto sphere_behind = Sphere(Vector3D(0, 0, 100000), 10);
+    auto sphere_behind = Sphere(Cartesian3D(0, 0, 100000), 10);
     EXPECT_TRUE(secondaries.GetEntryPoint(sphere_behind) == nullptr);
     EXPECT_TRUE(secondaries.GetExitPoint(sphere_behind) == nullptr);
 
     // Test for track beginning in geometry
-    auto sphere_start = Sphere(Vector3D(0, 0, 100), 100);
+    auto sphere_start = Sphere(Cartesian3D(0, 0, 100), 100);
     EXPECT_TRUE(secondaries.GetEntryPoint(sphere_start)->energy == energy);
     EXPECT_TRUE(secondaries.GetEntryPoint(sphere_start)->position == position);
 
     // Test for track ending in geometry
-    auto sphere_end = Sphere(Vector3D(0, 0, 49000), 1000);
+    auto sphere_end = Sphere(Cartesian3D(0, 0, 49000), 1000);
     EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->energy == secondaries.back().energy);
     EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->propagated_distance == secondaries.back().propagated_distance);
     EXPECT_TRUE(secondaries.GetExitPoint(sphere_end)->position == secondaries.back().position);
 
     // Test points where interaction points should be equal to entry/exit points
-    auto sphere = Sphere(Vector3D(0, 0, 10000), 1000);
+    auto sphere = Sphere(Cartesian3D(0, 0, 10000), 1000);
     EXPECT_TRUE(secondaries.GetEntryPoint(sphere)->propagated_distance == 9000);
     EXPECT_TRUE(secondaries.GetExitPoint(sphere)->propagated_distance == 11000);
 }
@@ -79,14 +79,14 @@ TEST(SecondaryVector, EntryPointExitPointRePropagation)
 {
     auto prop = GetPropagator();
 
-    Vector3D position(0, 0, 0);
-    Vector3D direction(0, 0, 1);
+    Cartesian3D position(0, 0, 0);
+    Cartesian3D direction(0, 0, 1);
     auto energy = 1e8; // MeV
     auto init_state = ParticleState(position, direction, energy, 0., 0.);
 
     auto secondaries = prop->Propagate(init_state, 1e5);
 
-    auto sphere = Sphere(Vector3D(0, 0, 5e4), 500);
+    auto sphere = Sphere(Cartesian3D(0, 0, 5e4), 500);
     auto entry_point = secondaries.GetEntryPoint(sphere);
     auto exit_point = secondaries.GetExitPoint(sphere);
     int i = 0;

--- a/tests/Vector3D_TEST.cxx
+++ b/tests/Vector3D_TEST.cxx
@@ -269,9 +269,9 @@ TEST(CalculateCartesianFromSpherical, Conversion)
     Cartesian3D C(B);
     double epsilon = std::numeric_limits<double>::epsilon();
     double error_factor = 2.;
-    bool test_x = std::abs(A[0] - C[0]) < std::abs(std::min(A[0], C[0])) * epsilon * error_factor;
-    bool test_y = std::abs(A[1] - C[1]) < std::abs(std::min(A[1], C[1])) * epsilon * error_factor;
-    bool test_z = std::abs(A[2] - C[2]) < std::abs(std::min(A[2], C[2])) * epsilon * error_factor;
+    bool test_x = std::abs(A.GetX() - C.GetX()) < std::abs(std::min(A.GetX(), C.GetX())) * epsilon * error_factor;
+    bool test_y = std::abs(A.GetY() - C.GetY()) < std::abs(std::min(A.GetY(), C.GetY())) * epsilon * error_factor;
+    bool test_z = std::abs(A.GetZ() - C.GetZ()) < std::abs(std::min(A.GetZ(), C.GetZ())) * epsilon * error_factor;
     EXPECT_TRUE(A == C || test_x && test_y && test_z);
 }
 

--- a/tests/Vector3D_TEST.cxx
+++ b/tests/Vector3D_TEST.cxx
@@ -1,6 +1,8 @@
 
 #include <cmath>
 #include <iostream>
+#include <PROPOSAL/math/Cartesian3D.h>
+#include <PROPOSAL/math/Spherical3D.h>
 
 #include "gtest/gtest.h"
 
@@ -11,78 +13,108 @@ using namespace PROPOSAL;
 
 TEST(Comparison, Comparison_equal)
 {
-    Vector3D A;
-    Vector3D B;
+    Cartesian3D A;
+    Cartesian3D B;
     EXPECT_TRUE(A == B);
-    Vector3D* C = new Vector3D(1., 2., 3.);
-    Vector3D* D = new Vector3D(1., 2., 3.);
+    Vector3D* C = new Cartesian3D(1., 2., 3.);
+    Vector3D* D = new Cartesian3D(1., 2., 3.);
     EXPECT_TRUE(*C == *D);
-    D->SetCartesianCoordinates(0., 0., 0.);
+    D->SetCoordinates({0., 0., 0.});
     EXPECT_TRUE(A == *D);
-    B.SetSphericalCoordinates(0.1, 0.2, 0.3);
-    D->SetSphericalCoordinates(0.1, 0.2, 0.3);
+    B.SetCoordinates({0.1, 0.2, 0.3});
+    D->SetCoordinates({0.1, 0.2, 0.3});
     EXPECT_TRUE(B == *D);
 }
 
 TEST(Comparison, Comparison_not_equal)
 {
-    Vector3D A;
-    Vector3D B;
-    B.SetCartesianCoordinates(1., 2., 3.);
+    Cartesian3D A;
+    Cartesian3D B;
+    B.SetCoordinates({1., 2., 3.});
     EXPECT_TRUE(A != B);
-    Vector3D C;
-    C.SetSphericalCoordinates(0.1, 0.2, 0.3);
+    Cartesian3D C;
+    C.SetCoordinates({0.1, 0.2, 0.3});
+    EXPECT_TRUE(A != C);
+}
+
+TEST(Comparison, Comparison_equal_spherical)
+{
+    Spherical3D A;
+    Spherical3D B;
+    EXPECT_TRUE(A == B);
+    Vector3D* C = new Spherical3D(1., 2., 3.);
+    Vector3D* D = new Spherical3D(1., 2., 3.);
+    EXPECT_TRUE(*C == *D);
+    D->SetCoordinates({0., 0., 0.});
+    EXPECT_TRUE(A == *D);
+    B.SetCoordinates({0.1, 0.2, 0.3});
+    D->SetCoordinates({0.1, 0.2, 0.3});
+    EXPECT_TRUE(B == *D);
+}
+
+TEST(Comparison, Comparison_not_equal_spherical)
+{
+    Spherical3D A;
+    Spherical3D B;
+    B.SetCoordinates({1., 2., 3.});
+    EXPECT_TRUE(A != B);
+    Spherical3D C;
+    C.SetCoordinates({0.1, 0.2, 0.3});
     EXPECT_TRUE(A != C);
 }
 
 TEST(Assignment, Copyconstructor)
 {
-    Vector3D A(1, 2, 3);
-    Vector3D B(A);
+    Cartesian3D A(1, 2, 3);
+    Cartesian3D B(A);
     EXPECT_TRUE(A == B);
-    Vector3D C(2, 3, 4);
+    Cartesian3D C(2, 3, 4);
     B = C;
     EXPECT_TRUE(C == B);
 }
 
 TEST(Assignment, Operator)
 {
-    Vector3D A;
-    Vector3D B;
-    A.SetCartesianCoordinates(1, 2, 3);
+    Cartesian3D A;
+    Cartesian3D B;
+    A.SetCoordinates({1, 2, 3});
     EXPECT_TRUE(A != B);
     B = A;
     EXPECT_TRUE(A == B);
 }
 
-TEST(Assignment, Swap)
+TEST(Assignment, Copyconstructor_spherical)
 {
-    Vector3D A;
-    Vector3D B;
+    Spherical3D A(1, 2, 3);
+    Spherical3D B(A);
     EXPECT_TRUE(A == B);
-    Vector3D* C = new Vector3D(1, 2, 3);
-    Vector3D* D = new Vector3D(1, 2, 3);
-    C->SetSphericalCoordinates(0.1, 0.2, 0.3);
-    D->SetSphericalCoordinates(0.1, 0.2, 0.3);
-    EXPECT_TRUE(*C == *D);
+    Spherical3D C(2, 3, 4);
+    B = C;
+    EXPECT_TRUE(C == B);
+}
 
-    A.swap(*C);
-    EXPECT_TRUE(A == *D);
-    EXPECT_TRUE(B == *C);
+TEST(Assignment, Operator_spherical)
+{
+    Spherical3D A;
+    Spherical3D B;
+    A.SetCoordinates({1, 2, 3});
+    EXPECT_TRUE(A != B);
+    B = A;
+    EXPECT_TRUE(A == B);
 }
 
 TEST(Addition, Operator)
 {
-    Vector3D A;
-    Vector3D B;
-    Vector3D C;
-    Vector3D D;
-    A.SetCartesianCoordinates(1, 2, 3);
-    B.SetCartesianCoordinates(2, 4, 6);
-    C.SetCartesianCoordinates(3, 6, 9);
+    Cartesian3D A;
+    Cartesian3D B;
+    Cartesian3D C;
+    Cartesian3D  D;
+    A.SetCoordinates({1, 2, 3});
+    B.SetCoordinates({2, 4, 6});
+    C.SetCoordinates({3, 6, 9});
     D = A + B;
     EXPECT_TRUE(C == D);
-    D.SetCartesianCoordinates(0, 0, 0);
+    D.SetCoordinates({0, 0, 0});
     EXPECT_TRUE(D != C);
     D = B + A;
     EXPECT_TRUE(D == C);
@@ -90,15 +122,15 @@ TEST(Addition, Operator)
 
 TEST(Subtraction, Operator)
 {
-    Vector3D A;
-    Vector3D B;
-    Vector3D C;
-    Vector3D D;
-    Vector3D E;
-    A.SetCartesianCoordinates(1, 2, 3);
-    B.SetCartesianCoordinates(2, 4, 6);
-    C.SetCartesianCoordinates(3, 6, 9);
-    E.SetCartesianCoordinates(-1, -2, -3);
+    Cartesian3D A;
+    Cartesian3D B;
+    Cartesian3D C;
+    Cartesian3D D;
+    Cartesian3D E;
+    A.SetCoordinates({1, 2, 3});
+    B.SetCoordinates({2, 4, 6});
+    C.SetCoordinates({3, 6, 9});
+    E.SetCoordinates({-1, -2, -3});
     D = -A;
     EXPECT_TRUE(D == E);
     D = C - B;
@@ -109,15 +141,15 @@ TEST(Subtraction, Operator)
 
 TEST(Scaling, Operator)
 {
-    Vector3D A;
-    Vector3D B;
-    Vector3D C;
+    Cartesian3D A;
+    Cartesian3D B;
+    Cartesian3D C;
     double factor1 = 2.;
-    A.SetCartesianCoordinates(1, 2, 3);
-    B.SetCartesianCoordinates(2, 4, 6);
+    A.SetCoordinates({1, 2, 3});
+    B.SetCoordinates({2, 4, 6});
     C = A * factor1;
     EXPECT_TRUE(C == B);
-    C.SetCartesianCoordinates(0, 0, 0);
+    C.SetCoordinates({0, 0, 0});
     EXPECT_TRUE(C != B);
     C = factor1 * A;
     EXPECT_TRUE(C == B);
@@ -125,31 +157,31 @@ TEST(Scaling, Operator)
 
 TEST(ScalarProduct, Operator)
 {
-    Vector3D A;
-    Vector3D B;
-    Vector3D C;
+    Cartesian3D A;
+    Cartesian3D B;
+    Cartesian3D C;
     double factor1 = 5;
     double result  = 0;
-    A.SetCartesianCoordinates(1, 1, 1);
-    B.SetCartesianCoordinates(2, 1, 2);
+    A.SetCoordinates({1, 1, 1});
+    B.SetCoordinates({2, 1, 2});
     EXPECT_TRUE(result != factor1);
-    result = scalar_product(A, B);
+    result = A*B;
     EXPECT_TRUE(result == factor1);
     result = 0.;
-    result = scalar_product(B, A);
+    result = B*A;
     EXPECT_TRUE(result == factor1);
 }
 
 TEST(VectorProduct, Operator)
 {
-    Vector3D A;
-    Vector3D B;
-    Vector3D C;
-    Vector3D D;
-    Vector3D E;
-    A.SetCartesianCoordinates(1, 0, 0);
-    B.SetCartesianCoordinates(0, 1, 0);
-    C.SetCartesianCoordinates(0, 0, 1);
+    Cartesian3D A;
+    Cartesian3D B;
+    Cartesian3D C;
+    Cartesian3D D;
+    Cartesian3D E;
+    A.SetCoordinates({1, 0, 0});
+    B.SetCoordinates({0, 1, 0});
+    C.SetCoordinates({0, 0, 1});
     D = vector_product(A, B);
     EXPECT_TRUE(D == C);
     D = -vector_product(B, A);
@@ -162,12 +194,26 @@ TEST(VectorProduct, Operator)
 
 TEST(Magnitude, Operator)
 {
-    Vector3D A;
-    Vector3D B;
+    Cartesian3D A;
+    Cartesian3D B;
     double sum = 3;
     double result;
-    A.SetCartesianCoordinates(1, 2, 2);
-    B.SetCartesianCoordinates(1, 1, 1);
+    A.SetCoordinates({1, 2, 2});
+    B.SetCoordinates({1, 1, 1});
+    result = A.magnitude();
+    EXPECT_TRUE(result == sum);
+    result = B.magnitude();
+    EXPECT_TRUE(result != sum);
+}
+
+TEST(Magnitude, Operator_spherical)
+{
+    Spherical3D A;
+    Spherical3D B;
+    double sum = 1;
+    double result;
+    A.SetCoordinates({1, 2, 2});
+    B.SetCoordinates({3, 1, 1});
     result = A.magnitude();
     EXPECT_TRUE(result == sum);
     result = B.magnitude();
@@ -176,56 +222,65 @@ TEST(Magnitude, Operator)
 
 TEST(Normalise, Operator)
 {
-    Vector3D A;
-    Vector3D B;
-    Vector3D C;
-    A.SetCartesianCoordinates(3, 0, 0);
-    B.SetCartesianCoordinates(1, 1, 1);
-    C.SetCartesianCoordinates(1, 0, 0);
+    Cartesian3D A;
+    Cartesian3D B;
+    Cartesian3D C;
+    A.SetCoordinates({3, 0, 0});
+    B.SetCoordinates({1, 1, 1});
+    C.SetCoordinates({1, 0, 0});
     EXPECT_TRUE(A != C);
     EXPECT_TRUE(B != C);
-    A.normalise();
-    C.SetSphericalCoordinates(1,0,0);
+    A.normalize();
     EXPECT_TRUE(A == C);
-    B.normalise();
+    B.normalize();
+    EXPECT_TRUE(B != C);
+}
+
+TEST(Normalise, Operator_spherical)
+{
+    Spherical3D A;
+    Spherical3D B;
+    Spherical3D C;
+    A.SetCoordinates({3, 0, 0});
+    B.SetCoordinates({1, 1, 1});
+    C.SetCoordinates({1, 0, 0});
+    EXPECT_TRUE(A != C);
+    EXPECT_TRUE(B != C);
+    A.normalize();
+    EXPECT_TRUE(A == C);
+    B.normalize();
     EXPECT_TRUE(B != C);
 }
 
 TEST(CalculateSphericalCoordinates, Conversion)
 {
-    Vector3D A;
-    Vector3D B(1, 2, 2);
-    A.SetCartesianCoordinates(1, 2, 2);
-    EXPECT_TRUE(A == B);
-    A.CalculateSphericalCoordinates();
-    EXPECT_TRUE(A != B);
-    B.SetSphericalCoordinates(3, std::atan2(2., 1.), std::acos(2. / 3.));
-    EXPECT_TRUE(B == A);
+    Cartesian3D A(1, 2, 2);
+    Spherical3D B(A.GetSphericalCoordinates());
+    Spherical3D C(3, std::atan2(2., 1.), std::acos(2. / 3.));
+    EXPECT_FALSE(A == B);
+    EXPECT_FALSE(A == C);
+    EXPECT_TRUE(B == C);
 }
 
 TEST(CalculateCartesianFromSpherical, Conversion)
 {
-    Vector3D A;
-    Vector3D B;
+    Cartesian3D A(1, 2, 2);
+    Spherical3D B(3, std::atan2(2., 1.), std::acos(2. / 3.));
+    Cartesian3D C(B);
     double epsilon = std::numeric_limits<double>::epsilon();
-    A.SetCartesianCoordinates(1, 2, 2);
-    B.SetSphericalCoordinates(3, std::atan2(2., 1.), std::acos(2. / 3.));
-    B.CalculateCartesianFromSpherical();
-    EXPECT_TRUE(A != B);
-    B.SetSphericalCoordinates(0, 0, 0);
     double error_factor = 2.;
-    bool test_x = std::abs(A.GetX() - B.GetX()) < std::abs(std::min(A.GetX(), B.GetX())) * epsilon * error_factor;
-    bool test_y = std::abs(A.GetY() - B.GetY()) < std::abs(std::min(A.GetY(), B.GetY())) * epsilon * error_factor;
-    bool test_z = std::abs(A.GetZ() - B.GetZ()) < std::abs(std::min(A.GetZ(), B.GetZ())) * epsilon * error_factor;
-    EXPECT_TRUE(A == B || test_x && test_y && test_z);
+    bool test_x = std::abs(A[0] - C[0]) < std::abs(std::min(A[0], C[0])) * epsilon * error_factor;
+    bool test_y = std::abs(A[1] - C[1]) < std::abs(std::min(A[1], C[1])) * epsilon * error_factor;
+    bool test_z = std::abs(A[2] - C[2]) < std::abs(std::min(A[2], C[2])) * epsilon * error_factor;
+    EXPECT_TRUE(A == C || test_x && test_y && test_z);
 }
 
 TEST(Deflection, Deflection)
 {
-    Vector3D direction_A(1., 0., 0.);
-    Vector3D direction_B(0., -1./SQRT2, 1./SQRT2);
-    Vector3D direction_C(1./3., 2./3., -2./3.);
-    Vector3D direction_tmp(1., 0., 0.);
+    Cartesian3D direction_A(1., 0., 0.);
+    Cartesian3D direction_B(0., -1./SQRT2, 1./SQRT2);
+    Cartesian3D direction_C(1./3., 2./3., -2./3.);
+    Cartesian3D direction_tmp(1., 0., 0.);
     double cosangle;
 
     std::vector<double> cos_phi_list{-1, -0.8, -0.2, 0., 0.2, 0.8, 1.};
@@ -235,17 +290,17 @@ TEST(Deflection, Deflection)
         for(auto const& theta: theta_list){
             direction_tmp = direction_A;
             direction_tmp.deflect(cos_phi, theta);
-            cosangle = scalar_product(direction_A, direction_tmp);
+            cosangle = direction_A*direction_tmp;
             EXPECT_NEAR(cos_phi, cosangle, 1e-8);
 
             direction_tmp = direction_B;
             direction_tmp.deflect(cos_phi, theta);
-            cosangle = scalar_product(direction_B, direction_tmp);
+            cosangle = direction_B*direction_tmp;
             EXPECT_NEAR(cos_phi, cosangle, 1e-8);
 
             direction_tmp = direction_C;
             direction_tmp.deflect(cos_phi, theta);
-            cosangle = scalar_product(direction_C, direction_tmp);
+            cosangle = direction_C*direction_tmp;
             EXPECT_NEAR(cos_phi, cosangle, 1e-8);
         }
     }


### PR DESCRIPTION
Until now, a Vector3D object held both Cartesian Coordinates and Spherical Coordinates. 
However, it has been the responsibility of both the user and/or a method to ensure that both coordinates are initialized and updated whenever necessary. This already lead to misunderstandings and errors (see #45 and #119).

In this pull request, I created a `Cartesian3D` and a `Spherical3D` class, both inheriting from a base class `Vector3D`.

The general idea is that both a Cartesian3D or a Spherical3D object may be passed to a function (using `const Vector3D&` as a parameter for the function). Then, the function can call one of the virtual functions `GetSphericalCoordinates()` or `GetCartesianCoordinates()` of the passed vector. If the Vector already contains the correct coordinates, they will just be returned, otherwise they will be calculated.

**Example:**
```
void DoSomething(const Vector3D& vec) {
    auto coordinates_cartesian = vec.GetCartesianCoordinates();
    // ...
}

auto vec1 = Cartesian3D(1, 0, 0);
auto vec2 = Spherical3D(1, 0, 0);

DoSomething(vec1); // inside the method, the cartesian coordinates are just used
DoSomething(vec2); // inside the method, the cartesian coordinates are calculated from the spherical coordinates
```