### PR TITLE
Use empirical correction factor for BremsElectronScreening only for energies below 50 MeV

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
@@ -496,9 +496,6 @@ double crosssection::BremsElectronScreening::CalculateParametrization(
         phi2 = phi1;
     }
 
-    // Coulomb correction function and empirical correction factor
-    double A_fac = interpolant_->InterpolateArray(logZ, energy);
-
     aux = ALPHA * comp.GetNucCharge();
     aux *= aux;
     auto f_c = aux
@@ -541,8 +538,11 @@ double crosssection::BremsElectronScreening::CalculateParametrization(
 
     xi = Lp / (Lr - f_c);
 
+    // Coulomb correction function and empirical correction factor
+    double A_fac = 1.0;
     if (energy < 50.) {
         f_c = 0;
+        A_fac = interpolant_->InterpolateArray(logZ, energy);
     }
 
     auto result = A_fac * comp.GetNucCharge() * (comp.GetNucCharge() + xi);


### PR DESCRIPTION
The parametrization `BremsElectronScreening` is supposed to reproduce the behavior of the bremsstrahlung crosssetion used in [EGS](https://www.researchgate.net/publication/255277661_The_EGS5_code_system).

However, in EGS, the empirical correction factor `A` is only applied for energies above 50 MeV. This is ok for higher energies because the Columb correction is treated numerically using the Colulomb correction term `f_c`.

However, in PROPOSAL, we used the correction factor `A` also for energies above 50 MeV, and for energies above 10 GeV, we used the correction factor at 10 GeV. This is wrong because this basically accounts for the Coulomb correction twice. The difference in the crosssection is going to be a few percents for high energies.