### PR TITLE
WIP: Find appropriate solution for visibility settings / Rework CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,9 @@ endif()
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# removes tons of compiler warnings on clang (issue #141). there is probably a cleaner solution.
-if(NOT BUILD_SHARED_LIBS)
-	set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-endif()
+set(WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_CXX_VISIBILITY_PRESET default)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
 
 option(BUILD_PYTHON "build python interface" OFF)
 option(BUILD_EXAMPLE "build example" OFF)


### PR DESCRIPTION
I've been looking into the visibility settings for PROPOSAL, trying to find an acceptable solution.

**Original problem and current quick-fix**

The reason we started thinking about this problem was a huge amount of linker errors when trying to build PROPOSAL (as a static library) with pybind11-bindings on MacOS (see  issue #141).
These warnings were gone by [adding](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/44265c664ce5d9664926c852c263ad99aa800f90/CMakeLists.txt#L35) these lines to the CMakeLists:

```
if(NOT BUILD_SHARED_LIBS)
	set(CMAKE_CXX_VISIBILITY_PRESET hidden)
endif()
```

However, I am not sure why this actually solved the initial problem (the visibility setting should have no influence when building a static library, does it?)

**Trying to find a better solution for this problem**

Looking at [this gist](https://gist.github.com/ax3l/ba17f4bb1edb5885a6bd01f58de4d542) about pybind11, the best solution would be to hide all symbols by default, and explicitly exposing all symbols that should be globally available. 

I've been trying to do so, but I ran into a significant problem: _Templates_

PROPOSAL is extensively relying on templates at the moment. The best example for a template function that causes problems is [`make_crosssection`](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/44265c664ce5d9664926c852c263ad99aa800f90/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionBuilder.h#L10). Exposing this function is essential since it is the main interface for users to create CrossSections objects. However, exposing this function also means that all functions and classes that are used within the original template function need to be exposed as well (since our function is a template function and is therefore inline). Otherwise, I get linker errors.

I found three possible solutions for this issue:

1. We can expose all functions and classes that are needed by the template function. To do that, we have to expose **a lot** of functions that are not really supposed to be exposed from the point of view of a user, for example functions such as [`transform_relative_loss`](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/44265c664ce5d9664926c852c263ad99aa800f90/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.h#L14) or classes such as [`AxisBuilderDNDX`](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/44265c664ce5d9664926c852c263ad99aa800f90/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDNDX/AxisBuilderDNDX.h#L9). 
2. We can write template specifications for all cases. Even with some adjustments, the best we could do (without a major code redesign) is to have template specifications for every possible parametrization (so we are talking about ~30 specifications just for that). This seems to be rather maintenance heavy.
3. We can expose everything ("if we have to expose almost everything, we can just expose everything")

I tried solution three for now since it seems to be the easiest and most practical solution:

```
set(WINDOWS_EXPORT_ALL_SYMBOLS ON)
set(CMAKE_CXX_VISIBILITY_PRESET default)
set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
```

Remember that `clang` and `gcc` already expose all symbols by default, while Windows hides them by default so we need to set an explicit CMake option.
Issue #141 seems to be still solved when using this solution.
