### PR TITLE
Trying to restructure Multiple Scattering return types

### DIFF
--- a/include/PROPOSAL/scattering/Scattering.h
+++ b/include/PROPOSAL/scattering/Scattering.h
@@ -61,7 +61,7 @@ protected:
         return _scale_deflect(angles, p.GetInteractionType());
     }
 
-    virtual std::array<double, 4> _scale_scatter(std::array<double, 4>& a)
+    virtual multiple_scattering::ScatteringAngles _scale_scatter(multiple_scattering::ScatteringAngles& a)
     {
         return a;
     }
@@ -133,11 +133,11 @@ public:
      * understanding.
      */
     template <typename... Args>
-    std::array<double, 4> CalculateMultipleScattering(Args... args)
+    multiple_scattering::ScatteringAngles CalculateMultipleScattering(Args... args)
     {
         if (m_scatter_ptr)
             return _multiple_scatter(*m_scatter_ptr, args...);
-        return std::array<double, 4> { 0, 0, 0, 0 };
+        return {};
     }
 };
 

--- a/include/PROPOSAL/scattering/ScatteringMultiplier.h
+++ b/include/PROPOSAL/scattering/ScatteringMultiplier.h
@@ -21,10 +21,10 @@ class ScatteringMultiplier : public Scattering {
         return angles;
     }
 
-    std::array<double, 4> _scale_scatter(std::array<double, 4>& angles) override
+    multiple_scattering::ScatteringAngles _scale_scatter(multiple_scattering::ScatteringAngles& angles) override
     {
-        for (auto& a : angles)
-            a *= multiple_scatt;
+        angles.s_phi *= multiple_scatt;
+        angles.t_phi *= multiple_scatt;
         return angles;
     }
 

--- a/include/PROPOSAL/scattering/multiple_scattering/Highland.h
+++ b/include/PROPOSAL/scattering/multiple_scattering/Highland.h
@@ -57,7 +57,7 @@ namespace multiple_scattering {
                 std::make_unique<Highland>(*this));
         }
 
-        std::array<double, 4> CalculateRandomAngle(double grammage, double ei,
+        ScatteringAngles CalculateRandomAngle(double grammage, double ei,
             double ef, const std::array<double, 4>& rnd) override;
         virtual double CalculateTheta0(double grammage, double ei, double ef);
     };

--- a/include/PROPOSAL/scattering/multiple_scattering/Moliere.h
+++ b/include/PROPOSAL/scattering/multiple_scattering/Moliere.h
@@ -79,7 +79,7 @@ namespace multiple_scattering {
         // constructor
         Moliere(const ParticleDef&, Medium const&);
 
-        std::array<double, 4> CalculateRandomAngle(double grammage, double ei,
+        ScatteringAngles CalculateRandomAngle(double grammage, double ei,
             double ef, const std::array<double, 4>& rnd) override;
     };
 } // namespace multiple_scattering

