### PR TITLE
Fix travis CI for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,13 +64,9 @@ jobs:
       dist: focal
       name: Linux clang 6.0
       python: 3.9
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-6.0
-          packages:
-            - clang-6.0
+      before_install:
+        - sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install ubuntu-toolchain-r-test llvm-toolchain-6.0 clang-6.0 -o Debug::pkgProblemResolver=yes
       env:
         - CC=clang
         - CXX=clang++
@@ -79,13 +75,9 @@ jobs:
       dist: focal
       name: Linux clang 10
       python: 3.9
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-focal-10
-          packages:
-            - clang-10
+      before_install:
+        - sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install ubuntu-toolchain-r-test llvm-toolchain-focal-10 clang-10 -o Debug::pkgProblemResolver=yes
       env:
         - CC=clang
         - CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,12 @@ jobs:
       python: 3.9
       before_install:
         - sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install ubuntu-toolchain-r-test llvm-toolchain-6.0 clang-6.0 -o Debug::pkgProblemResolver=yes
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install clang-6.0 -o Debug::pkgProblemResolver=yes
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-6.0
       env:
         - CC=clang
         - CXX=clang++
@@ -77,7 +82,13 @@ jobs:
       python: 3.9
       before_install:
         - sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install ubuntu-toolchain-r-test llvm-toolchain-focal-10 clang-10 -o Debug::pkgProblemResolver=yes
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-downgrades --allow-remove-essential --allow-change-held-packages install clang-10 -o Debug::pkgProblemResolver=yes
+
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-focal-10
       env:
         - CC=clang
         - CXX=clang++


### PR DESCRIPTION
Both clang-6 and clang-10 have recently been broken on travis.

I fixed it according to the instructions from [this post](https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527) in the travis forum.

To be honest, I am not quite happy that we need to make such a fix. So this would be another reason to change to github actions, as already suggested in issue #143. Maximilian already started some tests to make this work in MR #155.