### PR TITLE
Catch negative values of the differential crosssection for PhotoQ2Intgration

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/PhotoQ2Integration.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/PhotoQ2Integration.cxx
@@ -64,7 +64,7 @@ double crosssection::PhotoQ2Integral::DifferentialCrossSection(
 
     aux *= NA / comp.GetAtomicNum() * p_def.charge * p_def.charge;
 
-    return aux;
+    return std::max(aux, 0.);
 }
 
 Q2_PHOTO_PARAM_INTEGRAL_IMPL(AbramowiczLevinLevyMaor91)


### PR DESCRIPTION
When using specific photonuclear crosssections with tau leptons, the differential crosssection becomes negative, which happend at low energies close to the tau mass. This causes dNdx to be negative as well. CubicInterpolation seems to have problems with these negative values, and crashes when trying to initialize the tables.

For example, this is the differential crosssection for taus in ice, using an EnergyCut of (Inf, 0.05), the ButkevichMikheyev parametrization and DuttaRenoSarvecivSeckel for the shadowing, at an energy of 1.1 tau masses:

![2022-01-28 17 01 17](https://user-images.githubusercontent.com/15159319/151580091-ba20f41e-8023-4960-8709-d53e95b5043f.jpg)

This PR simply catches negative values of the differential crosssection and sets them to zero.