### PR TITLE
Add UnitTests for PhotoMuPairProduction

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Parametrization.hpp
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Parametrization.hpp
@@ -21,6 +21,10 @@ namespace crosssection {
     template <>
     struct is_only_stochastic<AnnihilationHeitler> : std::true_type {};
 
+    struct PhotoMuPairBurkhardtKelnerKokoulin;
+    template <>
+    struct is_only_stochastic<PhotoMuPairBurkhardtKelnerKokoulin> : std::true_type {};
+
     struct PhotoPairTsai;
     template <>
     struct is_only_stochastic<PhotoPairTsai> : std::true_type {};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(CMAKE_CXX_STANDARD 17)
 include(GoogleTest)
 
 SET(RESOURCE_URL https://proposal.app.tu-dortmund.de/resources)
-SET(TEST_FILES TestFiles-2022-01-28.tar.gz)
+SET(TEST_FILES TestFiles-2022-03-11.tar.gz)
 
 # download the test files
 add_custom_command(OUTPUT TestFiles
@@ -57,6 +57,7 @@ package_add_test(UnitTest_Ionization Ionization_TEST.cxx)
 package_add_test(UnitTest_Mupairproduction Mupairproduction_TEST.cxx)
 package_add_test(UnitTest_Photonuclear Photonuclear_TEST.cxx)
 package_add_test(UnitTest_PhotoPair PhotoPair_TEST.cxx)
+package_add_test(UnitTest_PhotoMuPair PhotoMuPair_TEST.cxx)
 package_add_test(UnitTest_WeakInteraction WeakInteraction_TEST.cxx)
 
 # propagation and utility tests

--- a/tests/PhotoMuPair_TEST.cxx
+++ b/tests/PhotoMuPair_TEST.cxx
@@ -1,0 +1,139 @@
+#include "gtest/gtest.h"
+#include <nlohmann/json.hpp>
+
+#include "PROPOSAL/crosssection/Factories/PhotoMuPairProductionFactory.h"
+#include "PROPOSAL/secondaries/parametrization/photomupairproduction/PhotoMuPairProductionBurkhardtKelnerKokoulin.h"
+#include "PROPOSAL/medium/MediumFactory.h"
+#include "PROPOSAL/particle/ParticleDef.h"
+#include "PROPOSALTestUtilities/TestFilesHandling.h"
+
+using namespace PROPOSAL;
+
+ParticleDef getParticleDef(const std::string& name)
+{
+    if (name == "Gamma") {
+        return GammaDef();
+    } else {
+        EXPECT_TRUE(false);
+        return MuMinusDef();
+    }
+}
+
+TEST(PhotoMuPair, Test_of_dNdx)
+{
+    std::ifstream in;
+    getTestFile("PhotoMuPair_dNdx.txt", in);
+
+    std::string particleName;
+    std::string mediumName;
+    double multiplier;
+    double energy;
+    std::string parametrization;
+    double dNdx_stored;
+    double dNdx_new;
+
+    std::cout.precision(16);
+
+    while (in >> particleName >> mediumName >> multiplier >> energy
+        >> parametrization >> dNdx_stored) {
+
+        ParticleDef particle_def = getParticleDef(particleName);
+        auto medium = CreateMedium(mediumName);
+
+        nlohmann::json config;
+        config["parametrization"] = parametrization;
+
+        auto cross = make_photomupairproduction(particle_def, *medium, false, config);
+
+        dNdx_new = cross->CalculatedNdx(energy);
+        EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-5 * dNdx_stored);
+
+        auto dEdx = cross->CalculatedEdx(energy);
+        EXPECT_EQ(dEdx, 0); // only-stochastic interaction
+
+        auto dE2dx = cross->CalculatedE2dx(energy);
+        EXPECT_EQ(dE2dx, 0); // only-stochastic interaction
+
+        auto v_loss = cross->CalculateStochasticLoss(0, energy, dNdx_new);
+        EXPECT_EQ(v_loss, 1); // fatal interaction
+    }
+}
+
+TEST(PhotoMuPair, Test_of_dNdx_Interpolant)
+{
+    std::ifstream in;
+    getTestFile("PhotoMuPair_dNdx.txt", in);
+
+    std::string particleName;
+    std::string mediumName;
+    double multiplier;
+    double energy;
+    std::string parametrization;
+    double dNdx_stored;
+    double dNdx_new;
+
+    while (in >> particleName >> mediumName >> multiplier >> energy
+        >> parametrization >> dNdx_stored) {
+
+        ParticleDef particle_def = getParticleDef(particleName);
+        auto medium = CreateMedium(mediumName);
+
+        nlohmann::json config;
+        config["parametrization"] = parametrization;
+
+        auto cross = make_photomupairproduction(particle_def, *medium, true, config);
+
+        dNdx_new = cross->CalculatedNdx(energy);
+        EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-3 * dNdx_stored);
+
+        auto dEdx = cross->CalculatedEdx(energy);
+        EXPECT_EQ(dEdx, 0); // only-stochastic interaction
+
+        auto dE2dx = cross->CalculatedE2dx(energy);
+        EXPECT_EQ(dE2dx, 0); // only-stochastic interaction
+
+        auto v_loss = cross->CalculateStochasticLoss(0, energy, dNdx_new);
+        EXPECT_EQ(v_loss, 1); // fatal interaction
+
+    }
+}
+
+TEST(PhotoMuPair, CalculateX)
+{
+    std::ifstream in;
+    getTestFile("PhotoMuPair_x.txt", in);
+
+    std::string particleName;
+    std::string mediumName;
+    double rnd1;
+    double rnd2;
+    double energy;
+    double x_stored;
+    double x;
+    std::string parametrization;
+
+    while (in >> particleName >> mediumName >> energy >> parametrization >> x_stored
+        >> rnd1 >> rnd2) {
+
+        ParticleDef particle_def = getParticleDef(particleName);
+        auto medium = CreateMedium(mediumName);
+
+        std::unique_ptr<secondaries::PhotoMuPairProduction> param;
+        if (parametrization == "BurkhardtKelnerKokoulin")
+            param = std::make_unique<secondaries::PhotoMuPairProductionBurkhardtKelnerKokoulin>(particle_def, *medium);
+        else
+            throw std::logic_error("Unknown parametrization in PhotoMuPair_TEST");
+
+        auto components = medium->GetComponents();
+        auto comp = components.at(int(rnd2 * components.size()));
+
+        x = param->Calculatex(energy, rnd1, comp);
+        EXPECT_NEAR(x, x_stored, 1e-10 * x_stored);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/PhotoMuPair_TEST.cxx
+++ b/tests/PhotoMuPair_TEST.cxx
@@ -46,7 +46,7 @@ TEST(PhotoMuPair, Test_of_dNdx)
         auto cross = make_photomupairproduction(particle_def, *medium, false, config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-5 * dNdx_stored);
+        EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-10 * dNdx_stored);
 
         auto dEdx = cross->CalculatedEdx(energy);
         EXPECT_EQ(dEdx, 0); // only-stochastic interaction

--- a/tests/gen_testfiles_scripts/photomupair.py
+++ b/tests/gen_testfiles_scripts/photomupair.py
@@ -1,0 +1,132 @@
+import os
+import proposal as pp
+import numpy as np
+
+particle_defs = [
+    pp.particle.GammaDef(),
+]
+
+mediums = [
+    pp.medium.Air(),
+    pp.medium.Ice(),
+    pp.medium.Uranium()
+]
+
+multiplier = 1.
+
+params = [
+    pp.parametrization.photomupair.BurkhardtKelnerKokoulin(),
+]
+
+secondary_params = [
+    pp.secondaries.PhotoMuPairProductionBurkhardtKelnerKokoulin,
+]
+
+secondary_params_names = [
+    "BurkhardtKelnerKokoulin"
+]
+
+energies = np.logspace(1, 13, num=13)
+
+
+def create_tables(dir_name, **kwargs):
+
+    pp.RandomGenerator.get().set_seed(1234)
+
+    buf = {}
+
+    for key in kwargs:
+        if key == "dNdx" and kwargs[key] is True:
+            f_dNdx = open(dir_name + "PhotoMuPair_dNdx.txt", "w")
+            buf["dNdx"] = [f_dNdx, [""]]
+
+    for particle in particle_defs:
+        for medium in mediums:
+            for param in params:
+                args = {
+                    "parametrization": param,
+                    "particle_def": particle,
+                    "target": medium,
+                    "cuts": None,
+                    "interpolate": False
+                }
+
+                xsection = pp.crosssection.make_crosssection(**args)
+
+                for key in buf:
+                    buf[key][1] = [""]
+
+                    for energy in energies:
+                        if key == "dNdx":
+                            result = [str(xsection.calculate_dNdx(energy))]
+
+                        buf[key][1].append(particle.name)
+                        buf[key][1].append(medium.name)
+                        buf[key][1].append(str(multiplier))
+                        buf[key][1].append(str(energy))
+                        buf[key][1].append(xsection.param_name)
+                        buf[key][1].extend(result)
+                        buf[key][1].append("\n")
+
+                    buf[key][0].write("\t".join(buf[key][1]))
+
+
+def create_tables_x(dir_name, **kwargs):
+
+    pp.RandomGenerator.get().set_seed(1234)
+
+    buf = {}
+
+    f_x = open(dir_name + "PhotoMuPair_x.txt", "w")
+    buf["x"] = [f_x, [""]]
+
+    for particle in particle_defs:
+        for medium in mediums:
+            for param, param_name in zip(secondary_params, secondary_params_names):
+                args = {
+                    "particle_def": particle,
+                    "medium": medium,
+                }
+
+                secondary_calc = param(**args)
+
+                for key in buf:
+                    buf[key][1] = [""]
+
+                    for energy in energies:
+                        if (energy <= 1000):
+                            continue
+                        rnd1 = pp.RandomGenerator.get().random_double()
+                        rnd2 = pp.RandomGenerator.get().random_double()
+
+                        components = medium.components
+                        comp = components[int(rnd2*len(components))]
+
+                        x = str(secondary_calc.calculate_x(energy, rnd1, comp))
+
+                        buf[key][1].append(particle.name)
+                        buf[key][1].append(medium.name)
+                        buf[key][1].append(str(energy))
+                        buf[key][1].append(param_name)
+                        buf[key][1].append(x)
+                        buf[key][1].append(str(rnd1))
+                        buf[key][1].append(str(rnd2))
+                        buf[key][1].append("\n")
+
+                    buf[key][0].write("\t".join(buf[key][1]))
+
+def main(dir_name):
+    create_tables(dir_name, dNdx=True)
+    create_tables_x(dir_name)
+
+if __name__ == "__main__":
+
+    dir_name = "TestFiles/"
+
+    if os.path.isdir(dir_name):
+        print("Directory {} already exists".format(dir_name))
+    else:
+        os.makedirs(dir_name)
+        print("Directory {} created".format(dir_name))
+
+    main(dir_name)


### PR DESCRIPTION
Add some UnitTests for PhotoMuPairProduction.
We check dNdx and the dNdx interpolant, we check that the interaction is only-stochastic (i.e. no dEdx), we check that losses are always catastrophic (i.e. v=1) and we check the x sampling.

While writing the tests, I also realized that the PhotoMuPairProduction parametrization has not yet been registered as "only_stochastic", so this has been fixed.