### PR TITLE
Add fallback if cubic_splines::find_parameter in CrossSectionDNDXInterpolant::GetUpperLimit fails

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ macro(package_add_test TESTNAME)
 endmacro()
 
 # Unit Tests
+package_add_test(UnitTest_CrossSection CrossSection_TEST.cxx)
 package_add_test(UnitTest_Decay Decay_TEST.cxx)
 package_add_test(UnitTest_DecayChannel DecayChannel_TEST.cxx)
 package_add_test(UnitTest_DecayTable DecayTable_TEST.cxx)

--- a/tests/CrossSection_TEST.cxx
+++ b/tests/CrossSection_TEST.cxx
@@ -1,0 +1,36 @@
+#include "gtest/gtest.h"
+
+#include "PROPOSAL/crosssection/parametrization/EpairProduction.h"
+#include "PROPOSAL/crosssection/CrossSectionBuilder.h"
+
+using namespace PROPOSAL;
+
+TEST(CalculateStochasticLoss, GetUpperLimit_Exception)
+{
+    // This causes cubic_splines::find_parameter to fail in
+    // CrossSectionDNDXInterpolant::GetUpperLimit, so we use Bisection as a
+    // backup method
+    auto param = crosssection::EpairForElectronPositron();
+    auto medium = Air();
+    auto cross = make_crosssection(
+            param, EMinusDef(), medium,
+            std::make_shared<EnergyCutSettings>(2.255, 1, false), true);
+
+    double energy = 3443;
+    double rate_failed = 0.000636779;
+    auto comp_hash = medium.GetComponents().at(0).GetHash();
+
+    // This function call causes the failure
+    auto v_sampled = cross->CalculateStochasticLoss(comp_hash, energy,
+                                                    rate_failed);
+
+    // Check that value calculated by Bisection method is correct / consistent
+    EXPECT_NEAR(cross->CalculateCumulativeCrosssection(energy, comp_hash, v_sampled),
+                rate_failed, rate_failed*1e-5);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/Interaction_TEST.cxx
+++ b/tests/Interaction_TEST.cxx
@@ -221,30 +221,6 @@ TEST(MeanFreePath, CompareIntegralInterpolant)
     }
 }
 
-TEST(CalculateLoss, SampleStochasticLoss_Exception)
-{
-    // This causes cubic_splines::find_parameter to fail in
-    // CrossSectionDNDXInterpolant::GetUpperLimit, so we use Bisection as a
-    // backup method
-    auto param = crosssection::EpairForElectronPositron();
-    auto medium = Air();
-    auto cross = make_crosssection(
-            param, EMinusDef(), medium,
-            std::make_shared<EnergyCutSettings>(2.255, 1, false), true);
-
-    double energy = 3443;
-    double rate_failed = 0.000636779;
-    auto comp_hash = medium.GetComponents().at(0).GetHash();
-
-    // This function call causes the failure
-    auto v_sampled = cross->CalculateStochasticLoss(comp_hash, energy,
-                                                    rate_failed);
-
-    // Check that value calculated by Bisection method is correct / consistent
-    EXPECT_NEAR(cross->CalculateCumulativeCrosssection(energy, comp_hash, v_sampled),
-                rate_failed, rate_failed*1e-5);
-}
-
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This is very similar to the PR #185.
Under specific conditions, the NewtonRaphson method of cubic_splines::find_parameter may fail is the
spline is overshooting as the method runs into local minima.
Similarly to the fix used in PR #185, we use a bisection method as a fallback. Again, this should
only happen in very rare cases (therefore, a warning is logged).

This is also the second out of two instances where cubic_splines::find_parameter is used, so we shouldn't
run into this problem anymore.