### PR TITLE
Rewrite Propagator::AdvanceParticle method

### DIFF
--- a/src/PROPOSAL/PROPOSAL/Propagator.h
+++ b/src/PROPOSAL/PROPOSAL/Propagator.h
@@ -33,7 +33,8 @@ public:
 private:
     Interaction::Loss DoStochasticInteraction(
         ParticleState&, PropagationUtility&, std::function<double()>);
-    int AdvanceParticle(ParticleState& p_cond, double E_f, double max_distance,
+    int AdvanceParticle(ParticleState& p_cond, const double E_f,
+                        const double max_distance,
         std::function<double()> rnd, Sector& current_sector);
     double CalculateDistanceToBorder(const Vector3D& particle_position,
         const Vector3D& particle_direction, const Geometry& current_geometry);
@@ -75,9 +76,10 @@ private:
         Stochastic = 2,
     };
     enum AdvancementType : int {
-        ReachedInteraction = 0,
-        ReachedMaxDistance = 1,
-        ReachedBorder = 2
+        InvalidStep = 0,
+        ReachedInteraction = 1,
+        ReachedMaxDistance = 2,
+        ReachedBorder = 3
     };
 
     std::vector<Sector> sector_list;

--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -86,6 +86,9 @@ Secondaries Propagator::Propagate(const ParticleState& initial_particle,
 
         advancement_type = AdvanceParticle(state, energy_at_next_interaction,
             max_distance, rnd, current_sector);
+        utility = get<UTILITY>(current_sector);
+        density = get<DENSITY_DISTR>(current_sector);
+
         track.push_back(state, InteractionType::ContinuousEnergyLoss);
 
         switch (advancement_type) {
@@ -139,93 +142,112 @@ Interaction::Loss Propagator::DoStochasticInteraction(ParticleState& p_cond,
     return loss;
 }
 
-int Propagator::AdvanceParticle(ParticleState& state, double E_f,
-    double max_distance, std::function<double()> rnd, Sector& current_sector)
-{
-    assert(max_distance > 0);
-    assert(E_f >= 0);
+int Propagator::AdvanceParticle(ParticleState &state,
+    const double energy_next_interaction, const double final_distance,
+    std::function<double()> rnd_generator, Sector& current_sector) {
 
     auto& utility = get<UTILITY>(current_sector);
     auto& density = get<DENSITY_DISTR>(current_sector);
     auto& geometry = get<GEOMETRY>(current_sector);
 
-    auto grammage_next_interaction
-        = utility.LengthContinuous(state.energy, E_f);
-    auto max_distance_left = max_distance - state.propagated_distance;
-    assert(max_distance_left > 0);
+    double energy = energy_next_interaction; // final energy of proposed step
+    double grammage = -1; // grammage of proposed step
+    double distance = -1; // geometrical distance of proposed step
 
-    Cartesian3D mean_direction, new_direction;
-    std::tie(mean_direction, new_direction) = utility.DirectionsScatter(
-        grammage_next_interaction, state.energy, E_f, state.direction, rnd);
+    // Calculate maximal allowed length of step (limit due to final_distance)
+    const double max_distance = final_distance - state.propagated_distance;
 
-    double distance_next_interaction;
-    try {
-        distance_next_interaction = density->Correct(state.position,
-            mean_direction, grammage_next_interaction, max_distance_left);
-    } catch (const DensityException&) {
-        Logging::Get("proposal.propagator")
-            ->debug("Interaction point exceeds "
-                    "maximum propagation distance or lies in infinity.");
-        distance_next_interaction = INF;
-    }
-    auto new_position
-        = state.position + distance_next_interaction * mean_direction;
+    // Calculate grammage until next stochastic interaction
+    double grammage_next_interaction = utility.LengthContinuous(
+            state.energy, energy_next_interaction);
 
-    auto AdvanceDistance = std::array<double, 3> { 0., 0., 0. };
-    AdvanceDistance[ReachedInteraction] = distance_next_interaction;
-    AdvanceDistance[ReachedMaxDistance] = max_distance_left;
-    AdvanceDistance[ReachedBorder]
-        = CalculateDistanceToBorder(state.position, mean_direction, *geometry);
+    int advancement_type;
+    Cartesian3D mean_direction, new_direction; // proposed scattering
 
-    int advancement_type = minimize(AdvanceDistance);
-    double advance_distance = AdvanceDistance[advancement_type];
-    double advance_grammage = grammage_next_interaction;
+    // This lambda expression ensures we always use the same 4 random numbers
+    std::array<double, 4> random_numbers = {-1, -1, -1, -1};
+    int i = 0;
+    auto rnd = [&rnd_generator, &i, &random_numbers]() {
+        if (random_numbers[i%4] == -1)
+            random_numbers[i%4] = rnd_generator();
+        return random_numbers[i++%4];
+    };
 
-    if (advancement_type != ReachedInteraction) {
-        double control_distance;
-        double energy_next_interaction = E_f;
-        do {
-            advance_distance = AdvanceDistance[advancement_type];
-            if (advancement_type == ReachedInteraction) {
-                // avoid recalculation if we go back to this case
-                advance_grammage = grammage_next_interaction;
-                E_f = energy_next_interaction;
-            } else {
-                advance_grammage = density->Calculate(
-                        state.position, state.direction, advance_distance);
-                E_f = utility.EnergyDistance(state.energy, advance_grammage);
-            }
-
-            std::tie(mean_direction, new_direction) = utility.DirectionsScatter(
-                advance_grammage, state.energy, E_f, state.direction, rnd);
-
+    do {
+        // Calculate grammage, energy and distance for step
+        if (energy != -1 && grammage == -1 && distance == -1) {
+            // Calculate grammage and distance from given energy
+            grammage = utility.LengthContinuous(state.energy, energy);
             try {
-                AdvanceDistance[ReachedInteraction]
-                    = density->Correct(state.position, mean_direction,
-                        grammage_next_interaction, max_distance_left);
+                distance = density->Correct(state.position, state.direction, grammage, max_distance);
             } catch (const DensityException&) {
-                AdvanceDistance[ReachedInteraction] = INF;
+                distance = INF;
             }
+        } else if (energy == -1 && grammage == -1 && distance != -1) {
+            // Calculate energy and grammage from given distance
+            auto grammage_step = density->Calculate(state.position, state.direction, distance);
+            if (grammage_step < grammage_next_interaction) {
+                grammage = grammage_step;
+                energy = utility.EnergyDistance(state.energy, grammage);
+            } else {
+                // we are unable to reach `distance` before we reach the next interaction
+                // this means we are stuck in a loop, and need to discard the current set of random numbers
+                for (auto& r: random_numbers) {
+                    r = rnd_generator();
+                }
+                Logging::Get("proposal.propagator")->debug("Discard current set of random numbers for multiple"
+                                                           " scattering since we are stuck in a loop.");
+                grammage = grammage_next_interaction;
+                energy = energy_next_interaction;
+                distance = density->Correct(state.position, state.direction, grammage, max_distance);
+            }
+        } else {
+            throw std::logic_error("Error in AdvanceParticle: We shouldn't end up here!");
+        }
 
-            AdvanceDistance[ReachedBorder] = CalculateDistanceToBorder(
-                state.position, mean_direction, *geometry);
-            advancement_type = minimize(AdvanceDistance);
-            control_distance = AdvanceDistance[advancement_type];
-        } while (std::abs(advance_distance - control_distance)
-            > PARTICLE_POSITION_RESOLUTION);
-        advance_distance = control_distance;
-        advance_grammage = density->Calculate(
-            state.position, mean_direction, advance_distance);
-        new_position = state.position + advance_distance * mean_direction;
-    }
+        // Calculate scattering proposal
+        std::tie(mean_direction, new_direction) = utility.DirectionsScatter(
+                grammage, state.energy, energy, state.direction, rnd);
 
-    state.time = state.time
-        + utility.TimeElapsed(state.energy, E_f, advance_grammage,
-            density->Evaluate(state.position));
-    state.position = new_position;
+        // Check step
+        double distance_to_border = CalculateDistanceToBorder(state.position, mean_direction, *geometry);
+        bool is_inside = geometry->IsInside(state.position, mean_direction);
+        if (!is_inside) {
+            // Special case: We are on the sector border, but scattering back outside the current sector!
+            // Update sector and recalculate values
+            advancement_type = InvalidStep;
+            auto new_sector = GetCurrentSector(state.position, mean_direction);
+            utility = get<UTILITY>(new_sector);
+            density = get<DENSITY_DISTR>(new_sector);
+            geometry = get<GEOMETRY>(new_sector);
+            grammage_next_interaction = utility.LengthContinuous(state.energy, energy_next_interaction);
+            energy = energy_next_interaction;
+            distance = -1;
+            grammage = -1;
+        } else if (distance <= distance_to_border && distance <= max_distance && energy == energy_next_interaction) {
+            // reached interaction
+            advancement_type = ReachedInteraction;
+        } else if (distance <= distance_to_border && distance == max_distance) {
+            // reached max distance
+            advancement_type = ReachedMaxDistance;
+        } else if (std::abs(distance - distance_to_border) <= PARTICLE_POSITION_RESOLUTION) {
+            // reached geometry border
+            advancement_type = ReachedBorder;
+            distance = distance_to_border;
+        } else {
+            // iteration not finished! discard energy and grammage
+            advancement_type = InvalidStep;
+            distance = std::min(distance_to_border, max_distance);
+            energy = -1;
+            grammage = -1;
+        }
+    } while (advancement_type == InvalidStep);
+
+    state.time = state.time + utility.TimeElapsed(state.energy, energy, grammage, density->Evaluate(state.position)); // TODO: should the energy passed here be the randomized energy or not?
+    state.position = state.position + distance * mean_direction;
     state.direction = new_direction;
-    state.propagated_distance = state.propagated_distance + advance_distance;
-    state.energy = utility.EnergyRandomize(state.energy, E_f, rnd);
+    state.propagated_distance = state.propagated_distance + distance;
+    state.energy = utility.EnergyRandomize(state.energy, energy, rnd);
 
     return advancement_type;
 }

--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -86,6 +86,10 @@ Secondaries Propagator::Propagate(const ParticleState& initial_particle,
 
         advancement_type = AdvanceParticle(state, energy_at_next_interaction,
             max_distance, rnd, current_sector);
+
+        // If the particle is on the sector border before the continuous step is
+        // performed in 'AdvanceParticle', we might enter a different sector due
+        // to multiple scattering. Therefore, we have to update current_sector.
         utility = get<UTILITY>(current_sector);
         density = get<DENSITY_DISTR>(current_sector);
 


### PR DESCRIPTION
## Problem description

The `Propagator::AdvanceParticle` method is responsible for doing the continuous steps of the particle propagation. This includes the calculation of the continuous energy losses as well at the particle displacement, where we also have to correctly consider the effects of multiple scattering and take into account border transitions.

However, the border transitions (in combination with multiple scattering) have been the focus of several issues in the past. One current issue that has to do with scattering and border transitions has been described in detail in issue #246.

Another issue on the master branch occurred when I tried to solve this issue.
Let's assume we have a particle that propagated to a sector border in the previous step. During the next continuous step, it can be possible that the particle immediately scatters back into the old sector ("backscattering"). This situation is shown in the following sketch.

![backscatter_small](https://user-images.githubusercontent.com/15159319/156737205-e0475d94-78c9-43bc-bf2e-4f5d17b8804d.png)

This behavior is not treated correctly on the current master branch, as PROPOSAL fails to realize that the particle moved back to the old sector during the transition. This could lead to runtime errors such as:

```
RuntimeError: Root must be bracketed in Bisection method!
```

## Fix

I started to fix both issues, which are originated in `Propagator::AdvanceParticle`. However, I did not only realize that fixing the code wasn't straight-forward, I also realized that the old code has been rather hard to understand.
Therefore, I decided to completely rewrite the code - Although the basic idea of the algorithm is still the same.

For border transitions, the idea is still to iterate multiple scattering steps until our combination of scattering angle and propagation distance reaches the sector transition (This concept is described in more detail in #246).

The fix for issue #246 is to keep the same random numbers for all iterations. If we run into the "loop" problem described in #246, we discard the current set of random numbers. This leads to a minimal directional bias for specific border transitions. However, this bias only occurs for very specific geometrical constellations, and is also minimal. Furthermore, this bias has basically been included in the old algorithm as well, and could even lead to very significant biases (an example will be given below).

## Runtime comparisons and check for biases

As described in #246, the algorithm has to perform way too many iterations since the random numbers are discarded for every iteration. Therefore, this fix is expected to have a significant impact on the runtime, at least for low-energy muons as well as propagations where border crossings are performed.

To check this, I created a propagation environment where I simply propagated muons until their decay, and put a border transition into the propagation environment at 0.25 times of the mean free path lenght of the muon.

If we compare the runtimes of this PR with the master, we see that the new algorithm improves the runtime per propagation by almost a factor of two for low energies. As we go to higher energies, the difference becomes negligible, which is expected since the issue in the algorithm becomes less severe for higher energies, and since the border transition is not as important runtime-wise for higher energies.

![runtime_comparison](https://user-images.githubusercontent.com/15159319/156744415-ac5110f4-6812-43cd-a7ba-86057e7c2fed.png)


Furthermore, we can look at the deflection from the shower axis at the end of the propagation.
If we compare the results from the old master with the PR, we see that particles have a higher overall deflection from the shower axis now. This is also to be expected: In the old algorithm, we basically sampled new deflections in each iteration, until two consecutive deflections pointed into the same direction by chance. However, the probability to be similar is much smaller for smaller deflections than for higher deflections (since the solid angle is smaller for smaller deflections.) This lead to a bias towards smaller deflections in the old algorithm.

![deflection_comparison_1228 113526588618](https://user-images.githubusercontent.com/15159319/156744680-941c8874-f0d9-4e69-b339-0e3da4ca9c65.png)

## Another bias check

In this check, we propagate particles in parallel and very close to a sector border (1‰ of the mean free path length away from the sector border). Note that both sectors have the same medium. If we look at the final particle positions with this PR, the histogram looks like this:

![deflection_bias_1228 113526588618](https://user-images.githubusercontent.com/15159319/156750077-d388e40f-a508-414f-a6f7-c2f4f1d95536.png)

We see a small bias where the particles are rather scattering away from the sector border (at around 0cm) instead of towards the sector border. This bias is expected, since in some cases, the random numbers are discarded.

If we look at the same plot created on the master branch, we see that the bias is actually much more significant:

![deflection_bias_1228 113526588618_master](https://user-images.githubusercontent.com/15159319/156750486-32d2bc94-b89f-4f63-8fed-914014198a5a.png)

This is because in the old algorithm, directions without a sector transition have always been preferred. Note that this is a constructed example where we propagate a particle in perfect parallel to a sector transition. It should also be noted that this propagation on the master has been very unstable and lead to a lot of runtime errors. The reason for this is the "backscattering" issue. This has been fixed with this PR

## Just some nice plots

To visualize the results, I also created some plots with medium transitions (between Hydrogen and Stone) which I didn't want to withhold. They basically just show visually that nothing crazy is happening at sector transitions.

<details>
<summary>Click to expand</summary>

![example1](https://user-images.githubusercontent.com/15159319/156754576-d3b6198c-644b-405c-9c37-551233424cd9.png)

![example2](https://user-images.githubusercontent.com/15159319/156755035-2a742aab-f8b2-4224-a3ba-c6a351438739.png)

![example3](https://user-images.githubusercontent.com/15159319/156754594-3435a5c0-ad2c-4641-87fd-838e5704d071.png)

![example4](https://user-images.githubusercontent.com/15159319/156754815-4848bf73-6bb6-4132-841b-2a7656c2ccfa.png)


</details>

## Conclusion

This PR has the following advantages:

- Simpler code in `AdvanceParticle`
- Better runtime at border transitions, especially for small energies (fix issue #246)
- Minimizing the bias at border transitions
- Fixing runtime errors for "backscattering"

