### PR TITLE
Keep initial lepton with updated energy instead of discarding particle

### DIFF
--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photonuclear/Photonuclear.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photonuclear/Photonuclear.h
@@ -19,14 +19,22 @@ namespace secondaries {
             = PROPOSAL::InteractionType::Photonuclear;
         InteractionType GetInteractionType() const noexcept override { return type; }
 
-        std::vector<ParticleState> CalculateSecondaries(StochasticLoss, const Component&,
-                                                   std::vector<double>&) override
+        std::vector<ParticleState> CalculateSecondaries(
+                StochasticLoss loss, const Component&, std::vector<double>&) override
         {
             Logging::Get("proposal.Secondaries")
                     ->warn("PROPOSAL can not generate secondary particles"
                             "for a photonuclear interaction.");
             //TODO: Treatment for hadronic interactions
-            return std::vector<ParticleState>{};
+            auto primary_lepton = ParticleState();
+            primary_lepton.energy = loss.parent_particle_energy - loss.energy;
+            primary_lepton.type = primary_particle_type;
+            primary_lepton.time = loss.time;
+            primary_lepton.position = loss.position;
+            primary_lepton.direction = loss.direction;
+            primary_lepton.propagated_distance = 0.;
+
+            return std::vector<ParticleState>{primary_lepton};
         };
     };
 } // namespace secondaries


### PR DESCRIPTION
We can not sample the secondary particles from photonuclear interactions yet, but we can at least keep the initial lepton with the updated energy.