### PR TITLE
Use json_fwd.hpp for forward declarations whenever possible

### DIFF
--- a/src/PROPOSAL/PROPOSAL/EnergyCutSettings.h
+++ b/src/PROPOSAL/PROPOSAL/EnergyCutSettings.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <ostream>
 
 namespace PROPOSAL {

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/AnnihilationFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/AnnihilationFactory.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 #include <memory>
 
 namespace PROPOSAL {

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/BremsstrahlungFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/BremsstrahlungFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/ComptonFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/ComptonFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/EpairProductionFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/EpairProductionFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/IonizationFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/IonizationFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/MupairProductionFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/MupairProductionFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotonuclearFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotonuclearFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/WeakInteractionFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/WeakInteractionFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
     struct CrossSectionBase;

--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <string>
 #include "PROPOSAL/crosssection/parametrization/Parametrization.h"
 #include "PROPOSAL/methods.h"
 

--- a/src/PROPOSAL/PROPOSAL/density_distr/density_distr.h
+++ b/src/PROPOSAL/PROPOSAL/density_distr/density_distr.h
@@ -30,7 +30,7 @@
 #include <functional>
 #include <string>
 #include "PROPOSAL/math/Cartesian3D.h"
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL {
 class Axis {

--- a/src/PROPOSAL/PROPOSAL/geometry/Box.h
+++ b/src/PROPOSAL/PROPOSAL/geometry/Box.h
@@ -30,7 +30,7 @@
 #pragma once
 
 #include "PROPOSAL/geometry/Geometry.h"
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 
 namespace PROPOSAL {

--- a/src/PROPOSAL/PROPOSAL/geometry/Box.h
+++ b/src/PROPOSAL/PROPOSAL/geometry/Box.h
@@ -30,8 +30,6 @@
 #pragma once
 
 #include "PROPOSAL/geometry/Geometry.h"
-#include <nlohmann/json_fwd.hpp>
-
 
 namespace PROPOSAL {
 

--- a/src/PROPOSAL/PROPOSAL/geometry/Cylinder.h
+++ b/src/PROPOSAL/PROPOSAL/geometry/Cylinder.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "PROPOSAL/geometry/Geometry.h"
-#include <nlohmann/json.hpp>
 
 namespace PROPOSAL {
 class Cylinder : public Geometry

--- a/src/PROPOSAL/PROPOSAL/geometry/Geometry.h
+++ b/src/PROPOSAL/PROPOSAL/geometry/Geometry.h
@@ -31,6 +31,7 @@
 
 #include <map>
 #include <memory>
+#include <nlohmann/json_fwd.hpp>
 #include "PROPOSAL/math/Cartesian3D.h"
 #include "PROPOSAL/math/Vector3D.h"
 

--- a/src/PROPOSAL/PROPOSAL/geometry/Geometry.h
+++ b/src/PROPOSAL/PROPOSAL/geometry/Geometry.h
@@ -31,10 +31,8 @@
 
 #include <map>
 #include <memory>
-#include <PROPOSAL/math/Cartesian3D.h>
-
+#include "PROPOSAL/math/Cartesian3D.h"
 #include "PROPOSAL/math/Vector3D.h"
-#include <nlohmann/json.hpp>
 
 
 namespace PROPOSAL {

--- a/src/PROPOSAL/PROPOSAL/geometry/Sphere.h
+++ b/src/PROPOSAL/PROPOSAL/geometry/Sphere.h
@@ -30,7 +30,7 @@
 #pragma once
 
 #include "PROPOSAL/geometry/Geometry.h"
-#include <nlohmann/json.hpp>
+
 namespace PROPOSAL {
 
 class Sphere : public Geometry

--- a/src/PROPOSAL/PROPOSAL/math/Cartesian3D.h
+++ b/src/PROPOSAL/PROPOSAL/math/Cartesian3D.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "PROPOSAL/math/Vector3D.h"
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL{
     class Spherical3D;

--- a/src/PROPOSAL/PROPOSAL/math/Function.h
+++ b/src/PROPOSAL/PROPOSAL/math/Function.h
@@ -31,7 +31,7 @@
 
 #include <functional>
 #include <vector>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 // %%%%%%%%%%%%%%%%%%%       Polynom      %%%%%%%%%%%%%%%%%%%%

--- a/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
+++ b/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "PROPOSAL/math/Vector3D.h"
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace PROPOSAL  {
     class Cartesian3D;

--- a/src/PROPOSAL/PROPOSAL/math/Spline.h
+++ b/src/PROPOSAL/PROPOSAL/math/Spline.h
@@ -33,7 +33,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <nlohmann/json.hpp>
 #include "PROPOSAL/math/Function.h"
 
 namespace PROPOSAL {

--- a/src/PROPOSAL/PROPOSAL/medium/MediumFactory.h
+++ b/src/PROPOSAL/PROPOSAL/medium/MediumFactory.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <string>
 
-#include <nlohmann/json.hpp>
 #include "PROPOSAL/medium/Medium.h"
 
 namespace PROPOSAL {

--- a/src/PROPOSAL/PROPOSAL/methods.h
+++ b/src/PROPOSAL/PROPOSAL/methods.h
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include <nlohmann/json.hpp> // TODO: Use json_fwd.hpp as soon as https://github.com/conan-io/conan-center-index/pull/5149 is merged
 #include <deque>
 #include <functional>
 #include <map>

--- a/src/PROPOSAL/detail/PROPOSAL/EnergyCutSettings.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/EnergyCutSettings.cxx
@@ -3,6 +3,7 @@
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/Logging.h"
 #include "PROPOSAL/methods.h"
+#include <nlohmann/json.hpp>
 
 #include <sstream>
 #include <stdexcept>

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXIntegral.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXIntegral.cxx
@@ -6,6 +6,7 @@
 #include "PROPOSAL/medium/Components.h"
 #include "PROPOSAL/medium/Medium.h"
 #include "PROPOSAL/particle/ParticleDef.h"
+#include <cmath>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/AnnihilationFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/AnnihilationFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/Annihilation.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using annih_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&, bool);

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/BremsstrahlungFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/BremsstrahlungFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/Bremsstrahlung.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using brems_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&,

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/ComptonFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/ComptonFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/Compton.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using compton_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&, std::shared_ptr<const EnergyCutSettings>, bool);

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/EpairProductionFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/EpairProductionFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/EpairProduction.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using epair_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&,

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/IonizationFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/IonizationFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/Ionization.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using ioniz_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&, std::shared_ptr<const EnergyCutSettings>, bool);

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/MupairProductionFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/MupairProductionFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/MupairProduction.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using mupair_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&, std::shared_ptr<const EnergyCutSettings>, bool);

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/PhotoPairProduction.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using photopair_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&, bool);

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/PhotonuclearFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/PhotonuclearFactory.cxx
@@ -3,6 +3,7 @@
 #include "PROPOSAL/crosssection/parametrization/PhotoRealPhotonAssumption.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using photoQ2_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&, std::shared_ptr<const EnergyCutSettings>, std::shared_ptr<crosssection::ShadowEffect>, bool);

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/WeakInteractionFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/Factories/WeakInteractionFactory.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/crosssection/parametrization/WeakInteraction.h"
 #include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/crosssection/CrossSectionMultiplier.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 using weak_func_ptr = cross_ptr (*)(const ParticleDef&, const Medium&, bool);

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Compton.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Compton.cxx
@@ -1,6 +1,6 @@
 
 #include <cmath>
-
+#include <cassert>
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/crosssection/parametrization/Compton.h"
 #include "PROPOSAL/medium/Components.h"

--- a/src/PROPOSAL/detail/PROPOSAL/decay/LeptonicDecayChannel.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/decay/LeptonicDecayChannel.cxx
@@ -1,6 +1,6 @@
 #include <functional>
 #include <cmath>
-
+#include <cassert>
 
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/decay/LeptonicDecayChannel.h"

--- a/src/PROPOSAL/detail/PROPOSAL/density_distr/density_distr.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/density_distr/density_distr.cxx
@@ -8,6 +8,7 @@
 #include "PROPOSAL/density_distr/density_splines.h"
 #include "PROPOSAL/medium/Medium.h"
 #include "PROPOSAL/math/Cartesian3D.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/density_distr/density_exponential.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/density_distr/density_exponential.cxx
@@ -3,6 +3,8 @@
 #include <iostream>
 #include "PROPOSAL/density_distr/density_exponential.h"
 #include "PROPOSAL/medium/Medium.h"
+#include <nlohmann/json.hpp>
+
 using namespace PROPOSAL;
 
 Density_exponential::Density_exponential(const Axis& axis, double sigma, double d0, double massDensity)

--- a/src/PROPOSAL/detail/PROPOSAL/density_distr/density_homogeneous.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/density_distr/density_homogeneous.cxx
@@ -3,6 +3,8 @@
 #include <iostream>
 #include "PROPOSAL/density_distr/density_homogeneous.h"
 #include "PROPOSAL/medium/Medium.h"
+#include <nlohmann/json.hpp>
+
 using namespace PROPOSAL;
 
 Density_homogeneous::Density_homogeneous(double massDensity)

--- a/src/PROPOSAL/detail/PROPOSAL/density_distr/density_polynomial.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/density_distr/density_polynomial.cxx
@@ -4,6 +4,8 @@
 #include "PROPOSAL/density_distr/density_polynomial.h"
 #include "PROPOSAL/medium/Medium.h"
 #include "PROPOSAL/math/Cartesian3D.h"
+#include <nlohmann/json.hpp>
+
 using namespace PROPOSAL;
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 // %%%%%%%%%%%%%%%%%%% Polynomial-Density %%%%%%%%%%%%%%%%%%%%

--- a/src/PROPOSAL/detail/PROPOSAL/density_distr/density_splines.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/density_distr/density_splines.cxx
@@ -3,6 +3,8 @@
 #include "PROPOSAL/density_distr/density_splines.h"
 #include "PROPOSAL/medium/Medium.h"
 #include "PROPOSAL/math/Cartesian3D.h"
+#include <nlohmann/json.hpp>
+
 using namespace PROPOSAL;
 
 Density_splines::Density_splines(const Axis& axis, const Spline& splines, double massDensity)

--- a/src/PROPOSAL/detail/PROPOSAL/geometry/Box.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/geometry/Box.cxx
@@ -5,6 +5,7 @@
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/Logging.h"
 #include "PROPOSAL/geometry/Box.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/geometry/Cylinder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/geometry/Cylinder.cxx
@@ -5,6 +5,7 @@
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/Logging.h"
 #include "PROPOSAL/geometry/Cylinder.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/geometry/Geometry.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/geometry/Geometry.cxx
@@ -9,6 +9,7 @@
 #include "PROPOSAL/geometry/Geometry.h"
 
 #include "PROPOSAL/methods.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/geometry/GeometryFactory.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/geometry/GeometryFactory.cxx
@@ -6,6 +6,7 @@
 #include "PROPOSAL/Logging.h"
 #include "PROPOSAL/geometry/Geometry.h"
 #include "PROPOSAL/geometry/GeometryFactory.h"
+#include <nlohmann/json.hpp>
 
 /* namespace PROPOSAL { */
 /* std::shared_ptr<Geometry> CreateGeometry(Geometry_Type type) */

--- a/src/PROPOSAL/detail/PROPOSAL/geometry/Sphere.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/geometry/Sphere.cxx
@@ -3,6 +3,8 @@
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/Logging.h"
 #include "PROPOSAL/geometry/Sphere.h"
+#include <nlohmann/json.hpp>
+
 using namespace PROPOSAL;
 
 Sphere::Sphere(const Vector3D& position, double radius, double inner_radius)

--- a/src/PROPOSAL/detail/PROPOSAL/math/Cartesian3D.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/math/Cartesian3D.cxx
@@ -1,5 +1,6 @@
 #include "PROPOSAL/math/Cartesian3D.h"
 #include "PROPOSAL/math/Spherical3D.h"
+#include <nlohmann/json.hpp>
 #include <cmath>
 
 using namespace PROPOSAL;

--- a/src/PROPOSAL/detail/PROPOSAL/math/Function.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/math/Function.cxx
@@ -4,6 +4,7 @@
 #include <functional>
 #include <iostream>
 #include "PROPOSAL/Constants.h"
+#include <nlohmann/json.hpp>
 
 // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 // %%%%%%%%%%%%%%%%%%%       Polynom      %%%%%%%%%%%%%%%%%%%%

--- a/src/PROPOSAL/detail/PROPOSAL/math/Spherical3D.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/math/Spherical3D.cxx
@@ -1,5 +1,6 @@
 #include "PROPOSAL/math/Spherical3D.h"
 #include "PROPOSAL/math/Cartesian3D.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/math/Spline.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/math/Spline.cxx
@@ -10,6 +10,7 @@
 #include "PROPOSAL/math/MathMethods.h"
 #include "PROPOSAL/math/Spline.h"
 #include "PROPOSAL/math/TableWriter.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/math/Vector3D.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/math/Vector3D.cxx
@@ -4,6 +4,7 @@
 
 #include "PROPOSAL/math/Vector3D.h"
 #include "PROPOSAL/methods.h"
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/Interaction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/Interaction.cxx
@@ -3,6 +3,7 @@
 #include "PROPOSAL/propagation_utility/Displacement.h"
 
 #include <sstream>
+#include <numeric>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/TsaiApproximationBremsstrahlung.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/TsaiApproximationBremsstrahlung.cxx
@@ -1,6 +1,6 @@
 #include "PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/TsaiApproximationBremsstrahlung.h"
 #include "PROPOSAL/Constants.h"
-
+#include <cmath>
 using namespace PROPOSAL;
 
 DirectionChangeAngular 

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.cxx
@@ -1,6 +1,6 @@
 #include "PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.h"
 #include "PROPOSAL/Constants.h"
-
+#include <cmath>
 using namespace PROPOSAL;
 
 DirectionChangeAngular

--- a/tests/Annihilation_TEST.cxx
+++ b/tests/Annihilation_TEST.cxx
@@ -1,5 +1,6 @@
 
 #include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
 
 #include "PROPOSAL/crosssection/CrossSection.h"
 #include "PROPOSAL/crosssection/Factories/AnnihilationFactory.h"

--- a/tests/Bremsstrahlung_TEST.cxx
+++ b/tests/Bremsstrahlung_TEST.cxx
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
 
 #include "PROPOSALTestUtilities/TestFilesHandling.h"
 #include "PROPOSAL/Constants.h"

--- a/tests/Compton_TEST.cxx
+++ b/tests/Compton_TEST.cxx
@@ -15,6 +15,7 @@
 #include "PROPOSALTestUtilities/TestFilesHandling.h"
 
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 using namespace PROPOSAL;
 

--- a/tests/Epairproduction_TEST.cxx
+++ b/tests/Epairproduction_TEST.cxx
@@ -1,5 +1,6 @@
 
 #include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
 
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/crosssection/Factories/EpairProductionFactory.h"

--- a/tests/Ionization_TEST.cxx
+++ b/tests/Ionization_TEST.cxx
@@ -1,5 +1,6 @@
 
 #include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
 
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/crosssection/CrossSection.h"

--- a/tests/Mupairproduction_TEST.cxx
+++ b/tests/Mupairproduction_TEST.cxx
@@ -1,5 +1,6 @@
 
 #include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
 
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/crosssection/CrossSection.h"

--- a/tests/PhotoPair_TEST.cxx
+++ b/tests/PhotoPair_TEST.cxx
@@ -1,5 +1,6 @@
 
 #include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
 
 #include "PROPOSAL/crosssection/CrossSection.h"
 #include "PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.h"

--- a/tests/Photonuclear_TEST.cxx
+++ b/tests/Photonuclear_TEST.cxx
@@ -1,6 +1,6 @@
 
 #include "gtest/gtest.h"
-
+#include <nlohmann/json.hpp>
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/crosssection/CrossSection.h"
 #include "PROPOSALTestUtilities/TestFilesHandling.h"

--- a/tests/WeakInteraction_TEST.cxx
+++ b/tests/WeakInteraction_TEST.cxx
@@ -1,5 +1,6 @@
 
 #include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
 
 #include "PROPOSAL/crosssection/CrossSection.h"
 #include "PROPOSAL/crosssection/Factories/WeakInteractionFactory.h"


### PR DESCRIPTION
Now that [this PR in conan-center-index](https://github.com/conan-io/conan-center-index/pull/5188) has been approved, we can use `json_fwd.hpp` in our code when we only need the forward declarations from nlohmann_json (for example in `.h` files). I've been going through the code to find as many files as possible where we can use `json_fwd.hpp` instead of the full `json.hpp` to save compilation time. I had to add some headers from the std library that were missing now.