### PR TITLE
Catch negative dNdx values

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.cxx
@@ -71,7 +71,13 @@ double CrossSectionDNDXInterpolant::Calculate(double energy, double v)
         return 0.;
     auto lim = GetIntegrationLimits(energy);
     v = retransform_v(lim.min, lim.max, v);
-    return std::max(interpolant.evaluate(std::array<double, 2> { energy, v }), 0.);
+    auto dNdx = interpolant.evaluate(std::array<double, 2> { energy, v });
+    if (dNdx < 0) {
+        logger->warn("Negative dNdx value for E = {:.4f} MeV, v = {:.4f} "
+                     "detected. Setting dNdx to zero.", energy, v);
+        dNdx = 0.;
+    }
+    return dNdx;
 }
 
 double CrossSectionDNDXInterpolant::GetUpperLimit(double energy, double rate)

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.cxx
@@ -71,7 +71,7 @@ double CrossSectionDNDXInterpolant::Calculate(double energy, double v)
         return 0.;
     auto lim = GetIntegrationLimits(energy);
     v = retransform_v(lim.min, lim.max, v);
-    return interpolant.evaluate(std::array<double, 2> { energy, v });
+    return std::max(interpolant.evaluate(std::array<double, 2> { energy, v }), 0.);
 }
 
 double CrossSectionDNDXInterpolant::GetUpperLimit(double energy, double rate)


### PR DESCRIPTION
Fixes #273 

This is basically a short-term fix to catch negative dNdx values.
We set the dNdx value to zero, but we also warn the user, so that he can fix the interpolation issues if necessary (e.g. by adapting the interpolation settings).

As a long term solution, as discussed in #273 and in the PROPOSAL developer meeting, we might want to think about 

1. ...implementing an automatic self-test for interpolation tables, which checks whether everything is consistent (for example by comparing interpolated and integrated values for the whole parameter range)
2. ...implementing a routine which automatically adjust the interpolating settings for a given set of parameters.