### PR TITLE
Return empty Loss object in Interaction::SampleLoss if no stochastic interaction is possible

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -92,7 +92,8 @@ Secondaries Propagator::Propagate(const ParticleState& initial_particle,
             switch (next_interaction_type) {
             case Stochastic: {
                 auto loss = DoStochasticInteraction(state, utility, rnd);
-                track.push_back(state, loss.type, loss.comp_hash);
+                if (loss.type != InteractionType::Undefined)
+                    track.push_back(state, loss.type, loss.comp_hash);
                 if (state.energy <= InteractionEnergy[MinimalE])
                     continue_propagation = false;
                 break;

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/Interaction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/Interaction.cxx
@@ -50,10 +50,17 @@ Interaction::Loss Interaction::SampleLoss(
         }
     }
 
+    if (overall_rate == 0) {
+        Logging::Get("proposal.interaction")->warn(
+                "No stochastic interaction possible for initial energy {} MeV.",
+                energy);
+        return {InteractionType::Undefined, 0, 0};
+    }
+
     std::stringstream ss;
     ss << "Given rate (" << std::to_string(sampled_rate)
        << ") for given energy (" << std::to_string(energy)
-       << ") by drawen random numer (" << std::to_string(rnd)
+       << ") by drawn random number (" << std::to_string(rnd)
        << ") is larger than the overall crosssection rate ("
        << std::to_string(overall_rate) << ").";
 

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/Interaction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/Interaction.cxx
@@ -50,7 +50,7 @@ Interaction::Loss Interaction::SampleLoss(
         }
     }
 
-    if (overall_rate == 0) {
+    if (overall_rate == 0.) {
         Logging::Get("proposal.interaction")->warn(
                 "No stochastic interaction possible for initial energy {} MeV.",
                 energy);


### PR DESCRIPTION
Fixes #227 

### Problem description

During propagation, the sampling of the stochastic loss consists of two steps:

1. Sample an energy where the next stochastic loss occurs using `Interaction::EnergyInteraction` ([here](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/e326289c172cfdc477f9fa4dea01ed62d9153b2c/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx#L80))
2. Sample a stochastic loss (i.e. type and size of the loss) for this energy using `Interaction::Rates` and `Interaction::SampleLoss` ([here](EnergyStochasticloss))

However, in rare cases, the first step can sample an energy where actually, no stochastic interactions are possible anymore. In this case, in the second step, `Interaction::Rates` returns only zeroes and `Interaction::SampleLoss` throws an error as seen in issue #227.

The reason behind this is basically a numerical uncertainty concerning the interpolation.
In the first step, the EnergyIntegral needs to be solved. For this task, an interpolant is created based on the `dNdx` and `dEdx` values. Below some energy, `dNdx` is only zero, which means that no interactions are possible anymore.

For the second step, the rates for all possible interaction types are sampled to decide which type of interaction actually occurs. For this, the rates are calculated directly from the separate `dNdx` interpolants.

The problem is that both tasks use individual interpolation tables. This means that the exact behavior of the interpolant is slightly different. In this case, `Interaction::EnergyInteraction` returns that `dNdx` is still non-zero for some energy, while `Interaction::SampleLoss` returns zero.

The following image shows the situation in #227. We have an initial energy of ~154 MeV, and want to sample `EnergyInteraction`. The x-axis shows the random number, the y-axis shows the energy of the next stochastic interaction for the given random number. The red line shows the energy that has been sampled.
![image](https://user-images.githubusercontent.com/15159319/144236551-59a08ebd-a1cc-4acf-ab6a-7aee67865f7c.png)
The energy for this random number is exactly where the return value of `EnergyInteraction` becomes equal to the particle mass. This is the area where no stochastic interactions are possible anymore. If everything would be numerically exact, this should not happen. In this case of a perfect world, there would be an exact random number below which all return values would be the particle mass, and above this random number all return values would match an energy where stochastic interactions are still possible.

### Solution

Since we are exactly at the numerical limits where stochastic interactions become impossible, it is physically correct to return an "empty stochastic" interaction. 
The Propagator will just continue with the propagation (the next step will be a last continuous step).
To ensure that this does not occur too often (which it shouldn't if nothing else is broken), I added a log warn message. 
 
It is worth noting that this problem has been solved in old PROPOSAL versions in a very similar way.
In `Sector::MakeStochasticLoss` (the equivalent of today's `PropagationUtility::EnergyStochasticLoss`), the case that "no interaction occurs" is considered [here](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/1a74f84bb0157cfd0dc298dc69b3b3f4c454f1fd/private/PROPOSAL/sector/Sector.cxx#L533).
In `Sector::Propagate`, this case is handled by throwing a logging message and continuing the propagation [here](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/1a74f84bb0157cfd0dc298dc69b3b3f4c454f1fd/private/PROPOSAL/sector/Sector.cxx#L388).