--- a/include/PROPOSAL/scattering/multiple_scattering/Parametrization.h
+++ b/include/PROPOSAL/scattering/multiple_scattering/Parametrization.h
@@ -33,6 +33,17 @@
 
 namespace PROPOSAL {
 namespace multiple_scattering {
+
+    struct ScatteringAngles {
+        ScatteringAngles() : s_phi(0.), s_theta(0.), t_phi(0.), t_theta(0.) {};
+        // mean_direction:
+        double s_phi;
+        double s_theta;
+        // final direction:
+        double t_phi;
+        double t_theta;
+    };
+
     class Parametrization {
     protected:
         double mass;
@@ -47,9 +58,7 @@ namespace multiple_scattering {
         virtual bool compare(const Parametrization&) const = 0;
         virtual void print(std::ostream&) const = 0;
 
-        enum { SX, SY, TX, TY };
-
-        virtual std::array<double, 4> CalculateRandomAngle(double grammage,
+        virtual ScatteringAngles CalculateRandomAngle(double grammage,
             double ei, double ef, const std::array<double, 4>& rnd)
             = 0;
 

--- a/src/PROPOSAL/propagation_utility/PropagationUtility.cxx
+++ b/src/PROPOSAL/propagation_utility/PropagationUtility.cxx
@@ -145,32 +145,11 @@ std::tuple<Cartesian3D, Cartesian3D> PropagationUtility::DirectionsScatter(
         auto random_angles = collection.scattering->CalculateMultipleScattering(
             displacement, initial_energy, final_energy, random_numbers);
 
-        auto& sx = random_angles[multiple_scattering::Parametrization::SX];
-        auto& sy = random_angles[multiple_scattering::Parametrization::SY];
-        auto& tx = random_angles[multiple_scattering::Parametrization::TX];
-        auto& ty = random_angles[multiple_scattering::Parametrization::TY];
-        auto sz = std::sqrt(std::max(1. - (sx * sx + sy * sy), 0.));
-        auto tz = std::sqrt(std::max(1. - (tx * tx + ty * ty), 0.));
+        auto mean_direction = Cartesian3D(direction);
+        mean_direction.deflect(std::cos(random_angles.s_phi), random_angles.s_theta);
 
-        auto direction_spherical = Spherical3D(direction);
-        auto sinth = std::sin(direction_spherical.GetZenith());
-        auto costh = std::cos(direction_spherical.GetZenith());
-        auto sinph = std::sin(direction_spherical.GetAzimuth());
-        auto cosph = std::cos(direction_spherical.GetAzimuth());
-
-        auto rotate_vector_x = Cartesian3D(costh * cosph, costh * sinph, -sinth);
-        auto rotate_vector_y = Cartesian3D(-sinph, cosph, 0.);
-
-        // Rotation towards all tree axes
-        auto direction_cartesian = Cartesian3D(direction);
-        auto mean_direction = sz * direction_cartesian;
-        mean_direction += sx * rotate_vector_x;
-        mean_direction += sy * rotate_vector_y;
-
-        // Rotation towards all tree axes
-        auto final_direction = tz * direction_cartesian;
-        final_direction += tx * rotate_vector_x;
-        final_direction += ty * rotate_vector_y;
+        auto final_direction = Cartesian3D(direction);
+        final_direction.deflect(std::cos(random_angles.t_phi), random_angles.t_theta);
 
         return std::make_tuple(mean_direction, final_direction);
     }

--- a/src/PROPOSAL/scattering/multiple_scattering/Highland.cxx
+++ b/src/PROPOSAL/scattering/multiple_scattering/Highland.cxx
@@ -66,7 +66,7 @@ double Highland::CalculateTheta0(double grammage, double ei, double ef)
 
 //----------------------------------------------------------------------------//
 
-std::array<double, 4> Highland::CalculateRandomAngle(
+ScatteringAngles Highland::CalculateRandomAngle(
     double grammage, double ei, double ef, const std::array<double, 4>& rnd)
 {
     auto Theta0 = CalculateTheta0(grammage, ei, ef);
@@ -83,5 +83,11 @@ std::array<double, 4> Highland::CalculateRandomAngle(
     auto sy = 0.5 * (rnd1 / SQRT3 + rnd2);
     auto ty = rnd2;
 
-    return std::array<double, 4> { sx, sy, tx, ty };
+    multiple_scattering::ScatteringAngles angles{};
+    angles.s_phi = std::asin(std::sqrt(sx * sx + sy * sy));
+    angles.s_theta = std::atan2(sy, sx);
+    angles.t_phi = std::asin(std::sqrt(tx * tx + ty * ty));
+    angles.t_theta = std::atan2(ty, tx);
+
+    return angles;
 }

--- a/src/PROPOSAL/scattering/multiple_scattering/Moliere.cxx
+++ b/src/PROPOSAL/scattering/multiple_scattering/Moliere.cxx
@@ -10,7 +10,7 @@
 
 using namespace PROPOSAL::multiple_scattering;
 
-std::array<double, 4> Moliere::CalculateRandomAngle(
+ScatteringAngles Moliere::CalculateRandomAngle(
     double grammage, double ei, double ef, const std::array<double, 4>& rnd)
 {
     (void)ef;
@@ -57,7 +57,7 @@ std::array<double, 4> Moliere::CalculateRandomAngle(
         //  Check for inappropriate values of B. If B < 4.5 it is practical to
         //  assume no deviation.
         if ((xn < 4.5) || xn != xn) {
-            return std::array<double, 4>{0,0,0,0};
+            return {};
         }
 
         B_[i] = xn;
@@ -77,7 +77,13 @@ std::array<double, 4> Moliere::CalculateRandomAngle(
     auto sy = 0.5 * (rnd1 / SQRT3 + rnd2);
     auto ty = rnd2;
 
-    return std::array<double, 4>{sx, sy, tx, ty};
+    multiple_scattering::ScatteringAngles angles{};
+    angles.s_phi = std::asin(std::sqrt(sx * sx + sy * sy));
+    angles.s_theta = std::atan2(sy, sx);
+    angles.t_phi = std::asin(std::sqrt(tx * tx + ty * ty));
+    angles.t_theta = std::atan2(ty, tx);
+
+    return angles;
 }
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
As already described in issue #117, the return types of multiple scattering are rather confusing.
From the point of view of a user, it would be more convenient to return angles rather than cartesian offsets.
Here, I naively tried to implement this behavior by converting these offsets to angles. However, there are still some unresolved issue and problems:

- There are a lot of conversions during the whole process which are probably computationally expensive and become numerically unstable, at least when very small angles (< 1e-5° are involved). This causes UnitTests to fail.
- I was unable to come up with an appropriate, intuitive name for the members of the `ScatteringAngles` (currently named `s` and `t`)

The problem with the first point is that the description of Multiple Scattering we currently use describes Multiple Scattering using the Cartesian offests I would actually like to get rid off:

![image](https://user-images.githubusercontent.com/15159319/110636179-4102e980-81ac-11eb-8a36-d0879ef81781.png)
where z_1 and z_2 are independent standard Gaussian random variables and theta_0 is a given constant (image taken from [arXiv:hep-ph/0407075](https://arxiv.org/pdf/hep-ph/0407075.pdf))

I am not sure whether there is an intelligent way to avoid all these conversions.
