### PR TITLE
Avoid unnecessary evaluations and possible floating point exceptions in Moliere scattering

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/scattering/multiple_scattering/Moliere.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/multiple_scattering/Moliere.cxx
@@ -49,6 +49,8 @@ ScatteringOffset Moliere::CalculateRandomAngle(
         double xn = 15.;
 
         for (int n = 0; n < 6; n++) {
+            if (xn < 0)
+                return offsets; // xn would become nan for further iterations
             xn = xn
                 * ((1. - std::log(xn) - std::log(chiCSq_ / chi_A_Sq[i]) - 1.
                        + 2. * EULER_MASCHERONI)


### PR DESCRIPTION
For small continuous steps, `xn` can become negative.
This causes `xn` to become `nan` (because `log(xn)` is calculated), but the for loop still continues.
The case is still handled later in the code with the line `xn != xn`(which checks if `xn` became `nan`), however this possibly causes several unnecessary iterations of the for-loop.
Furthermore, `std::log(xn)` causes a floating point exception if they are enabled (FE_INVALID).
This fix catches the case where `xn` would become `nan` before the log of it is actually calculated.

Since `xn` will always stay `nan` after it once became `nan`, the behaviour of the code does not change (except for avoiding the unnecessary calculations and the floating point exceptions).