### PR TITLE
Add fallback to UtilityIntegral::GetUpperLimit if UtilityInterpolant::GetUpperLimit fails

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityIntegral.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityIntegral.cxx
@@ -2,8 +2,6 @@
 #include "PROPOSAL/propagation_utility/PropagationUtilityIntegral.h"
 #include "PROPOSAL/Constants.h"
 
-#include <cassert>
-
 using namespace PROPOSAL;
 
 UtilityIntegral::UtilityIntegral(
@@ -26,7 +24,6 @@ double UtilityIntegral::GetUpperLimit(double energy_initial, double rnd)
     auto sum = integral.IntegrateWithRandomRatio(
         energy_initial, lower_lim, FunctionToIntegral, 4, -rnd);
 
-    assert(sum > rnd); // searched energy is below lower_lim
     (void)sum;
 
     return integral.GetUpperLimit();

--- a/tests/Interaction_TEST.cxx
+++ b/tests/Interaction_TEST.cxx
@@ -160,6 +160,22 @@ TEST(EnergyInteraction, CompareIntegralInterpolant)
     }
 }
 
+TEST(EnergyInteraction, UtilityInterpolantFail)
+{
+    auto cross = GetCrossSections();
+    auto interaction = make_interaction(cross, true);
+    double E_i = 3180.6693833361928;
+    double rnd = 0.7638014946;
+
+    // this should cause cubic_splines::find_parameter to fail
+    // TODO: Check that this actually triggers the correct case
+    auto E_f = interaction->EnergyInteraction(E_i, rnd);
+
+    // Check that the result is consistent
+    auto val = interaction->EnergyIntegral(E_i, E_f);
+    EXPECT_NEAR(-std::log(rnd), val, val * 1e-4);
+}
+
 TEST(MeanFreePath, ConsistencyCheck)
 {
     // The free mean path length should decrease for higher energies


### PR DESCRIPTION
After #187 did unfortunately not solve the original issue, and after the solution in #185 has not been completely satisfying, this is the third attempt to solve the problem with the boost error that is occasionally thrown when calling `cubic_splines::find_parameter` (see MR #185 for a more detailed description of the problem).

Here, I try to do a fallback to `UtilityIntegral::GetUpperLimit` in the case that `UtilityInterpolant::GetUpperLimit` fails.
To avoid numerical problems at the lowest energies, I had to introduce a cutoff if we get too close to the `lower_lim`.

A logging warning is thrown when this case occurs, however, it should only happen very rarely.