### PR TITLE
Fix numerical issues when propagating high energy muons with low energy cut settings

### DIFF
--- a/src/PROPOSAL/PROPOSAL/math/MathMethods.h
+++ b/src/PROPOSAL/PROPOSAL/math/MathMethods.h
@@ -108,7 +108,12 @@ double dilog(double x);
 double NewtonRaphson(std::function<double(double)> f, std::function<double(double)> df, double x1, double x2,
         double xinit, int MAX_STEPS = 101, double xacc = 1.e-6);
 
-double Bisection(std::function<double(double)> f, double x1, double x2,
+// from stackoverflow https://stackoverflow.com/a/4609795/8227894
+template <typename T> int sgn(T val) {
+    return (T(0) < val) - (val < T(0));
+}
+
+std::pair<double, double> Bisection(std::function<double(double)> f, double x1, double x2,
                  double xacc, double MAX_ITER);
 
 struct SplineCoefficients{

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDE2DX/AxisBuilderDE2DX.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDE2DX/AxisBuilderDE2DX.cxx
@@ -22,7 +22,7 @@ void AxisBuilderDE2DX::refine_definition_range(
 
     double i_accuracy = 0.5;
     auto f = [&func, &ax](double i) {return func(ax.back_transform(i));};
-    auto i_low = Bisection(f, i-1, i, i_accuracy, 100);
+    auto i_low = Bisection(f, i-1, i, i_accuracy, 100).first;
     low = ax.back_transform(i_low + i_accuracy);
 }
 

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDEDX/AxisBuilderDEDX.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDEDX/AxisBuilderDEDX.cxx
@@ -24,7 +24,7 @@ void AxisBuilderDEDX::refine_definition_range(
 
     double i_accuracy = 0.1;
     auto f = [&func, &ax](double i) { return func(ax.back_transform(i)); };
-    auto i_low = Bisection(f, i - 1, i, i_accuracy, 100);
+    auto i_low = Bisection(f, i - 1, i, i_accuracy, 100).first;
     low = ax.back_transform(i_low + i_accuracy);
 }
 

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/AxisBuilderDNDX.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/AxisBuilderDNDX.cxx
@@ -30,7 +30,7 @@ void AxisBuilderDNDX::refine_definition_range(
     else {
         double i_accuracy = 0.1;
         auto f = [&func, &ax](double i) { return func(ax.back_transform(i)); };
-        auto i_low = Bisection(f, i - 1, i, i_accuracy, 100);
+        auto i_low = Bisection(f, i - 1, i, i_accuracy, 100).first;
         energy_lim.low = ax.back_transform(i_low + i_accuracy);
     }
 }

--- a/src/PROPOSAL/detail/PROPOSAL/math/MathMethods.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/math/MathMethods.cxx
@@ -272,33 +272,28 @@ double NewtonRaphson(std::function<double(double)> func,
     return rts;
 }
 
-double Bisection(std::function<double(double)> f, double x1, double x2,
-                 double xacc, double MAX_ITER) {
+std::pair<double, double> Bisection(std::function<double(double)> f, double x1,
+                                    double x2, double xacc, double MAX_ITER) {
     if (f(x1) * f(x2) > 0.)
         throw MathException("Root must be bracketed in Bisection method!");
 
-    double dx;
-    double root_guess;
-
-    if (f(x1) <= 0.0) {
-        dx = x2 - x1;
-        root_guess = x1;
-    } else {
-        dx = x1 - x2;
-        root_guess = x2;
+    if (x1 > x2) {
+        std::swap(x1, x2);
     }
+
+    double center;
 
     for (int i = 0; i<=MAX_ITER; i++) {
-        dx *= 0.5;
-        double x_mid = root_guess + dx;
-        double f_mid = f(x_mid);
-        if (f_mid <= 0.)
-            root_guess = x_mid;
-        if (std::abs(dx) < xacc)
-            return root_guess;
+        center = (x1 + x2) / 2;
+        if (sgn(f(center)) == sgn(f(x1)))
+            x1 = center;
+        else
+            x2 = center;
+        if (std::abs(x2 - x1) < xacc)
+            return std::make_pair(x1, x2);
     }
-    Logging::Get("proposal.math")->warn("Maximum number of iteration exeeded in Bisection");
-    return root_guess;
+    Logging::Get("proposal.math")->warn("Maximum number of iteration exceeded in Bisection");
+    return std::make_pair(x1, x2);
 }
 
 std::vector<SplineCoefficients> CalculateSpline(std::vector<double> x,

--- a/tests/Interaction_TEST.cxx
+++ b/tests/Interaction_TEST.cxx
@@ -153,7 +153,10 @@ TEST(EnergyInteraction, CompareIntegralInterpolant)
     for (double Elog_i = std::log10(low); Elog_i < 14; Elog_i += 5e-2) {
         double E_i = std::pow(10., Elog_i);
         for (auto i_stat = 0; i_stat < 100; i_stat++) {
-            rnd = RandomGenerator::Get().RandomDouble();
+            if (i_stat == 0)
+                rnd = 0.999; // ensure to test edges of phase space
+            else
+                rnd = RandomGenerator::Get().RandomDouble();
             energy_integral = interaction_integral->EnergyInteraction(E_i, rnd);
             energy_interpol = interaction_interpol->EnergyInteraction(E_i, rnd);
             auto lower_lim = CrossSectionVector::GetLowerLim(cross);

--- a/tests/MathMethods_TEST.cxx
+++ b/tests/MathMethods_TEST.cxx
@@ -53,18 +53,26 @@ TEST(Bisection, Comparison_equal)
     double real1 = pow(2., 2./3);
     double real2 = 0;
 
-    double aux1 = Bisection(f1, -5, 15, 1e-6, 100);
-    double aux2 = Bisection(f2, -3./4 * PI, 1./2 * PI, 1e-6, 100);
+    auto aux1 = Bisection(f1, -5, 15, 1e-6, 100);
+    auto aux2 = Bisection(f2, -3./4 * PI, 1./2 * PI, 1e-6, 100);
 
-    ASSERT_NEAR(aux1, real1, 1.e-6 );
-    ASSERT_NEAR(aux2, 0, 1.e-6 );
+    ASSERT_NEAR((aux1.first + aux1.second)/2, real1, 1.e-6 );
+    ASSERT_LT(aux1.first, real1);
+    ASSERT_LT(real1, aux1.second);
+
+    ASSERT_NEAR((aux2.first + aux2.second)/2, 0, 1.e-6 );
+    ASSERT_LT(aux2.first, real2);
+    ASSERT_LT(real2, aux2.second);
 
     aux1 = Bisection(f1, 15, -5, 1e-6, 100);
     aux2 = Bisection(f2, 1./2 * PI, -3./4 * PI, 1e-6, 100);
 
-    ASSERT_NEAR(aux1, real1, 1.e-6 );
-    ASSERT_NEAR(aux2, real2, 1.e-6 );
-
+    ASSERT_NEAR((aux1.first + aux1.second)/2, real1, 1.e-6 );
+    ASSERT_LT(aux1.first, real1);
+    ASSERT_LT(real1, aux1.second);
+    ASSERT_NEAR((aux2.first + aux2.second)/2, real2, 1.e-6 );
+    ASSERT_LT(aux2.first, real2);
+    ASSERT_LT(real2, aux2.second);
 }
 
 


### PR DESCRIPTION
There is a bug in the current version of PROPOSAL when trying to propagate high energy particles with a relatively low energy cut (thanks to @wjwoodley for bringing this to our attention!)

### Bug description

In this case, muons have been propagated in StandardRock for a distance of 1 km, using an e_cut of 500 MeV. Looking at the final particle energies for different initial energies, the histogram looked like this:
![old](https://user-images.githubusercontent.com/15159319/136819235-96769e69-d076-4835-9f44-7f23bb035bf5.png)

With this fix, the histogram changes to this 
![new](https://user-images.githubusercontent.com/15159319/136819315-2675ca35-9900-4e86-8b38-6b678aa4d1bc.png)
which is in agreement with PROPOSAL 6 results.

### Bug source

The source of this bug has been the sampling of the energy of the next stochastic interaction ('InteractionBuilder::EnergyInteraction()'). For random numbers close to one (i.e. the edge of the parameter space), the energy of the next stochastic interaction should be very close to the initial energy. Instead, the interaction energy is quite far away from the initial energy, causing an nonphysical, very high continuous loss. 
Normally, this bug should only occur in very rare cases. However, when using high initial energies with a low e_cut, there are a lot of steps during the propagation process, so that this nonphysical case starts to appear in almost every propagation.

### Bug solution

The bug occurs because the NewtonRaphson method of CubicInterpolation is unreliable in this very specific case. Changing the accuracy or the number of steps does not improve the results. However, the results have been vastly improved by changing the initial condition of the NewtonRaphson method: Normally, the initial conditions have been determined by the CubicInterpolation library by performing a bisection search to find an interval that includes only 1% of the original parameter space, and use the middle of this interval as a starting point for the NewtonRaphson method. But if we are very close to the original upper_limit of the problem, it seems to be much better to use the upper_limit as an initial guess of the NewtonRaphon method. 

A similar procedure has been used in former versions of PROPOSAL: If the random number has been very close to the edge of the parameter space, only two NewtonRaphson steps, starting at the edge of the parameter space, have been performed (see [here](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/37059e4b6337b3db908e33580eb2795c5473a196/private/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx#L318))


To test this specific case, I also adapted the UnitTests to account for random numbers close to the edge of the parameter space.
