### PR TITLE
Fix boost interpolation error

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
@@ -99,7 +99,7 @@ double UtilityInterpolant::GetUpperLimit(double upper_limit, double rnd)
     try {
         return cubic_splines::find_parameter(
                 *interpolant_, integrated_to_upper - rnd, initial_guess);
-    } catch (...) {
+    } catch (std::runtime_error&) {
         Logging::Get("proposal.UtilityInterpolant")->warn(
                 "Newton-Raphson iteration in UtilityInterpolant::GetUpperLimit "
                 "failed. Try solving using bisection method.");

--- a/tests/Interaction_TEST.cxx
+++ b/tests/Interaction_TEST.cxx
@@ -160,6 +160,22 @@ TEST(EnergyInteraction, CompareIntegralInterpolant)
     }
 }
 
+TEST(EnergyInteraction, BisectionCase)
+{
+    auto cross = GetCrossSections();
+    auto interaction = make_interaction(cross, true);
+    double E_i = 3180.6693833361928;
+    double rnd = 0.7638014946;
+
+    // this should run into the Bisection case of UtilityInterpolant
+    // TODO: Check that this actually triggers the correct case
+    auto E_f = interaction->EnergyInteraction(E_i, rnd);
+
+    // Check that the result is consistent
+    auto val = interaction->EnergyIntegral(E_i, E_f);
+    EXPECT_NEAR(-std::log(rnd), val, val * 1e-5);
+}
+
 TEST(MeanFreePath, ConsistencyCheck)
 {
     // The free mean path length should decrease for higher energies


### PR DESCRIPTION
We noticed that the Propagation can still produce boost exceptions when executing the `cubic_splines::find_parameter` method, although only in very rare cases.

After some investigation, I found out the reason for this.
When trying to run `UtilityInterpolant::GetUpperLimit` for interpolated functions, the Newton Raphson method can run into local minima when the spline is overshooting, see for example here:

![image](https://user-images.githubusercontent.com/15159319/125441949-cafd28e8-dec3-48af-a949-6e22f8f05144.png)
This happens only rarely when the sampled random number is very specific.

My first idea and attempt at a solution was to fall back to the integrated function, `UtilityIntegral`, however mixing Interpolation and Integration can lead to inconsistencies in the long run.
Instead, I implemented a fall back to a simple Bisection method. This will be slower than the NewtonRaphson method, but more stable. To avoid that this fallback happens too often and without knowledge of the user, a warning will be issued by the Logger.
I also added a UnitTest to test the implemented lines, showing that the method indeed works very nicely.
