### PR TITLE
Fix gcc5 compiler error and add gcc5 building test 

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -46,7 +46,7 @@ jobs:
             path: ~/.conan
             key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
         - name: Which key?
-          run: echo ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
+          run: echo ${{ runner.os }}-cache-build-${{ matrix.compiler }}
         - name: Cache build
           id: cache-build
           uses: actions/cache@v2

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -28,7 +28,7 @@ jobs:
         - uses: actions/checkout@v2
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
-          run: >
+          run: |
             sudo apt install g++-5
             sudo apt install gcc-5
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -8,19 +8,19 @@ jobs:
       strategy:
         matrix:
           include:
-#            - os : "ubuntu-latest"
-#              compiler : "gcc"
-#              compilerpp : "g++"
-#            - os : "macos-latest"
-#              compiler : "clang"
-#              compilerpp : "clang++"
-#            - os : "ubuntu-18.04"
-#              compiler : "gcc-7"
-#              compilerpp : "g++-7"
+            - os : "ubuntu-latest"
+              compiler : "gcc"
+              compilerpp : "g++"
+            - os : "macos-latest"
+              compiler : "clang"
+              compilerpp : "clang++"
+            - os : "ubuntu-18.04"
+              compiler : "gcc-7"
+              compilerpp : "g++-7"
             - os : "ubuntu-18.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
-#            - os : "windows-latest"
+            - os : "windows-latest"
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilerpp }}
@@ -84,38 +84,37 @@ jobs:
           if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
 
-#    test:
-#      runs-on: ${{ matrix.os }}
-#      needs: build
-#      strategy:
-#        matrix:
-#          include:
-#            - os : "ubuntu-latest"
-#              compiler : "gcc"
-#              compilerpp : "g++"
-#            - os : "macos-latest"
-#              compiler : "clang"
-#              compilerpp : "clang++"
-#            - os : "ubuntu-18.04"
-#              compiler : "gcc-7"
-#              compilerpp : "g++-7"
-#            - os : "windows-latest"
-#      env:
-#        PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
-#      steps:
-#        - uses: actions/checkout@v2
-#        - name: Cache conan
-#          id: cache-conan
-#          uses: actions/cache@v2
-#          with:
-#            path: ~/.conan
-#            key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
-#        - name: Cache build
-#          id: cache-build
-#          uses: actions/cache@v2
-#          with:
-#            path: PROPOSAL_BUILD
-#            key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}
-#        - name: Run tests
-#          run: ctest --test-dir PROPOSAL_BUILD -j2 --verbose -E "(Brems|Photo|Epair|Mupair)"
-#
+    test:
+      runs-on: ${{ matrix.os }}
+      needs: build
+      strategy:
+        matrix:
+          include:
+            - os : "ubuntu-latest"
+              compiler : "gcc"
+              compilerpp : "g++"
+            - os : "macos-latest"
+              compiler : "clang"
+              compilerpp : "clang++"
+            - os : "ubuntu-18.04"
+              compiler : "gcc-7"
+              compilerpp : "g++-7"
+            - os : "windows-latest"
+      env:
+        PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
+      steps:
+        - uses: actions/checkout@v2
+        - name: Cache conan
+          id: cache-conan
+          uses: actions/cache@v2
+          with:
+            path: ~/.conan
+            key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
+        - name: Cache build
+          id: cache-build
+          uses: actions/cache@v2
+          with:
+            path: PROPOSAL_BUILD
+            key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}
+        - name: Run tests
+          run: ctest --test-dir PROPOSAL_BUILD -j2 --verbose -E "(Brems|Photo|Epair|Mupair)"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -66,9 +66,17 @@ jobs:
           if : steps.cache-build.outputs.cache-hit != 'true'
           run: mkdir PROPOSAL_BUILD
         - name: Install PROPOSAL dependencies
+          if: ${{ matrix.compiler != 'gcc-5' }}
           run: cd PROPOSAL_BUILD && conan install .. -o with_testing=True --build=missing
+        - name: Install PROPOSAL dependencies
+          if: ${{ matrix.compiler == 'gcc-5' }}
+          run: cd PROPOSAL_BUILD && conan install .. -o with_testing=False --build=missing
         - name: Run build automatisation tool
+          if: ${{ matrix.compiler != 'gcc-5' }}
           run: cmake . -B PROPOSAL_BUILD -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTING=TRUE
+        - name: Run build automatisation tool
+          if: ${{ matrix.compiler == 'gcc-5' }}
+          run: cmake . -B PROPOSAL_BUILD -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTING=False
         - name: Build lib
           if: ${{ matrix.os != 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -8,21 +8,37 @@ jobs:
       strategy:
         matrix:
           include:
-            - os : "ubuntu-latest"
-              compiler : "gcc"
-              compilerpp : "g++"
-            - os : "macos-latest"
-              compiler : "clang"
-              compilerpp : "clang++"
+#            - os : "ubuntu-latest"
+#              compiler : "gcc"
+#              compilerpp : "g++"
+#            - os : "macos-latest"
+#              compiler : "clang"
+#              compilerpp : "clang++"
+#            - os : "ubuntu-18.04"
+#              compiler : "gcc-7"
+#              compilerpp : "g++-7"
             - os : "ubuntu-18.04"
-              compiler : "gcc-7"
-              compilerpp : "g++-7"
-            - os : "windows-latest"
+              compiler : "gcc-5"
+              compilerpp : "g++-5"
+#            - os : "windows-latest"
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilerpp }}
       steps:
         - uses: actions/checkout@v2
