### PR TITLE
Avoid (possible) unnecessary recalculations when crossing sector borders

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -183,11 +183,18 @@ int Propagator::AdvanceParticle(ParticleState& state, double E_f,
 
     if (advancement_type != ReachedInteraction) {
         double control_distance;
+        double energy_next_interaction = E_f;
         do {
             advance_distance = AdvanceDistance[advancement_type];
-            advance_grammage = density->Calculate(
-                state.position, state.direction, advance_distance);
-            E_f = utility.EnergyDistance(state.energy, advance_grammage);
+            if (advancement_type == ReachedInteraction) {
+                // avoid recalculation if we go back to this case
+                E_f = energy_next_interaction;
+                advance_grammage = grammage_next_interaction;
+            } else {
+                E_f = utility.EnergyDistance(state.energy, advance_grammage);
+                advance_grammage = density->Calculate(
+                        state.position, state.direction, advance_distance);
+            }
 
             std::tie(mean_direction, new_direction) = utility.DirectionsScatter(
                 advance_grammage, state.energy, E_f, state.direction, rnd);


### PR DESCRIPTION
When the algorithm at the sector border returns back to the case where a stochastic loss in the next interaction, we do not need to recalculate the energy (and grammage) to the next interaction since we already made the calculations.
Next to the wasted computational time, this calculation can also be numerically unstable (which lead to runtime errors in rare cases).

When solving issue #246, this whole code section is probably going to be restructured anyway. But for now, this should be a quick fix.