### PR TITLE
add pybindings for the `DirectionChangeAngular`

### DIFF
--- a/src/PROPOSAL/PROPOSAL/PROPOSAL.h
+++ b/src/PROPOSAL/PROPOSAL/PROPOSAL.h
@@ -156,7 +156,6 @@
 #include "PROPOSAL/scattering/ScatteringFactory.h"
 #include "PROPOSAL/scattering/ScatteringMultiplier.h"
 #include "PROPOSAL/scattering/ScatteringFactory.h"
-#include "PROPOSAL/scattering/DirectionChange.h"
 
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/EnergyCutSettings.h"

--- a/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
+++ b/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
@@ -34,4 +34,22 @@ namespace PROPOSAL  {
     protected:
         void print(std::ostream&) const override;
      };
+
+
+    /*!
+     * Container for a spherical vector with radius 1
+     *
+     * \param zenith
+     * \param azimuth
+     */
+     struct UnitSphericalVector{
+        double zenith;
+        double azimuth;
+    
+        constexpr UnitSphericalVector(const UnitSphericalVector&) = default;
+        constexpr UnitSphericalVector(double zenith, double azimuth)
+            : zenith(zenith), azimuth(azimuth) {};
+        constexpr UnitSphericalVector(const Spherical3D& s)
+            : zenith(s.GetZenith()), azimuth(s.GetAzimuth()) {};
+     };
 } // namespace PROPOSAL

