### PR TITLE
add NoScattering case to make_multiple_scattering function

### DIFF
--- a/src/PROPOSAL/PROPOSAL/scattering/Scattering.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/Scattering.h
@@ -118,7 +118,11 @@ public:
     /**
      * @brief random numbers required for multiple scattering.
      */
-    static constexpr size_t MultipleScatteringRandomNumbers() noexcept { return 4; }
+    size_t MultipleScatteringRandomNumbers() const noexcept {
+        if (m_scatter_ptr)
+            return 4;
+        return 0;
+    }
 
     /**
      * @brief Calculates deflection angles for specific interaction type. Take a

--- a/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/ScatteringFactory.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/ScatteringFactory.h
@@ -68,6 +68,8 @@ inline auto make_multiple_scattering(
         return make_highland(p, m);
     case MultipleScatteringType::Moliere:
         return make_moliere(p, m);
+    case MultipleScatteringType::NoScattering:
+        return std::unique_ptr<multiple_scattering::Parametrization>(nullptr);
     default:
         throw std::out_of_range("This constructor is not provided.");
     }

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtility.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtility.cxx
@@ -143,8 +143,9 @@ std::tuple<Cartesian3D, Cartesian3D> PropagationUtility::DirectionsScatter(
 {
     if (collection.scattering) {
         std::array<double, 4> random_numbers;
-        for (auto& r : random_numbers)
-            r = rnd();
+        for (size_t i = 0; i < collection.scattering->MultipleScatteringRandomNumbers(); i++) {
+            random_numbers.at(i) = rnd();
+        }
         auto random_angles = collection.scattering->CalculateMultipleScattering(
             displacement, initial_energy, final_energy, random_numbers);
 

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -13,15 +13,20 @@
 #include "PROPOSAL/particle/ParticleDef.h"
 
 #include "PROPOSAL/scattering/multiple_scattering/ScatteringFactory.h"
+#include "PROPOSAL/scattering/ScatteringFactory.h"
 #include "PROPOSAL/scattering/multiple_scattering/Highland.h"
 #include "PROPOSAL/scattering/multiple_scattering/HighlandIntegral.h"
 #include "PROPOSAL/scattering/multiple_scattering/Moliere.h"
 #include "PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h"
 #include "PROPOSAL/crosssection/CrossSection.h"
+#include <nlohmann/json.hpp>
 
+#include "PROPOSAL/propagation_utility/PropagationUtility.h"
 #include "PROPOSAL/propagation_utility/PropagationUtilityIntegral.h"
-#include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 #include "PROPOSAL/propagation_utility/DisplacementBuilder.h"
+#include "PROPOSAL/propagation_utility/InteractionBuilder.h"
+#include "PROPOSAL/propagation_utility/TimeBuilder.h"
+#include "PROPOSAL/crosssection/CrossSectionBuilder.h"
 
 #include "PROPOSALTestUtilities/TestFilesHandling.h"
 
@@ -443,6 +448,35 @@ TEST(Scattering, ScatterReproducibilityTest)
     }
 }
 
+TEST(Scattering, NoScattering)
+{
+    // Check that "NoScattering" does not scatter the initial direction
+    // Also check that no random numbers are actually used here
+    nlohmann::json config;
+    config["multiple_scattering"] = "NoScattering";
+
+    auto cross_dummy = GetStdCrossSections(
+            MuMinusDef(), StandardRock(),
+            std::make_shared<EnergyCutSettings>(500, 0.05, false), false);
+
+    PropagationUtility::Collection collection;
+    collection.interaction_calc = make_interaction(cross_dummy, false);
+    collection.displacement_calc = make_displacement(cross_dummy, false);
+    collection.time_calc = make_time(cross_dummy, MuMinusDef(), false);
+    collection.scattering = make_scattering(config, MuMinusDef(),
+                                            StandardRock(), cross_dummy, false);
+
+    PropagationUtility utility(collection);
+
+    Cartesian3D init_dir(0, 0, 1);
+    auto rnd_lambda = []()->double {
+        throw std::logic_error("No random numbers should be used here!");
+    };
+    auto new_dir = utility.DirectionsScatter(1e2, 1e6, 1e5, init_dir, rnd_lambda);
+
+    EXPECT_EQ(std::get<0>(new_dir), init_dir);
+    EXPECT_EQ(std::get<1>(new_dir), init_dir);
+}
 
 int main(int argc, char** argv)
 {

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -387,14 +387,17 @@ TEST(Scattering, ScatterReproducibilityTest)
         crosssection_list_t cross;
 
         std::unique_ptr<multiple_scattering::Parametrization> scattering = NULL;
-        if (parametrization == "NoScattering")
-        {
-            continue; // not implemented anymore
-        } else if (parametrization == "HighlandIntegral") {
+        if (parametrization == "HighlandIntegral") {
             cross = GetCrossSections(particle_def, *medium, ecuts, false);
         }
 
         scattering = make_multiple_scattering(parametrization, particle_def, *medium, cross, false);
+
+        if (parametrization == "NoScattering")
+        {
+            EXPECT_TRUE(scattering == nullptr);
+            continue;
+        }
 
         // There has been a correction in the LPM effect parametrization for
         // bremsstrahlung which influences the scattering angles for electrons


### PR DESCRIPTION
Before this, one could not explicitly choose `NoScattering`as a scattering method in the configuration file.