### PR TITLE
Fix extrapolation to lower energies for PhotoproductionRhode

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Photoproduction.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Photoproduction.h
@@ -36,6 +36,8 @@ namespace PROPOSAL {
 
             double GetLowerEnergyLim(const ParticleDef&, const Medium&, cut_ptr) const override;
 
+            double GetCutOff(const Component& comp) const;
+
             size_t GetHash(const ParticleDef&, const Medium& m, cut_ptr) const noexcept override;
 
             InteractionType GetInteractionType() const noexcept override;

--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Photoproduction.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Photoproduction.h
@@ -34,9 +34,7 @@ namespace PROPOSAL {
                 return 1.; // all energy is always lost, i.e. v=1
             };
 
-            double GetLowerEnergyLim(const ParticleDef&, const Medium&, cut_ptr) const override {
-                return 2. * ME; // TODO: other limit?
-            };
+            double GetLowerEnergyLim(const ParticleDef&, const Medium&, cut_ptr) const override;
 
             size_t GetHash(const ParticleDef&, const Medium& m, cut_ptr) const noexcept override;
 

--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Photoproduction.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Photoproduction.h
@@ -12,6 +12,8 @@ namespace PROPOSAL {
         class Photoproduction : public ParametrizationDirect {
             virtual double PhotonAtomCrossSection(double, const Component&);
             double ShadowingFactor(double, const Component&);
+        protected:
+            double GetCutOff(const Component& comp) const;
         public:
             Photoproduction() = default;
 
@@ -35,8 +37,6 @@ namespace PROPOSAL {
             };
 
             double GetLowerEnergyLim(const ParticleDef&, const Medium&, cut_ptr) const override;
-
-            double GetCutOff(const Component& comp) const;
 
             size_t GetHash(const ParticleDef&, const Medium& m, cut_ptr) const noexcept override;
 

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Photoproduction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Photoproduction.cxx
@@ -24,6 +24,7 @@ double crosssection::Photoproduction::GetLowerEnergyLim(const ParticleDef&, cons
 };
 
 double crosssection::Photoproduction::GetCutOff(const Component& comp) const {
+    // pion production threshold
     auto m_N = comp.GetAverageNucleonWeight();
     return MPI + MPI * MPI / (2. * m_N);
 }

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Photoproduction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Photoproduction.cxx
@@ -16,6 +16,13 @@ size_t crosssection::Photoproduction::GetHash(const ParticleDef&, const Medium &
     return combined_hash;
 }
 
+double crosssection::Photoproduction::GetLowerEnergyLim(const ParticleDef&, const Medium& medium, cut_ptr) const {
+    double max_nuc_mass = 0.;
+    for (const auto& c : medium.GetComponents())
+        max_nuc_mass = std::max(max_nuc_mass, c.GetAverageNucleonWeight());
+    return MPI + MPI * MPI / (2. * max_nuc_mass);
+};
+
 double crosssection::Photoproduction::PhotonAtomCrossSection(double energy, const Component& comp) {
     auto cross_photon_nucleon = PhotonNucleonCrossSection(energy, comp);
     if (cross_photon_nucleon == 0.)
@@ -179,7 +186,9 @@ std::unique_ptr<crosssection::ParametrizationDirect> crosssection::Photoproducti
 
 double crosssection::PhotoproductionRhode::PhotonNucleonCrossSection(double energy, const Component& comp) {
     auto nu = energy * 1e-3; // from MeV to GeV
-    if (nu <= 200.) {
+    if (nu <= 0.1) {
+        return 0.; // do not extrapolate
+    } else if (nu <= 200.) {
         return std::max(interpolant_->InterpolateArray(nu), 0.);
     } else {
         return PhotoproductionCaldwell::PhotonNucleonCrossSection(energy, comp);


### PR DESCRIPTION
The cross section values of PhotoproductionRhode are provided as tables values which are interpolated. The lowest energy for which an interpolation point is given is at 0.1 GeV. For energies below, until now, the cross section has just been extrapolated, leading to unphysical results. This can be seen in this plot by @asandrock:

![2022-02-09 13 09 52](https://user-images.githubusercontent.com/15159319/153198348-90b989e2-0f79-4cb7-98e9-f16eb4fc3709.jpg)

This PR now ensures that we do not extrapolate the Rhode parametrization below our lowest point at 0.1 GeV.

However, this does not fix an issue with other photoproduction parametrizations.
Right now, their dNdx values look like this:

![photoproduction_cross](https://user-images.githubusercontent.com/15159319/153200272-35dbaf95-9158-48a6-a646-1bc0a2f58bc2.png)

We see that there is still an extrapolation for all other cross sections, which lead to an unphysical increase of the cross section towards lower energies. How should we behave here?
We could set the cross section to zero below a fixed energy, such as `M_PI**2  / 2*M_N`, but this would introduce a hard cut-off at this energy. However, this hard cut-off wouldn't be a big problem, because at energies of the cut off, the cross section is dominated by other processes.
The following plot indicated where this cut_off would be in this specific case:

![photoproduction_cross](https://user-images.githubusercontent.com/15159319/153201065-1207d766-956f-4ff8-8456-49a169627e40.png)