--- a/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
+++ b/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
@@ -43,10 +43,10 @@ namespace PROPOSAL  {
      * \param azimuth
      */
      struct UnitSphericalVector{
-        double zenith;
-        double azimuth;
+        double zenith = 0;
+        double azimuth = 0;
     
-        UnitSphericalVector() = default;
+        constexpr UnitSphericalVector() = default;
         constexpr UnitSphericalVector(double zenith, double azimuth)
             : zenith(zenith), azimuth(azimuth) {};
         constexpr UnitSphericalVector(const Spherical3D& s)

--- a/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
+++ b/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
@@ -15,8 +15,8 @@ namespace PROPOSAL  {
 
 
         auto GetRadius() const {return coordinates[Radius];}
-        auto GetAzimuth() const {return coordinates[Azimuth];}
-        auto GetZenith() const {return coordinates[Zenith];}
+        constexpr auto GetAzimuth() const {return coordinates[Azimuth];}
+        constexpr auto GetZenith() const {return coordinates[Zenith];}
         void SetRadius(double radius) {coordinates[Radius] = radius;}
         void SetAzimuth(double azimuth) {coordinates[Azimuth] = azimuth;}
         void SetZenith(double zenith) {coordinates[Zenith] = zenith;}
@@ -46,7 +46,7 @@ namespace PROPOSAL  {
         double zenith;
         double azimuth;
     
-        constexpr UnitSphericalVector(const UnitSphericalVector&) = default;
+        UnitSphericalVector() = default;
         constexpr UnitSphericalVector(double zenith, double azimuth)
             : zenith(zenith), azimuth(azimuth) {};
         constexpr UnitSphericalVector(const Spherical3D& s)

--- a/src/PROPOSAL/PROPOSAL/scattering/DirectionChange.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/DirectionChange.h
@@ -1,8 +1,0 @@
-#pragma once 
-
-namespace PROPOSAL {
-struct DirectionChangeAngular {
-    double zenith;
-    double azimuth;
-};
-}

--- a/src/PROPOSAL/PROPOSAL/scattering/Scattering.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/Scattering.h
@@ -53,8 +53,8 @@ class Scattering {
     }
 
 protected:
-    virtual DirectionChangeAngular _scale_deflect(
-        DirectionChangeAngular& a, InteractionType)
+    virtual UnitSphericalVector _scale_deflect(
+        UnitSphericalVector& a, InteractionType)
     {
         return a;
     }
@@ -126,15 +126,13 @@ public:
      * understanding.
      */
     template <typename... Args>
-    DirectionChangeAngular CalculateStochasticDeflection(
+    UnitSphericalVector CalculateStochasticDeflection(
         InteractionType t, Args... args)
     {
         auto it = stochastic_deflection.find(t);
         if (it != stochastic_deflection.end())
             return _stochastic_deflect(*it->second, args...);
-        auto new_dir =DirectionChangeAngular();
-        new_dir.zenith = 0.;
-        new_dir.azimuth = 0.;
+        auto new_dir = UnitSphericalVector(0, 0);
         return new_dir;
     }
 

--- a/src/PROPOSAL/PROPOSAL/scattering/Scattering.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/Scattering.h
@@ -124,6 +124,9 @@ public:
      * @brief Calculates deflection angles for specific interaction type. Take a
      * deeper look into stochastic_deflection::Parametrization for a better
      * understanding.
+     *
+     * returns a UnitSphericalVector, which is a normalized spherical vector
+     * containing the angular change of the direction.
      */
     template <typename... Args>
     UnitSphericalVector CalculateStochasticDeflection(

--- a/src/PROPOSAL/PROPOSAL/scattering/ScatteringMultiplier.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/ScatteringMultiplier.h
@@ -8,7 +8,7 @@ class ScatteringMultiplier : public Scattering {
     double multiple_scatt = 1;
     std::vector<std::pair<InteractionType, double>> stochastic_deflect;
 
-    DirectionChangeAngular _scale_deflect(DirectionChangeAngular& angles, InteractionType t) override
+    UnitSphericalVector _scale_deflect(UnitSphericalVector& angles, InteractionType t) override
     {
         for (auto m : stochastic_deflect) {
             if (m.first == t) {

--- a/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/Parametrization.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/Parametrization.h
@@ -3,7 +3,7 @@
 #include "PROPOSAL/RegisteredInDefault.h"
 #include "PROPOSAL/medium/Components.h"
 #include "PROPOSAL/particle/Particle.h"
-#include "PROPOSAL/scattering/DirectionChange.h"
+#include "PROPOSAL/math/Spherical3D.h"
 
 #include <array>
 #include <memory>
@@ -21,7 +21,7 @@ namespace stochastic_deflection {
 
         virtual size_t RequiredRandomNumbers() const noexcept = 0;
         virtual InteractionType GetInteractionType() const noexcept = 0;
-        virtual DirectionChangeAngular CalculateStochasticDeflection(
+        virtual UnitSphericalVector CalculateStochasticDeflection(
             double initial_energy, double final_energy,
             std::vector<double> const&) const = 0;
     };

--- a/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/TsaiApproximationBremsstrahlung.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/TsaiApproximationBremsstrahlung.h
@@ -22,7 +22,7 @@ namespace stochastic_deflection {
 
         size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
 
-        DirectionChangeAngular CalculateStochasticDeflection(
+        UnitSphericalVector CalculateStochasticDeflection(
             double e_i, double e_f, std::vector<double> const& rnd) const final;
     };
 } // namespace stochastic_deflection

--- a/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.h
@@ -22,7 +22,7 @@ namespace PROPOSAL {
 
             size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
 
-            DirectionChangeAngular CalculateStochasticDeflection(
+            UnitSphericalVector CalculateStochasticDeflection(
                     double e_i, double e_f, std::vector<double> const& rnd) const final;
         };
     } // namespace stochastic_deflection

--- a/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/nuclearInteraction/BorogPetrukhinNuclearInteraction.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/nuclearInteraction/BorogPetrukhinNuclearInteraction.h
@@ -23,7 +23,7 @@ namespace PROPOSAL {
 
             size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
 
-            DirectionChangeAngular CalculateStochasticDeflection(
+            UnitSphericalVector CalculateStochasticDeflection(
                     double e_i, double e_f, std::vector<double> const& rnd) const final;
         };
     } // namespace stochastic_deflection

--- a/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/pairProd/KelnerPairProduction.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/pairProd/KelnerPairProduction.h
@@ -22,7 +22,7 @@ namespace PROPOSAL {
 
             size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
 
-            DirectionChangeAngular CalculateStochasticDeflection(
+            UnitSphericalVector CalculateStochasticDeflection(
                     double e_i, double e_f, std::vector<double> const& rnd) const final;
         };
     } // namespace stochastic_deflection

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/TsaiApproximationBremsstrahlung.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/TsaiApproximationBremsstrahlung.cxx
@@ -3,7 +3,7 @@
 #include <cmath>
 using namespace PROPOSAL;
 
-DirectionChangeAngular 
+UnitSphericalVector 
 stochastic_deflection::TsaiApproximationBremsstrahlung::CalculateStochasticDeflection(
     double e_i, double e_f, std::vector<double> const& rnd) const
 {
@@ -15,5 +15,5 @@ stochastic_deflection::TsaiApproximationBremsstrahlung::CalculateStochasticDefle
     auto theta_photon = mass / e_i * r;
     auto theta_muon = epsilon / e_f * theta_photon;
 
-    return  DirectionChangeAngular {theta_muon, 2 * PI * rnd[1]};
+    return  UnitSphericalVector {theta_muon, 2 * PI * rnd[1]};
 }

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/ionization/NaivIonization.cxx
@@ -3,7 +3,7 @@
 #include <cmath>
 using namespace PROPOSAL;
 
-DirectionChangeAngular
+UnitSphericalVector
 stochastic_deflection::NaivIonization::CalculateStochasticDeflection(
         double e_i, double e_f, std::vector<double> const& rnd) const
 {
@@ -11,5 +11,5 @@ stochastic_deflection::NaivIonization::CalculateStochasticDeflection(
     auto p_f = std::sqrt((e_f + mass) * (e_f - mass));
     auto costheta = ((e_i + ME) * e_f - e_i * ME - mass * mass) / (p_i * p_f);
 
-    return DirectionChangeAngular { std::acos(costheta), 2 * PI * rnd[0] };
+    return UnitSphericalVector { std::acos(costheta), 2 * PI * rnd[0] };
 }

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/nuclearInteraction/BorogPetrukhinNuclearInteraction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/nuclearInteraction/BorogPetrukhinNuclearInteraction.cxx
@@ -4,7 +4,7 @@
 
 using namespace PROPOSAL;
 
-DirectionChangeAngular
+UnitSphericalVector
 stochastic_deflection::BorogPetrukhinNuclearInteraction::CalculateStochasticDeflection(
         double e_i, double e_f, std::vector<double> const& rnd) const
 {
@@ -18,5 +18,5 @@ stochastic_deflection::BorogPetrukhinNuclearInteraction::CalculateStochasticDefl
     auto sin2 = (t_p - t_min) / (4 * (e_i * e_f - mass * mass) - 2 * t_min);
     auto theta_muon = 2 * std::asin(std::sqrt(sin2));
 
-    return DirectionChangeAngular { theta_muon, 2 * PI * rnd[1] };
+    return UnitSphericalVector { theta_muon, 2 * PI * rnd[1] };
 }

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/pairProd/KelnerPairProduction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/pairProd/KelnerPairProduction.cxx
@@ -6,7 +6,7 @@
 
 using namespace PROPOSAL;
 
-DirectionChangeAngular
+UnitSphericalVector
 stochastic_deflection::KelnerPairProduction::CalculateStochasticDeflection(
         double e_i, double e_f, std::vector<double> const& rnd) const
 {
@@ -32,5 +32,5 @@ stochastic_deflection::KelnerPairProduction::CalculateStochasticDeflection(
     // Need sqrt because of sampling in theta^2
     auto theta_muon = std::sqrt(SampleFromExponential(rnd[0], lambda));
 
-    return DirectionChangeAngular { theta_muon, 2 * PI * rnd[1] };
+    return UnitSphericalVector { theta_muon, 2 * PI * rnd[1] };
 }

--- a/src/pyPROPOSAL/detail/pybindings.cxx
+++ b/src/pyPROPOSAL/detail/pybindings.cxx
@@ -100,10 +100,17 @@ PYBIND11_MODULE(proposal, m)
         .def_property("azimuth", &Spherical3D::GetAzimuth, &Spherical3D::SetAzimuth)
         .def_property("zenith", &Spherical3D::GetZenith, &Spherical3D::SetZenith);
 
-    py::class_<DirectionChangeAngular, std::shared_ptr<DirectionChangeAngular>>(m, "DirectionChangeAngular")
+    py::class_<UnitSphericalVector, std::shared_ptr<UnitSphericalVector>>(m,
+        "UnitSphericalVector",
+        R"pbdoc(
+            Container for a spherical vector with radius 1,
+            i.e. the zenith and azimuth
+            mainly used in scattering and deflection
+        )pbdoc")
         .def(py::init<double, double>(), py::arg("zenith"), py::arg("azimuth"))
-        .def_readwrite("zenith", &DirectionChangeAngular::zenith)
-        .def_readwrite("azimuth", &DirectionChangeAngular::azimuth);
+        .def(py::init<const Spherical3D&>())
+        .def_readwrite("zenith", &UnitSphericalVector::zenith)
+        .def_readwrite("azimuth", &UnitSphericalVector::azimuth);
 
     py::class_<EnergyCutSettings, std::shared_ptr<EnergyCutSettings>>(m,
         "EnergyCutSettings",

--- a/src/pyPROPOSAL/detail/pybindings.cxx
+++ b/src/pyPROPOSAL/detail/pybindings.cxx
@@ -100,6 +100,11 @@ PYBIND11_MODULE(proposal, m)
         .def_property("azimuth", &Spherical3D::GetAzimuth, &Spherical3D::SetAzimuth)
         .def_property("zenith", &Spherical3D::GetZenith, &Spherical3D::SetZenith);
 
+    py::class_<DirectionChangeAngular, std::shared_ptr<DirectionChangeAngular>>(m, "DirectionChangeAngular")
+        .def(py::init<double, double>(), py::arg("zenith"), py::arg("azimuth"))
+        .def_readwrite("zenith", &DirectionChangeAngular::zenith)
+        .def_readwrite("azimuth", &DirectionChangeAngular::azimuth);
+
     py::class_<EnergyCutSettings, std::shared_ptr<EnergyCutSettings>>(m,
         "EnergyCutSettings",
         R"pbdoc(

--- a/src/pyPROPOSAL/detail/pybindings.cxx
+++ b/src/pyPROPOSAL/detail/pybindings.cxx
@@ -107,6 +107,7 @@ PYBIND11_MODULE(proposal, m)
             i.e. the zenith and azimuth
             mainly used in scattering and deflection
         )pbdoc")
+        .def(py::init<>())
         .def(py::init<double, double>(), py::arg("zenith"), py::arg("azimuth"))
         .def(py::init<const Spherical3D&>())
         .def_readwrite("zenith", &UnitSphericalVector::zenith)

--- a/src/pyPROPOSAL/detail/scattering.cxx
+++ b/src/pyPROPOSAL/detail/scattering.cxx
@@ -84,11 +84,22 @@ void init_scattering(py::module& m)
         .def("stochastic_deflection",
             &stochastic_deflection::Parametrization::
                 CalculateStochasticDeflection,
-            py::arg("initial_energy"), py::arg("loss_energy"),
+            py::arg("initial_energy"), py::arg("final_energy"),
             py::arg("random_numbers"),
-            R"pbdoc(TODO: Doc is missing because it's not clear if second argument
-            should be the lost energy or the final energy. Please contact the
-            maintainers if required.)pbdoc");
+            R"pbdoc( Calculation of the stochastic deflection of an interaction
+
+                Args:
+                    initial_energy(double): Initial energy of the muon
+                    final_energy(double): Final energy of the muon
+                    random_numbers(list(double)): Random numbers to sample the deflection angles
+
+                Returns:
+                    UnitSphericalVector: The angular change of the direction
+                        contained in a normed spherical vector
+            TODO: it's not clear if second argument should be the lost energy or the final energy.
+            This might probably change in the future.
+            Please contact the maintainers if required.
+            )pbdoc");
 
     using deflect_ptr = std::shared_ptr<stochastic_deflection::Parametrization>;
     using deflect_list_t = std::vector<deflect_ptr>;


### PR DESCRIPTION
To call the stochastic deflection in python the return type was not pybinded resulting in:
`TypeError: Unable to convert function return value to a Python type! The signature was
	(self: proposal.scattering.StochasticDeflection, initial_energy: float, loss_energy: float, random_numbers: List[float]) -> PROPOSAL::DirectionChangeAngular`

an example code would be
```
import proposal as pp

mudef = pp.particle.MuMinusDef()
med = pp.medium.StandardRock()
param = pp.make_stochastic_deflection('kelnerpairproduction', mudef, med)

 deflect = param.stochastic_deflection(1e6, 1e5, [0.1, 0.2, 0.3, 0.1])
```