### PR TITLE
Push GTest version to 1.11.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -39,7 +39,7 @@ class PROPOSALConan(ConanFile):
             self.requires("pybind11/2.6.2")
         if self.options.with_testing:
             self.requires("boost/1.75.0")
-            self.requires("gtest/1.10.0")
+            self.requires("gtest/1.11.0")
         if self.options.with_documentation:
             self.requires("doxygen/1.8.20")
 


### PR DESCRIPTION
Building fails on the master now because CMake is having trouble with the difference of `gtest` and `GTest`. Apparently, this has been a bug in conan that has been fixed in the package for gtest/1.11.0 [here](https://github.com/conan-io/conan-center-index/pull/7894).

If there are no objections, I would propose to push the GTest version to the newest release to fix this issue.