### PR TITLE
New return case if UtilityInterpolant::GetUpperLimit is trivial

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
@@ -88,6 +88,9 @@ double UtilityInterpolant::GetUpperLimit(double upper_limit, double rnd)
                                "is below lower_lim. rnd was " + std::to_string(rnd)
                                + " with rnd_max " + std::to_string(max_rnd));
 
+    if (rnd == max_rnd)
+        return lower_lim;
+
     if (reverse_)
         rnd = -rnd;
 

--- a/tests/Displacement_TEST.cxx
+++ b/tests/Displacement_TEST.cxx
@@ -108,6 +108,16 @@ TEST(UpperLimitTrackIntegral, CompareIntegralInterpolant)
     }
 }
 
+TEST(UpperLimitTrackIntegral, LowerLimCheck)
+{
+    DisplacementBuilder disp_calc(GetCrossSections(), std::true_type());
+    auto lower_lim = disp_calc.GetLowerLim();
+    double E_i = 1e6;
+    auto rnd = disp_calc.SolveTrackIntegral(E_i, lower_lim);
+    auto E_f = disp_calc.UpperLimitTrackIntegral(E_i, rnd);
+    EXPECT_NEAR(E_f, lower_lim, lower_lim * COMPUTER_PRECISION);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
`UtilityInterpolant` solves integral equations. We have a `lower_lim` variable that indicated the lowest energy that we are interpolating.

`UtilityInterpolant::GetUpperLimit` [checks](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/5016366c1722f8208ea4f0b29a5a96e1952e87cc/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx#L86) if the integral equation, given an initial energy `E_i`, can be solved within the interpolation limits (i.e. for an energy `E_f > lower_lim`). If this is not the case, an error is thrown.

However, there is also the case where the solution would be `E_f = lower_lim`. For this case however, the BisectionMethod [may thrown an error](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/5016366c1722f8208ea4f0b29a5a96e1952e87cc/src/PROPOSAL/detail/PROPOSAL/math/MathMethods.cxx#L277) because the requirements of the Bisection method are not fulfilled (basically because we are already at the numerical value of our solution).

But we can trivially solve this case by returning `lower_lim`, avoiding the Bisection method (and all other calculations, which are unnecessary because we already now the solution!).

I also added a UnitTest to check that this behavior is valid.