### PR TITLE
fix decay if no particle type is given in the particle state

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/decay/ManyBodyPhaseSpace.cxx
@@ -138,8 +138,11 @@ std::vector<ParticleState> ManyBodyPhaseSpace::Decay(const ParticleDef& p_def, c
         GenerateEvent(products, kinematics);
     }
 
+    // Get Momentum is not defined for pseudo particle decay, so it must be
+    // calculated manually
+    double primary_momentum = std::sqrt(std::max((p_condition.energy + p_def.mass) * (p_condition.energy - p_def.mass), 0.0));
     // Boost all products in Lab frame (the reason, why the boosting goes in the negative direction of the particle)
-    Boost(products, -p_condition.direction, p_condition.energy/p_def.mass, p_condition.GetMomentum() / p_def.mass);
+    Boost(products, -p_condition.direction, p_condition.energy/p_def.mass, primary_momentum / p_def.mass);
 
     return products;
 }

--- a/src/PROPOSAL/detail/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/decay/TwoBodyPhaseSpace.cxx
@@ -54,8 +54,11 @@ std::vector<ParticleState> TwoBodyPhaseSpace::Decay(const ParticleDef& p_def, co
     products[1].direction = opposite_direction;
     products[1].SetMomentum(momentum);
 
+    // Get Momentum is not defined for pseudo particle decay, so it must be
+    // calculated manually
+    double primary_momentum = std::sqrt(std::max((p_condition.energy + p_def.mass) * (p_condition.energy - p_def.mass), 0.0));
     // Boost all products in Lab frame (the reason, why the boosting goes in the negative direction of the particle)
-    Boost(products, -p_condition.direction, p_condition.energy / p_def.mass, p_condition.GetMomentum() / p_def.mass);
+    Boost(products, -p_condition.direction, p_condition.energy / p_def.mass, primary_momentum / p_def.mass);
 
     return products;
 }


### PR DESCRIPTION
In the LeptonicDecayChannel` the decay calculation, taking the particle def and the particle state, was already changed that the state doesn't need the particle def information.
In `ManyBodyPhaseSpace` and `TwoBodyPhaseSpace`this wasn't changed, too.