### PR TITLE
Fit not initalized values in ManyBodyPhaseSpace::SampleEstimateMaxWeight

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
@@ -257,13 +257,16 @@ void ManyBodyPhaseSpace::SampleEstimateMaxWeight(PhaseSpaceParameters& params, c
     }
 
     // precalculated kinematics
-    PhaseSpaceKinematics kinematics;
     ParticleState particle;
     particle.type = parent_def.particle_type;
     particle.energy = parent_def.mass;
 
-    double result = 0.0;
-    params.weight_min = 0.0;
+    // initialization of weights
+    PhaseSpaceKinematics kinematics = CalculateKinematics(params.normalization, parent_def.mass);
+    GenerateEvent(products, kinematics);
+    double result = kinematics.weight * matrix_element_(particle, products);
+    params.weight_min = result;
+    params.weight_max = result;
 
     for (int i = 0; i < broad_phase_statistic_; ++i)
     {

--- a/src/PROPOSAL/detail/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
@@ -268,7 +268,7 @@ void ManyBodyPhaseSpace::SampleEstimateMaxWeight(PhaseSpaceParameters& params, c
     params.weight_min = result;
     params.weight_max = result;
 
-    for (int i = 0; i < broad_phase_statistic_; ++i)
+    for (int i = 1; i < broad_phase_statistic_; ++i)
     {
         kinematics = CalculateKinematics(params.normalization, parent_def.mass);
         GenerateEvent(products, kinematics);


### PR DESCRIPTION
In ManyBodyPhaseSpace::SampleEstimateMaxWeight, the PhaseSpaceParameters struct has not been intialized. This undefined behavior was able to cause bugs depending on the build system. The initial guesses are now initialized using the first iteration.