### PR TITLE
Cylinder: change order of arguments in json documentation

### DIFF
--- a/docs/config_docu.md
+++ b/docs/config_docu.md
@@ -126,9 +126,9 @@ Each sector consists of at least one **geometry**. Three different geometry type
 
 | Keyword        |  Type  | Default | Description                               |
 | -------------- | ------ | ------- | ----------------------------------------- |
+| `height`       | Number | `-`     | Height of cylinder in z-direction in cm.  |
 | `outer_radius` | Number | `-`     | Outer radius of the cylinder in cm.       |
 | `inner_radius` | Number | `0`     | Inner radius of the cylinder in cm.       |
-| `height`       | Number | `-`     | Height of cylinder in z-direction in cm.  |
 
 #### Example
 


### PR DESCRIPTION
Cylinder: change order of arguments in json documentation to be consistent with argument order of constructor

The order in the json file is actually arbitrary, but this might avoid confusion (since for the rest of the documentation, the order it similar, whenever applicable)