### PR TITLE
Avoid invalid used of EnergyCutSettings for only stochastic parametrizations

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionBuilder.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionBuilder.h
@@ -39,11 +39,20 @@ auto make_crosssection_impl(Param&& param, P&& p_def, M&& medium,
 }
 }
 
-template <typename Param, typename P, typename M>
+template <typename Param, typename P, typename M,
+        typename _param = std::remove_reference_t<std::remove_cv_t<Param>>,
+        typename _only_stochastic = typename crosssection::is_only_stochastic<_param>::type>
 auto make_crosssection(Param&& param, P&& p_def, M&& medium,
                        std::shared_ptr<const EnergyCutSettings> cuts,
                        bool interpolate)
 {
+
+    if (std::is_same<_only_stochastic, std::true_type>::value && cuts != nullptr) {
+        throw std::logic_error(std::string("Parametrization ") + crosssection::ParametrizationName<_param>::value
+        + std::string(" can not be used with EnergyCutSettings because it is only stochastic. Pass a nullptr/None "
+                      "as a cut setting instead!"));
+    }
+
     // Call alternative implicit creation function if param
     // is a `ParametrizationDirect` object. In this case, the last argument of
     // `make_crosssection_impl` is a std::true_type, otherwise a std::false_type


### PR DESCRIPTION
This is something I discovered while creating plots for the DPG conference.

### Two types of cross sections in PROPOSAL

In PROPOSAL, we have cross sections that use an energy cut: Their differential cross sections are given in `v` (with `v` being the relative energy loss). The energy loss is drawn from the differential cross sections by sampling `v`. We have continuous energy losses `dEdx` and a total stochastic crosssection `dNdx`. Examples are ionization and bremsstrahlung.

Furtheremore, we have cross sections that are only stochastic and therefore do not use an energy cut: Their differential cross sections are given in variables that are unrelated to the relative energy loss (such as `x` or `rho`), or we only have a total cross section. The relative energy loss is always 1. Per definition, we don't have any continuous energy losses, therefore `dEdx` should be zero. Examples are annihilation, photopairproduction and the weak interaction.

### Creation of CrossSection objects in PROPOSAL

If we want to create a cross section object in python, we use the method
 ```
pp.crosssection.make_crosssection(parametrization, particle_def, medium, cuts, interpolate)
```

For a cross section that uses EnergyCutSettings, the creation of a crosssection object would look like this:

```
particle = pp.particle.EMinusDef()
medium = pp.medium.StandardRock()
cuts = pp.EnergyCutSettings(np.inf, 0.05, False)
param = pp.parametrization.bremsstrahlung.ElectronScreening()
cross = pp.crosssection.make_crosssection(param, particle, medium, cuts, True)
```

For a cross section that does not use an EnergyCutSetting, the creation of a crosssection should look like this:

```
particle = pp.particle.GammaDef()
medium = pp.medium.StandardRock()
param = pp.parametrization.photopair.KochMotz()
cross = pp.crosssection.make_crosssection(param, particle, medium, None, True)
```

Here, we do not pass an EnergyCutSettings since the crosssection doesn't require one.

### Invalid creation of CrossSection objects in PROPOSAL

What happens if we pass an EnergyCutSetting to an only-stochastic crosssection, either by accident or because we don't undestand the concept? This could look like this:

```
particle = pp.particle.GammaDef()
medium = pp.medium.StandardRock()
cuts = pp.EnergyCutSettings(np.inf, 0.05, False) # this should be None
param = pp.parametrization.photopair.KochMotz()
cross = pp.crosssection.make_crosssection(param, particle, medium, cuts, True)
```

Currently, this leads to an unintended behavior of PROPOSAL which looks like this:
The sampled relative energy losses is still calculated as 1, which is correct:

```
>>> cross.calculate_stochastic_loss(medium.components[0].hash, 1e5, cross.calculate_dEdx(1e5))
1.0
```

However, if we look at `dEdx` and `dNdx`, we see that `dEdx` is not zero:

```
>>> cross.calculate_dNdx(1e5)
0.027271780984909427
>>> cross.calculate_dEdx(1e5)
4.493690524769996
```

What happens here is that `dEdx` and `dNdx` are calculated by integrating the differential cross section. What **should** be happening is that `dEdx` is zero, and `dNdx` is calculated by integrating the differential cross section over the entire kinematic range.

Instead, we use the number from the `EnergyCutSettings` (here: `0.05`), and calculate `dEdx` by integrating from the lower kinematic limit to `v_cut`, and `dNdx` by integrating from `v_cut` to the upper kinematic limit. However, the kinematic range has nothing to do with the relative energy loss (because the differential cross section is not given in `v`)! Therefore, combining it with the numbers from the `EnergyCutSettings` is not logical.

As a result, we get continuous energy losses from parametrizations that should be only-stochastic based on an unphysical calculation.

### How to solve this

The idea is that only stochastic cross sections should only be initialized without EnergyCutSettings. However, this is never checked in PROPOSAL. 

The approach in this PR is to check if someone tries to define an only stochastic cross section with EnergyCutSettings, and if someone does, we throw an exception describing what to do:

```
>>> particle = pp.particle.GammaDef()
>>> medium = pp.medium.StandardRock()
>>> cuts = pp.EnergyCutSettings(np.inf, 0.05, False) # this should be None
>>> param = pp.parametrization.photopair.KochMotz()
>>> cross = pp.crosssection.make_crosssection(param, particle, medium, cuts, True)
RuntimeError: Parametrization kochmotz can not be used with EnergyCutSettings because it is only stochastic. Pass a nullptr/None as a cut setting instead!
```

I think there are both advantages and disadvantages to this approach to solve this problem.
One could argue that it is unnecessary that a user always has to pass `None` to create an only stochastic cross section. Alternatively, we could provide an overload of the `make_crosssection` method which doesn't take an EnergyCutSettings object:

```
>>> cross = pp.crosssection.make_crosssection(param, particle, medium, True)
```

However, this way, it would be implicit that we don't use EnergyCutSettings here, so the user may not notice. If we want to realize parametrizations where the user can actually decide whether he want to use a cross section with or without EnergyCuts (for example if we include only-stochastic propagation as an alternative way of propagation), this could be rather confusing. By only having one implementation of `make_crosssection`, the user would always know what he is doing (and will be notified if he is doing something that makes no sense). 
 