+        - name: Install gcc-5
+          if : ${{ matrix.compiler == 'gcc-5' }}
+          run: >
+            sudo apt install g++-5
+            sudo apt install gcc-5
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20
+            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10
+            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20
+            sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
+            sudo update-alternatives --set cc /usr/bin/gcc
+            sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
+            sudo update-alternatives --set c++ /usr/bin/g++
         - name: Cache conan
           id: cache-conan
           uses: actions/cache@v2
@@ -60,37 +76,38 @@ jobs:
           if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
 
-    test:
-      runs-on: ${{ matrix.os }}
-      needs: build
-      strategy:
-        matrix:
-          include:
-            - os : "ubuntu-latest"
-              compiler : "gcc"
-              compilerpp : "g++"
-            - os : "macos-latest"
-              compiler : "clang"
-              compilerpp : "clang++"
-            - os : "ubuntu-18.04"
-              compiler : "gcc-7"
-              compilerpp : "g++-7"
-            - os : "windows-latest"
-      env:
-        PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
-      steps:
-        - uses: actions/checkout@v2
-        - name: Cache conan
-          id: cache-conan
-          uses: actions/cache@v2
-          with:
-            path: ~/.conan
-            key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
-        - name: Cache build
-          id: cache-build
-          uses: actions/cache@v2
-          with:
-            path: PROPOSAL_BUILD
-            key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}
-        - name: Run tests
-          run: ctest --test-dir PROPOSAL_BUILD -j2 --verbose -E "(Brems|Photo|Epair|Mupair)"
+#    test:
+#      runs-on: ${{ matrix.os }}
+#      needs: build
+#      strategy:
+#        matrix:
+#          include:
+#            - os : "ubuntu-latest"
+#              compiler : "gcc"
+#              compilerpp : "g++"
+#            - os : "macos-latest"
+#              compiler : "clang"
+#              compilerpp : "clang++"
+#            - os : "ubuntu-18.04"
+#              compiler : "gcc-7"
+#              compilerpp : "g++-7"
+#            - os : "windows-latest"
+#      env:
+#        PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
+#      steps:
+#        - uses: actions/checkout@v2
+#        - name: Cache conan
+#          id: cache-conan
+#          uses: actions/cache@v2
+#          with:
+#            path: ~/.conan
+#            key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
+#        - name: Cache build
+#          id: cache-build
+#          uses: actions/cache@v2
+#          with:
+#            path: PROPOSAL_BUILD
+#            key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}
+#        - name: Run tests
+#          run: ctest --test-dir PROPOSAL_BUILD -j2 --verbose -E "(Brems|Photo|Epair|Mupair)"
+#

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -45,6 +45,8 @@ jobs:
           with:
             path: ~/.conan
             key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
+        - name: Which key?
+          run: echo ${{ runner.os }}-cache-conan-${{ matrix.compiler }}
         - name: Cache build
           id: cache-build
           uses: actions/cache@v2

--- a/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
+++ b/src/PROPOSAL/PROPOSAL/math/Spherical3D.h
@@ -15,8 +15,8 @@ namespace PROPOSAL  {
 
 
         auto GetRadius() const {return coordinates[Radius];}
-        constexpr auto GetAzimuth() const {return coordinates[Azimuth];}
-        constexpr auto GetZenith() const {return coordinates[Zenith];}
+        auto GetAzimuth() const {return coordinates[Azimuth];}
+        auto GetZenith() const {return coordinates[Zenith];}
         void SetRadius(double radius) {coordinates[Radius] = radius;}
         void SetAzimuth(double azimuth) {coordinates[Azimuth] = azimuth;}
         void SetZenith(double zenith) {coordinates[Zenith] = zenith;}
@@ -46,10 +46,10 @@ namespace PROPOSAL  {
         double zenith = 0;
         double azimuth = 0;
     
-        constexpr UnitSphericalVector() = default;
-        constexpr UnitSphericalVector(double zenith, double azimuth)
+        UnitSphericalVector() = default;
+        UnitSphericalVector(double zenith, double azimuth)
             : zenith(zenith), azimuth(azimuth) {};
-        constexpr UnitSphericalVector(const Spherical3D& s)
+        UnitSphericalVector(const Spherical3D& s)
             : zenith(s.GetZenith()), azimuth(s.GetAzimuth()) {};
      };
 } // namespace PROPOSAL


### PR DESCRIPTION
[When trying to distribute the latest release on conan](https://github.com/conan-io/conan-center-index/pull/6845), the build using a gcc5 compiler failed. To avoid such a problem in the future, I added a job building PROPOSAL on gcc5 to the workflows.

Furthermore, I fixed the compiler error, which was caused by the `constexpr` specifier in the `UnitSphericalVector`. I am not sure why they were introduced there, maybe @sudojan can comment on that?