### PR TITLE
Add sampling methods for bremsstrahlung photons

### DIFF
--- a/src/PROPOSAL/PROPOSAL/PROPOSAL.h
+++ b/src/PROPOSAL/PROPOSAL/PROPOSAL.h
@@ -71,6 +71,7 @@
 #include "PROPOSAL/secondaries/parametrization/annihilation/SingleDifferentialAnnihilation.h"
 #include "PROPOSAL/secondaries/parametrization/bremsstrahlung/Bremsstrahlung.h"
 #include "PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.h"
+#include "PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.h"
 #include "PROPOSAL/secondaries/parametrization/compton/Compton.h"
 #include "PROPOSAL/secondaries/parametrization/compton/NaivCompton.h"
 #include "PROPOSAL/secondaries/parametrization/epairproduction/EpairProduction.h"

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.h"
+
+namespace PROPOSAL {
+namespace secondaries {
+    class BremsEGS4Approximation
+            : public secondaries::NaivBremsstrahlung,
+              public DefaultSecondaries<BremsEGS4Approximation> {
+        static constexpr int n_rnd = 1;
+        double primary_lepton_mass;
+
+    public:
+        BremsEGS4Approximation() = delete;
+        BremsEGS4Approximation(ParticleDef p, Medium m)
+            : secondaries::NaivBremsstrahlung(p, m),
+            primary_lepton_mass(p.mass) {};
+
+        size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
+
+        std::pair<Cartesian3D, Cartesian3D> CalculateDirections(
+                const Vector3D&, double, std::vector<double>&) final;
+    };
+} // namespace secondaries
+} // namespace PROPOSAL

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.h
@@ -5,8 +5,7 @@
 namespace PROPOSAL {
 namespace secondaries {
     class NaivBremsstrahlung
-        : public secondaries::Bremsstrahlung,
-          public DefaultSecondaries<NaivBremsstrahlung> {
+        : public secondaries::Bremsstrahlung {
         static constexpr int n_rnd = 0;
         const int primary_lepton_type;
 
@@ -15,9 +14,12 @@ namespace secondaries {
         NaivBremsstrahlung(ParticleDef p, Medium)
             : primary_lepton_type(p.particle_type) {};
 
-        size_t RequiredRandomNumbers() const noexcept final { return n_rnd; }
+        size_t RequiredRandomNumbers() const noexcept override { return n_rnd; }
         std::vector<ParticleState> CalculateSecondaries(
-            StochasticLoss, const Component&, std::vector<double>&);
+            StochasticLoss, const Component&, std::vector<double>&) override;
+
+        virtual std::pair<Cartesian3D, Cartesian3D> CalculateDirections(
+                const Vector3D&, double, std::vector<double>&);
     };
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.cxx
@@ -1,5 +1,6 @@
 #include "PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.h"
 #include "PROPOSAL/Constants.h"
+#include <cmath>
 
 using namespace PROPOSAL;
 

--- a/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.cxx
@@ -1,0 +1,16 @@
+#include "PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.h"
+#include "PROPOSAL/Constants.h"
+
+using namespace PROPOSAL;
+
+std::pair<Cartesian3D, Cartesian3D>
+secondaries::BremsEGS4Approximation::CalculateDirections(
+        const Vector3D& init_direction, double energy,
+        std::vector<double>& rnd){
+    // Approximation for bremsstrahlung photons used in EGS4
+    auto cosphi = std::cos(primary_lepton_mass / energy);
+    auto theta = rnd[0] * 2. * PI;
+    auto dir_photon = Cartesian3D(init_direction);
+    dir_photon.deflect(cosphi, theta);
+    return std::pair<Cartesian3D, Cartesian3D>(init_direction, dir_photon);
+}

--- a/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.cxx
@@ -8,14 +8,17 @@
 using namespace PROPOSAL;
 
 std::vector<ParticleState> secondaries::NaivBremsstrahlung::CalculateSecondaries(
-    StochasticLoss loss, const Component&, std::vector<double>&)
+    StochasticLoss loss, const Component&, std::vector<double>& rnd)
 {
+    auto directions = CalculateDirections(
+            loss.direction, loss.parent_particle_energy, rnd);
+
     auto primary_lepton = ParticleState();
     primary_lepton.energy = loss.parent_particle_energy - loss.energy;
     primary_lepton.type = primary_lepton_type;
     primary_lepton.time = loss.time;
     primary_lepton.position = loss.position;
-    primary_lepton.direction = loss.direction;
+    primary_lepton.direction = directions.first;
     primary_lepton.propagated_distance = 0.;
 
     auto brems_photon = ParticleState();
@@ -23,8 +26,14 @@ std::vector<ParticleState> secondaries::NaivBremsstrahlung::CalculateSecondaries
     brems_photon.SetType(PROPOSAL::ParticleType::Gamma);
     brems_photon.time = loss.time;
     brems_photon.position = loss.position;
-    brems_photon.direction = loss.direction;
+    brems_photon.direction = directions.second;
 
     auto sec = std::vector<ParticleState>{primary_lepton, brems_photon};
     return sec;
+}
+
+std::pair<Cartesian3D, Cartesian3D>
+        secondaries::NaivBremsstrahlung::CalculateDirections(
+                const Vector3D& init_direction, double, std::vector<double>&) {
+    return std::pair<Cartesian3D, Cartesian3D>(init_direction, init_direction);
 }

--- a/src/pyPROPOSAL/detail/secondaries.cxx
+++ b/src/pyPROPOSAL/detail/secondaries.cxx
@@ -1,6 +1,7 @@
 #include "PROPOSAL/secondaries/parametrization/Parametrization.h"
 #include "PROPOSAL/secondaries/parametrization/annihilation/HeitlerAnnihilation.h"
 #include "PROPOSAL/secondaries/parametrization/bremsstrahlung/NaivBremsstrahlung.h"
+#include "PROPOSAL/secondaries/parametrization/bremsstrahlung/BremsEGS4Approximation.h"
 #include "PROPOSAL/secondaries/parametrization/compton/NaivCompton.h"
 #include "PROPOSAL/secondaries/parametrization/epairproduction/KelnerKokoulinPetrukhinEpairProduction.h"
 #include "PROPOSAL/secondaries/parametrization/epairproduction/NaivEpairProduction.h"
@@ -95,6 +96,9 @@ void init_secondaries(py::module& m)
     SecondariesBuilder<secondaries::NaivBremsstrahlung,
         secondaries::Bremsstrahlung> {}
         .decl_param(m_sub, "NaivBremsstrahlung");
+    SecondariesBuilder<secondaries::BremsEGS4Approximation,
+        secondaries::NaivBremsstrahlung> {}
+        .decl_param(m_sub, "BremsEGS4Approximation");
 
     SecondariesBuilder<secondaries::NaivCompton, secondaries::Compton> {}
         .decl_param(m_sub, "NaivCompton");


### PR DESCRIPTION
Currently, I've only added the simple approximation used in EGS4, where the bremsstrahlung photons gets a fixed angle based on the initial lepton energy.

I will probably add another, more sophisticated method, based on the Koch and Motz distribution (method described [here](https://www.researchgate.net/profile/Alex-Bielajew/publication/44076059_Improved_bremsstrahlung_photon_angular_sampling_in_the_EGS4_code_system/links/0c960520deb0898978000000/Improved-bremsstrahlung-photon-angular-sampling-in-the-EGS4-code-system.pdf))