### PR TITLE
Change setup.py to be able to find correct python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=45",
     "wheel",
-    "cmake>=3.9",
+    "cmake>=3.16",
     "conan>=1.33",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -99,10 +99,6 @@ class build_ext_cmake(build_ext):
         cmake = get_cmake()
 
         rpath = '@loader_path' if sys.platform == 'darwin' else '$ORIGIN'
-        python_lib = pathlib.Path(
-            sysconfig.get_config_var('LIBDIR'),
-            sysconfig.get_config_var('INSTSONAME')
-        )
         CMAKE_CXX_FLAGS = ""
         if not os.getenv("NO_CONAN", False):
             print(

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def get_cmake():
 
         if ret.returncode == 0:
             return exe
-    raise OSError("You need cmake >= 3.9")
+    raise OSError("You need cmake >= 3.16")
 
 
 def exists_conan_default_file():

--- a/setup.py
+++ b/setup.py
@@ -132,12 +132,10 @@ class build_ext_cmake(build_ext):
             '-DBUILD_PYTHON=ON',
             '-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE',
             '-DBUILD_EXAMPLE=OFF',
-            '-DPYTHON_EXECUTABLE=' + sys.executable,
-            '-DPYTHON_LIBRARY=' + str(python_lib),
+            '-DPython_EXECUTABLE=' + sys.executable,
             '-DCMAKE_INSTALL_RPATH={}'.format(rpath),
             '-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON',
             '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF',
-            '-DPYTHON_INCLUDE_DIR=' + sysconfig.get_path('include')
         ]
         if CMAKE_CXX_FLAGS:
             cmake_call.append(CMAKE_CXX_FLAGS)


### PR DESCRIPTION
When trying to install proposal with pip in virtual environments, I realized that python does not find the installed modules.

Looking at the verbose output of `pip install`, CMake said:
```
-- Found Python: /usr/bin/python3.10 (found version "3.10.1") found components: Interpreter Development Development.Module Development.Embed
```
which means that CMake does not use the python version of the virtual environment, but rather the global python version!
The CMake output also said
```
CMake Warning:
    Manually-specified variables were not used by the project:

      PYTHON_EXECUTABLE
      PYTHON_INCLUDE_DIR
      PYTHON_LIBRARY
```
so the variables from the `setup.py` that should set the correct python version are in fact ignored!

From the [manual page of `FindPython`](https://cmake.org/cmake/help/git-stage/module/FindPython.html), I learned that we can set `Python_EXECUTABLE` as an artifacts specification. If I do that (as it is done by the changes in this PR draft), pypi finds the correct python version and everything seems to work smoothly.

(I tested this on both MacOS (CMake 3.20.3) and Arch Linux (3.22.1))

However, I am not sure if this is the correct way of solving this problem. If I understand the manual page correctly, `Python_EXECUTABLE` has only been introduced in CMake 3.16, so I am not sure what will happen for older CMake 
versions. 

@maxnoe, maybe you could have a short look at this issue?
