### PR TITLE
Move density_correction parameter for LPM classes from Constructor to method

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
@@ -63,6 +63,7 @@ namespace crosssection {
         bool lorenz_;       // enable lorenz cut
         double lorenz_cut_; // in [MeV]
         std::shared_ptr<BremsLPM> lpm_;
+        double density_correction_; // correction to standard medium density for LPM
 
     public:
         Bremsstrahlung();
@@ -120,14 +121,12 @@ namespace crosssection {
         double mol_density_;
         double mass_density_;
         double sum_charge_;
-        double density_correction_;
         double eLpm_;
 
     public:
-        BremsLPM(const ParticleDef&, const Medium&, const Bremsstrahlung&,
-            double density_correction = 1.0);
-        double suppression_factor(
-            double energy, double v, const Component&) const;
+        BremsLPM(const ParticleDef&, const Medium&, const Bremsstrahlung&);
+        double suppression_factor(double energy, double v, const Component&,
+                                  double density_correction = 1.0) const;
         size_t GetHash() const noexcept { return hash; }
     };
 

--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/EpairProduction.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/EpairProduction.h
@@ -63,6 +63,7 @@ namespace crosssection {
 
     protected:
         std::shared_ptr<EpairLPM> lpm_;
+        double density_correction_; // correction to standard medium density for LPM
 
     public:
         EpairProduction(bool lpm = false);
@@ -112,15 +113,14 @@ namespace crosssection {
         double mass_;
         double charge_;
         double mol_density_;
-        double density_correction_;
         double eLpm_;
         size_t hash;
 
     public:
-        EpairLPM(
-            const ParticleDef&, const Medium&, double density_correction = 1.0);
+        EpairLPM(const ParticleDef&, const Medium&);
         double suppression_factor(
-            double E, double v, double r2, double beta, double xi) const;
+                double E, double v, double r2, double beta, double xi,
+                double density_correction = 1.0) const;
         size_t GetHash() const noexcept { return hash; }
     };
 

--- a/src/pyPROPOSAL/detail/parametrization.cxx
+++ b/src/pyPROPOSAL/detail/parametrization.cxx
@@ -286,11 +286,12 @@ void init_parametrization(py::module& m)
     py::class_<crosssection::BremsLPM, std::shared_ptr<crosssection::BremsLPM>>(
         m_sub_brems, "brems_lpm")
         .def(py::init<const ParticleDef&, const Medium&,
-                 const crosssection::Bremsstrahlung&, double>(),
+                 const crosssection::Bremsstrahlung&>(),
             py::arg("particle_def"), py::arg("medium"),
-            py::arg("bremsstrahlung"), py::arg("density_correction") = 1.0)
+            py::arg("bremsstrahlung"))
         .def("supression_factor", &crosssection::BremsLPM::suppression_factor,
-            py::arg("energy"), py::arg("v"), py::arg("component"));
+            py::arg("energy"), py::arg("v"), py::arg("component"),
+            py::arg("density_correction") = 1.0);
 
     // ---------------------------------------------------------------------
     // // Epair
@@ -355,12 +356,11 @@ void init_parametrization(py::module& m)
 
     py::class_<crosssection::EpairLPM, std::shared_ptr<crosssection::EpairLPM>>(
         m_sub_epair, "epair_lpm")
-        .def(py::init<const ParticleDef&, const Medium&, double>(),
-            py::arg("particle_def"), py::arg("medium"),
-            py::arg("density_correction") = 1.0)
+        .def(py::init<const ParticleDef&, const Medium&>(),
+            py::arg("particle_def"), py::arg("medium"))
         .def("supression_factor", &crosssection::EpairLPM::suppression_factor,
             py::arg("energy"), py::arg("v"), py::arg("r2"), py::arg("beta"),
-            py::arg("xi"));
+            py::arg("xi"), py::arg("density_correction") = 1.0);
 
     // --------------------------------------------------------------------- //
     // Annihilation


### PR DESCRIPTION
This way, we do not need to create new instances if the density correction changes.
For users of the crosssection/parametrization classes, only the hash calculation changes.

This is a preparing change for LPM in inhomogeneous media (#54), where we do not want to re-create this class for every evaluation point. 