### PR TITLE
Add function "HitGeometry" to Secondaries

### DIFF
--- a/src/PROPOSAL/PROPOSAL/Secondaries.h
+++ b/src/PROPOSAL/PROPOSAL/Secondaries.h
@@ -68,6 +68,12 @@ public:
     std::shared_ptr<ParticleState> GetExitPoint(const Geometry&) const;
     std::shared_ptr<ParticleState> GetClosestApproachPoint(const Geometry&) const;
 
+    /*!
+    * Check if particle has hit a geometry. Particle tracks ending at the border
+    * of a geometry count as a hit.
+    */
+    bool HitGeometry(const Geometry&) const;
+
     std::vector<ParticleState> GetTrack() const { return track_; };
     std::vector<ParticleState> GetTrack(const Geometry&) const;
 

--- a/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
@@ -248,6 +248,29 @@ std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(const Geomet
     return std::make_unique<ParticleState>(track_.back());
 }
 
+bool Secondaries::HitGeometry(const Geometry& geometry) const {
+    for (unsigned int i = 0; i < track_.size() - 1; i++) {
+        auto pos_a = track_.at(i).position;
+        auto dir_a = track_.at(i).direction;
+        auto pos_b = track_.at(i + 1).position;
+        auto dir_b = track_.at(i + 1).direction;
+
+        // check if first track point lies inside geometry
+        if (geometry.IsInside(pos_a, dir_a))
+            return true;
+
+        // check if geometry lies between two track points
+        if (geometry.IsInfront(pos_a, dir_a) && geometry.IsBehind(pos_b, dir_b))
+            return true;
+    }
+
+    // check if last track point is in geometry
+    if (geometry.IsInside(track_.back().position, track_.back().direction))
+        return true;
+
+    return false;
+}
+
 ParticleState Secondaries::RePropagateEnergy(const ParticleState& init,
                                              double energy_lost,
                                              double max_distance) const

--- a/src/pyPROPOSAL/detail/particle.cxx
+++ b/src/pyPROPOSAL/detail/particle.cxx
@@ -299,6 +299,7 @@ void init_particle(py::module& m) {
             .def("entry_point", &Secondaries::GetEntryPoint)
             .def("exit_point", &Secondaries::GetExitPoint)
             .def("closest_approach_point", &Secondaries::GetClosestApproachPoint)
+            .def("hit_geometry", &Secondaries::HitGeometry)
             .def("track", overload_cast_<>()(&Secondaries::GetTrack, py::const_))
             .def("track", overload_cast_<const Geometry&>()(&Secondaries::GetTrack, py::const_))
             .def("get_state_for_energy", &Secondaries::GetStateForEnergy)

--- a/tests/Secondaries_TEST.cxx
+++ b/tests/Secondaries_TEST.cxx
@@ -154,6 +154,47 @@ TEST(SecondaryVector, EntryPointExitPointRePropagation)
     EXPECT_TRUE(exit_point->propagated_distance == sphere.GetPosition().GetZ() + sphere.GetRadius());
 }
 
+
+TEST(SecondaryVector, HitDetector) {
+    // define our dummy particle track
+    Secondaries dummy_track(nullptr, std::vector<Sector>{});
+    std::vector<Cartesian3D> positions{ {0, 0, 0}, {0, 0, 10}, {0, 0, 20} };
+
+    for (auto p : positions) {
+        ParticleState p_state;
+        p_state.position = p;
+        p_state.direction = Cartesian3D(0, 0, 1);
+        dummy_track.push_back(p_state, InteractionType::Undefined);
+    }
+
+    // test geometries along propagation axis
+    EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, -5), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 0), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 0.5), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 1), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 5), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 9), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 9.5), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 10), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 10.5), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 11), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 15), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 19), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 19.5), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 20), 1)));
+    EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 30), 1)));
+
+    // test geometries displaced to propagation axis
+    EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 5, 10), 1)));
+    EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(-5, 0, 5), 1)));
+
+    // check border cases
+    EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, -1), 1)));
+    EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 1, 10), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 21), 1)));
+
+}
+
 TEST(SecondaryVector, EnergyConservation) {
     auto prop = GetPropagatorStochastic();
 

--- a/tests/Secondaries_TEST.cxx
+++ b/tests/Secondaries_TEST.cxx
@@ -3,6 +3,8 @@
 #include "PROPOSAL/Propagator.h"
 #include "PROPOSAL/medium/Medium.h"
 #include "PROPOSAL/geometry/Sphere.h"
+#include "PROPOSAL/geometry/Box.h"
+#include "PROPOSAL/geometry/Cylinder.h"
 #include "PROPOSAL/Secondaries.h"
 #include "PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h"
 #include "PROPOSAL/propagation_utility/TimeBuilder.h"
@@ -169,18 +171,11 @@ TEST(SecondaryVector, HitDetector) {
 
     // test geometries along propagation axis
     EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, -5), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 0), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 0.5), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 1), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 5), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 9), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 9.5), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 10), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 10.5), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 11), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 15), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 19), 1)));
-    EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 19.5), 1)));
+    for (double z = -0.5; z <= 20.5; z=z+0.5) {
+        EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, z), 1)));
+        EXPECT_TRUE(dummy_track.HitGeometry(Box(Cartesian3D(0, 0, z), 2, 2, 2)));
+        EXPECT_TRUE(dummy_track.HitGeometry(Cylinder(Cartesian3D(0, 0, z), 5, 1)));
+    }
     EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 20), 1)));
     EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 30), 1)));
 
@@ -192,6 +187,8 @@ TEST(SecondaryVector, HitDetector) {
     EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, -1), 1)));
     EXPECT_FALSE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 1, 10), 1)));
     EXPECT_TRUE(dummy_track.HitGeometry(Sphere(Cartesian3D(0, 0, 21), 1)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Box(Cartesian3D(0, 0, 21), 2, 2, 2)));
+    EXPECT_TRUE(dummy_track.HitGeometry(Cylinder(Cartesian3D(0, 0, 21), 5, 2)));
 
 }
 


### PR DESCRIPTION
Fixes #238 

This adds a function which checks whether a particle track has a hit a certain geometry or not. 
We decided that particles where the propagation ended on the border of a geometry (i.e. the particle did not enter the geometry, but "touched" it) will be counted as a hit. 
