### PR TITLE
Fix windows CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -20,7 +20,7 @@ jobs:
             - os : "ubuntu-18.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
-            - os : "windows-latest"
+            - os : "windows-2019"
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilerpp }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -70,10 +70,10 @@ jobs:
         - name: Run build automatisation tool
           run: cmake . -B PROPOSAL_BUILD -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTING=TRUE
         - name: Build lib
-          if: ${{ matrix.os != 'windows-latest' }}
+          if: ${{ matrix.os != 'windows-2019' }}
           run: cmake --build PROPOSAL_BUILD
         - name: Build lib
-          if: ${{ matrix.os == 'windows-latest' }}
+          if: ${{ matrix.os == 'windows-2019' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
 
     test:
@@ -94,7 +94,7 @@ jobs:
             - os : "ubuntu-18.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
-            - os : "windows-latest"
+            - os : "windows-2019"
       env:
         PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
       steps:

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class PROPOSALConan(ConanFile):
         if self.options.with_python:
             self.requires("pybind11/2.6.2")
         if self.options.with_testing:
-            self.requires("boost/1.78.0")
+            self.requires("boost/1.75.0")
             self.requires("gtest/1.11.0")
         if self.options.with_documentation:
             self.requires("doxygen/1.8.20")

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class PROPOSALConan(ConanFile):
         if self.options.with_python:
             self.requires("pybind11/2.6.2")
         if self.options.with_testing:
-            self.requires("boost/1.75.0")
+            self.requires("boost/1.78.0")
             self.requires("gtest/1.11.0")
         if self.options.with_documentation:
             self.requires("doxygen/1.8.20")


### PR DESCRIPTION
Github actions recently updated the default Windows runner from Windows Server 2019 to Windows Server 2022.
It looks like this not yet completely compatible with conan, at least they don't provide prebuilt packages for Visual Studio 17 which comes with WS2022.

Therefore, I would suggest that we keep testing on Windows Server 2019 until conan figured out all possible issues and provides the binaries.