### PR TITLE
Disable caches in GitHub actions and fix Secondaries_TEST

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -24,6 +24,7 @@ jobs:
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilerpp }}
+        PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
       steps:
         - uses: actions/checkout@v2
         - name: Install gcc-5
@@ -39,31 +40,17 @@ jobs:
             sudo update-alternatives --set cc /usr/bin/gcc
             sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
             sudo update-alternatives --set c++ /usr/bin/g++
-        - name: Cache conan
-          id: cache-conan
-          uses: actions/cache@v2
-          with:
-            path: ~/.conan
-            key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}-key
-        - name: Cache build
-          id: cache-build
-          uses: actions/cache@v2
-          with:
-            path: PROPOSAL_BUILD
-            key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}-key
         - uses: actions/setup-python@v2
           with:
             python-version: '3.7'
         - name: Install python dependencies
           run: python -m pip install conan
         - name: Initialize conan
-          if : steps.cache-conan.outputs.cache-hit != 'true'
           run: conan profile new default --detect
         - name: Update conan profile
           if : ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-latest' }}
           run: conan profile update settings.compiler.libcxx=libstdc++11 default
         - name: create build directory
-          if : steps.cache-build.outputs.cache-hit != 'true'
           run: mkdir PROPOSAL_BUILD
         - name: Install PROPOSAL dependencies
           run: cd PROPOSAL_BUILD && conan install .. -o with_testing=True --build=missing
@@ -75,41 +62,5 @@ jobs:
         - name: Build lib
           if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
-
-    test:
-      runs-on: ${{ matrix.os }}
-      needs: build
-      strategy:
-        matrix:
-          include:
-            - os : "ubuntu-latest"
-              compiler : "gcc"
-              compilerpp : "g++"
-            - os : "macos-latest"
-              compiler : "clang"
-              compilerpp : "clang++"
-            - os : "ubuntu-18.04"
-              compiler : "gcc-7"
-              compilerpp : "g++-7"
-            - os : "ubuntu-18.04"
-              compiler : "gcc-5"
-              compilerpp : "g++-5"
-            - os : "windows-latest"
-      env:
-        PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
-      steps:
-        - uses: actions/checkout@v2
-        - name: Cache conan
-          id: cache-conan
-          uses: actions/cache@v2
-          with:
-            path: ~/.conan
-            key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}-key
-        - name: Cache build
-          id: cache-build
-          uses: actions/cache@v2
-          with:
-            path: PROPOSAL_BUILD
-            key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}-key
         - name: Run tests
           run: ctest --test-dir PROPOSAL_BUILD -j2 --verbose -E "(Brems|Photo|Epair|Mupair)"

--- a/tests/Secondaries_TEST.cxx
+++ b/tests/Secondaries_TEST.cxx
@@ -179,7 +179,7 @@ TEST(SecondaryVector, EnergyConservation) {
     }
 
     // energy needs to be conserved
-    EXPECT_EQ(sum_continuous_losses + sum_stochastic_losses + MuMinusDef().mass, energy);
+    EXPECT_DOUBLE_EQ(sum_continuous_losses + sum_stochastic_losses + MuMinusDef().mass, energy);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Caching the build in GitHub actions seems to cause some problems. Sometimes, the wrong cache is loaded, so the test are sometimes run with an outdated build.
I disabled the caches and just combined building and testing into one run for now.

Furthermore, there have been some floating point precision in Secondaries_TEST on Windows. This PR fixes them. 