### PR TITLE
Remove fixes and warnings related to former bug with pybind11 in conan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ class build_ext_cmake(build_ext):
                 '-o with_testing=False'
             ]
             sp.run(conan_call, cwd=self.build_temp, check=True)
-            os.remove(self.build_temp + "/Findpybind11.cmake") # bugfix
         cmake_call = [
             cmake,
             ext.source_dir,

--- a/src/pyPROPOSAL/CMakeLists.txt
+++ b/src/pyPROPOSAL/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.9)
 
 project(pyPROPOSAL LANGUAGES CXX)
 
-if (EXISTS ${CMAKE_BINARY_DIR}/Findpybind11.cmake)
-    message(WARNING " There seems to be currently a bug in conans pybind11 module, you have to temporary install pybind11 by your own and delete the Findpybind11.cmake module in your binary dir. Hopefully fix this soon.")
-endif()
-
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
 find_package(pybind11 REQUIRED)
 


### PR DESCRIPTION
There has been a [bugfix in conan](https://github.com/conan-io/conan-center-index/pull/4445) which means that installation of pybind11 with conan should now be possible again.

Therefore, I removed the workaround in pypi as well as the warning message in the CMakeLists.txt