### PR TITLE
Fix bug in calculation of photonuclear secondaries

### DIFF
--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photonuclear/Photonuclear.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photonuclear/Photonuclear.h
@@ -31,12 +31,12 @@ namespace secondaries {
             primary_lepton.propagated_distance = 0.;
 
             auto hadron = ParticleState();
-            primary_lepton.energy = loss.energy;
-            primary_lepton.SetType(ParticleType::Hadron);
-            primary_lepton.time = loss.time;
-            primary_lepton.position = loss.position;
-            primary_lepton.direction = loss.direction;
-            primary_lepton.propagated_distance = 0.;
+            hadron.energy = loss.energy;
+            hadron.SetType(ParticleType::Hadron);
+            hadron.time = loss.time;
+            hadron.position = loss.position;
+            hadron.direction = loss.direction;
+            hadron.propagated_distance = 0.;
 
             return std::vector<ParticleState>{primary_lepton, hadron};
         };


### PR DESCRIPTION
Fix wrong assignment of particle properties in secondaries::Photonuclear::CalculateSecondaries

A bug introduced MR #199 caused the wrong properties to be assigned to the lepton, and the hadron has been completely uninitialized. This bug is therefore present in version 7.0.7