### PR TITLE
Improve exception thrown when path to configuration file is not readable

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -284,6 +284,11 @@ Sector Propagator::GetCurrentSector(
 
 nlohmann::json Propagator::ParseConfig(const string& config_file)
 {
+    std::ifstream f(config_file.c_str());
+    if (!f.good()) {
+        throw std::invalid_argument("No configuration file found under "
+                                    "path "+ config_file);
+    }
     nlohmann::json json_config;
     try {
         if (config_file== "")


### PR DESCRIPTION
Until now, if one tried to create a Propagator but passed an invalid path, the error message thrown by PROPOSAL looked something like this:

```
[2021-12-22 18:04:06.308] [proposal.propagator] [critical] Unable to parse /wrong/path/ as json file
libc++abi.dylib: terminating with uncaught exception of type nlohmann::detail::parse_error: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
```

This is rather confusing, and especially the json exception gives the expression there is a syntax error rather than just a wrong path.

With this, the message looks like this

```
libc++abi.dylib: terminating with uncaught exception of type std::invalid_argument: No configuration file found under path /wrong/path/
```

This should be more useful, especially for first-time users who just forget to adapt the path in an example script.

