### PR TITLE
Fix Secondaries calculation when Multiple Scattering is enabled

### DIFF
--- a/src/PROPOSAL/PROPOSAL/Secondaries.h
+++ b/src/PROPOSAL/PROPOSAL/Secondaries.h
@@ -47,7 +47,7 @@ using Sector = std::tuple<std::shared_ptr<const Geometry>, PropagationUtility,
 class Secondaries {
 
 public:
-    Secondaries(std::shared_ptr<ParticleDef>, std::vector<Sector>);
+    Secondaries(std::shared_ptr<ParticleDef> p_def, std::vector<Sector> sectors);
 
     // Operational functions to fill and access track
     void reserve(size_t number_secondaries);
@@ -62,23 +62,23 @@ public:
     const ParticleState& operator[](std::size_t idx) { return track_[idx]; };
 
     // Track functions
-    double GetELost(const Geometry&) const;
+    double GetELost(const Geometry& geometry) const;
     //TODO: These methods should return unique_ptr instead of shared_ptr, but pybind11 seems to have problems with them
-    std::shared_ptr<ParticleState> GetEntryPoint(const Geometry&) const;
-    std::shared_ptr<ParticleState> GetExitPoint(const Geometry&) const;
-    std::shared_ptr<ParticleState> GetClosestApproachPoint(const Geometry&) const;
+    std::shared_ptr<ParticleState> GetEntryPoint(const Geometry& geometry) const;
+    std::shared_ptr<ParticleState> GetExitPoint(const Geometry& geometry) const;
+    std::shared_ptr<ParticleState> GetClosestApproachPoint(const Geometry& geometry) const;
 
     /*!
     * Check if particle has hit a geometry. Particle tracks ending at the border
     * of a geometry count as a hit.
     */
-    bool HitGeometry(const Geometry&) const;
+    bool HitGeometry(const Geometry& geometry) const;
 
     std::vector<ParticleState> GetTrack() const { return track_; };
-    std::vector<ParticleState> GetTrack(const Geometry&) const;
+    std::vector<ParticleState> GetTrack(const Geometry& geometry) const;
 
-    ParticleState GetStateForEnergy(double) const;
-    ParticleState GetStateForDistance(double) const;
+    ParticleState GetStateForEnergy(double energy) const;
+    ParticleState GetStateForDistance(double propagated_distance) const;
 
     std::vector<Cartesian3D> GetTrackPositions() const;
     std::vector<Cartesian3D> GetTrackDirections() const;
@@ -93,19 +93,23 @@ public:
     // Loss functions
 
     std::vector<StochasticLoss> GetStochasticLosses() const;
-    std::vector<StochasticLoss> GetStochasticLosses(const Geometry&) const;
-    std::vector<StochasticLoss> GetStochasticLosses(const InteractionType&) const;
-    std::vector<StochasticLoss> GetStochasticLosses(const std::string&) const;
+    std::vector<StochasticLoss> GetStochasticLosses(const Geometry& geometry) const;
+    std::vector<StochasticLoss> GetStochasticLosses(const InteractionType& interaction_type) const;
+    std::vector<StochasticLoss> GetStochasticLosses(const std::string& interaction_type) const;
 
     std::vector<ContinuousLoss> GetContinuousLosses() const;
-    std::vector<ContinuousLoss> GetContinuousLosses(const Geometry&) const;
+    std::vector<ContinuousLoss> GetContinuousLosses(const Geometry& geometry) const;
 
 private:
-    ParticleState RePropagateDistance(const ParticleState&, const Cartesian3D&,
-                                      double) const;
-    ParticleState RePropagateEnergy(const ParticleState&, const Cartesian3D&,
-                                    double, double) const;
-    Sector GetCurrentSector(const Vector3D&, const Vector3D&) const;
+    ParticleState RePropagateDistance(const ParticleState& init_state,
+                                      const Cartesian3D& direction,
+                                      double displacement) const;
+    ParticleState RePropagateEnergy(const ParticleState& init_state,
+                                    const Cartesian3D& direction,
+                                    double energy_lost,
+                                    double max_distance) const;
+    Sector GetCurrentSector(const Vector3D& position,
+                            const Vector3D& direction) const;
 
     std::vector<ParticleState> track_;
     std::vector<InteractionType> types_;

--- a/src/PROPOSAL/PROPOSAL/Secondaries.h
+++ b/src/PROPOSAL/PROPOSAL/Secondaries.h
@@ -101,8 +101,10 @@ public:
     std::vector<ContinuousLoss> GetContinuousLosses(const Geometry&) const;
 
 private:
-    ParticleState RePropagateDistance(const ParticleState&, double) const;
-    ParticleState RePropagateEnergy(const ParticleState&, double, double) const;
+    ParticleState RePropagateDistance(const ParticleState&, const Cartesian3D&,
+                                      double) const;
+    ParticleState RePropagateEnergy(const ParticleState&, const Cartesian3D&,
+                                    double, double) const;
     Sector GetCurrentSector(const Vector3D&, const Vector3D&) const;
 
     std::vector<ParticleState> track_;

--- a/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
@@ -179,9 +179,9 @@ std::shared_ptr<ParticleState> Secondaries::GetEntryPoint(
         return nullptr; // track starts in geometry
 
     for (unsigned int i = 0; i < track_.size() - 1; i++) {
-        auto pos_i = track_.at(i).position;
-        auto pos_f = track_.at(i+1).position;
-        auto dir_i = track_.at(i).direction;
+        auto pos_i = track_[i].position;
+        auto pos_f = track_[i+1].position;
+        auto dir_i = track_[i].direction;
 
         auto displacement = pos_f - pos_i;
         auto dist_i_f = displacement.magnitude();
@@ -190,8 +190,8 @@ std::shared_ptr<ParticleState> Secondaries::GetEntryPoint(
         auto distance = geometry.DistanceToBorder(pos_i, displacement).first;
         if (distance <= dist_i_f && distance >= 0) {
             if (std::abs(dist_i_f - distance) < PARTICLE_POSITION_RESOLUTION)
-                return std::make_unique<ParticleState>(track_.at(i + 1));
-            auto entry_point = RePropagateDistance(track_.at(i), displacement,
+                return std::make_unique<ParticleState>(track_[i+1]);
+            auto entry_point = RePropagateDistance(track_[i], displacement,
                                                    distance);
             return std::make_unique<ParticleState>(entry_point);
         }
@@ -210,9 +210,9 @@ std::shared_ptr<ParticleState> Secondaries::GetExitPoint(
         return nullptr; // track ends inside geometry
 
     for (auto i = track_.size() - 1; i > 0; i--) {
-        auto pos_i = track_.at(i-1).position;
-        auto pos_f = track_.at(i).position;
-        auto dir_i = track_.at(i-1).direction;
+        auto pos_i = track_[i-1].position;
+        auto pos_f = track_[i].position;
+        auto dir_i = track_[i-1].direction;
 
         auto displacement = pos_f - pos_i;
         auto dist_i_f = displacement.magnitude();
@@ -221,9 +221,9 @@ std::shared_ptr<ParticleState> Secondaries::GetExitPoint(
         auto distance = geometry.DistanceToBorder(pos_f, -displacement).first;
         if (distance <= dist_i_f && distance >= 0) {
             if (std::abs(dist_i_f - distance) < PARTICLE_POSITION_RESOLUTION)
-                return std::make_unique<ParticleState>(track_.at(i - 1));
+                return std::make_unique<ParticleState>(track_[i-1]);
             auto exit_point = RePropagateDistance(
-                    track_.at(i - 1), displacement, dist_i_f - distance);
+                    track_[i-1], displacement, dist_i_f - distance);
             return std::make_unique<ParticleState>(exit_point);
         }
     }
@@ -243,8 +243,8 @@ std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(
        return std::make_unique<ParticleState>(track_.front());
 
     for (unsigned int i = 0; i < track_.size() - 1; i++) {
-        auto pos_i = track_.at(i).position;
-        auto pos_f = track_.at(i+1).position;
+        auto pos_i = track_[i].position;
+        auto pos_f = track_[i+1].position;
 
         auto displacement = pos_f - pos_i;
         auto dist_i_f = displacement.magnitude();
@@ -252,11 +252,11 @@ std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(
 
         auto distance_to_closest_approach
             = geometry.DistanceToClosestApproach(pos_i, displacement);
-        if (distance_to_closest_approach == dist_i_f) {
-            return std::make_unique<ParticleState>(track_.at(i+1));
+        if (std::abs(distance_to_closest_approach - dist_i_f) <= PARTICLE_POSITION_RESOLUTION) {
+            return std::make_unique<ParticleState>(track_[i+1]);
         } else if (distance_to_closest_approach < dist_i_f) {
             if (distance_to_closest_approach < PARTICLE_POSITION_RESOLUTION)
-                return std::make_unique<ParticleState>(track_.at(i));
+                return std::make_unique<ParticleState>(track_[i]);
 
             auto closest_approach = RePropagateDistance(
                     track_.at(i), displacement, distance_to_closest_approach);
@@ -268,10 +268,10 @@ std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(
 
 bool Secondaries::HitGeometry(const Geometry& geometry) const {
     for (unsigned int i = 0; i < track_.size() - 1; i++) {
-        auto pos_a = track_.at(i).position;
-        auto dir_a = track_.at(i).direction;
-        auto pos_b = track_.at(i + 1).position;
-        auto dir_b = track_.at(i + 1).direction;
+        auto pos_a = track_[i].position;
+        auto dir_a = track_[i].direction;
+        auto pos_b = track_[i+1].position;
+        auto dir_b = track_[i+1].direction;
 
         // check if first track point lies inside geometry
         if (geometry.IsInside(pos_a, dir_a))

--- a/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
@@ -89,8 +89,10 @@ ParticleState Secondaries::GetStateForEnergy(double energy) const
     for (unsigned int i=1; i<track_.size(); i++) {
         if (track_[i].energy < energy) {
             if (types_[i] == InteractionType::ContinuousEnergyLoss) {
+                auto displacement = track_[i].position - track_[i-1].position;
+                displacement.normalize();
                 return RePropagateEnergy(
-                        track_[i-1], track_[i-1].energy - energy,
+                        track_[i-1], displacement, track_[i-1].energy - energy,
                         track_[i-1].propagated_distance - track_[i].propagated_distance);
             } else {
                 return track_[i-1];
@@ -108,8 +110,10 @@ ParticleState Secondaries::GetStateForDistance(double propagated_distance) const
 
     for (unsigned int i=1; i<track_.size(); i++) {
         if (track_[i].propagated_distance > propagated_distance) {
+            auto displacement = track_[i].position - track_[i-1].position;
+            displacement.normalize();
             return RePropagateDistance(
-                    track_[i-1],
+                    track_[i-1], displacement,
                     propagated_distance - track_[i-1].propagated_distance);
         }
     }
@@ -178,13 +182,17 @@ std::shared_ptr<ParticleState> Secondaries::GetEntryPoint(
         auto pos_i = track_.at(i).position;
         auto pos_f = track_.at(i+1).position;
         auto dir_i = track_.at(i).direction;
-        auto dist_i_f = (pos_f - pos_i).magnitude();
 
-        auto distance = geometry.DistanceToBorder(pos_i, dir_i).first;
+        auto displacement = pos_f - pos_i;
+        auto dist_i_f = displacement.magnitude();
+        displacement.normalize();
+
+        auto distance = geometry.DistanceToBorder(pos_i, displacement).first;
         if (distance <= dist_i_f && distance >= 0) {
-            if ( dist_i_f - distance < GEOMETRY_PRECISION)
+            if (std::abs(dist_i_f - distance) < PARTICLE_POSITION_RESOLUTION)
                 return std::make_unique<ParticleState>(track_.at(i + 1));
-            auto entry_point = RePropagateDistance(track_.at(i), distance);
+            auto entry_point = RePropagateDistance(track_.at(i), displacement,
+                                                   distance);
             return std::make_unique<ParticleState>(entry_point);
         }
     }
@@ -205,14 +213,17 @@ std::shared_ptr<ParticleState> Secondaries::GetExitPoint(
         auto pos_i = track_.at(i-1).position;
         auto pos_f = track_.at(i).position;
         auto dir_i = track_.at(i-1).direction;
-        auto dist_i_f = (pos_f - pos_i).magnitude();
 
-        auto distance = geometry.DistanceToBorder(pos_f, -dir_i).first;
+        auto displacement = pos_f - pos_i;
+        auto dist_i_f = displacement.magnitude();
+        displacement.normalize();
+
+        auto distance = geometry.DistanceToBorder(pos_f, -displacement).first;
         if (distance <= dist_i_f && distance >= 0) {
-            if ( dist_i_f - distance < GEOMETRY_PRECISION)
+            if (std::abs(dist_i_f - distance) < PARTICLE_POSITION_RESOLUTION)
                 return std::make_unique<ParticleState>(track_.at(i - 1));
-            auto exit_point = RePropagateDistance(track_.at(i-1),
-                                                  dist_i_f - distance);
+            auto exit_point = RePropagateDistance(
+                    track_.at(i - 1), displacement, dist_i_f - distance);
             return std::make_unique<ParticleState>(exit_point);
         }
     }
@@ -225,23 +236,28 @@ std::shared_ptr<ParticleState> Secondaries::GetExitPoint(
     return nullptr; // No exit point found
 }
 
-std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(const Geometry& geometry) const
+std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(
+        const Geometry& geometry) const
 {
-    for (unsigned int i = 0; i < track_.size(); i++) {
-        auto sec_pos = track_.at(i).position;
-        auto sec_dir = track_.at(i).direction;
-        if (geometry.DistanceToClosestApproach(sec_pos, sec_dir) <= 0.) {
-            if(std::abs(geometry.DistanceToClosestApproach(sec_pos, sec_dir))
-                        < PARTICLE_POSITION_RESOLUTION)
+   if (track_.size() == 1)
+       return std::make_unique<ParticleState>(track_.front());
+
+    for (unsigned int i = 0; i < track_.size() - 1; i++) {
+        auto pos_i = track_.at(i).position;
+        auto pos_f = track_.at(i+1).position;
+
+        auto displacement = pos_f - pos_i;
+        auto dist_i_f = displacement.magnitude();
+        displacement.normalize();
+
+        auto distance_to_closest_approach
+            = geometry.DistanceToClosestApproach(pos_i, displacement);
+        if (distance_to_closest_approach <= dist_i_f) {
+            if (distance_to_closest_approach < PARTICLE_POSITION_RESOLUTION)
                 return std::make_unique<ParticleState>(track_.at(i));
-            if (i == 0)
-                return std::make_unique<ParticleState>(track_.front());
-            auto prev_pos = track_.at(i-1).position;
-            auto prev_dir = track_.at(i-1).direction;
-            auto displacement = geometry.DistanceToClosestApproach(prev_pos,
-                                                                   prev_dir);
-            auto closest_approach = RePropagateDistance(track_.at(i-1),
-                                                        displacement);
+
+            auto closest_approach = RePropagateDistance(
+                    track_.at(i), displacement, distance_to_closest_approach);
             return std::make_unique<ParticleState>(closest_approach);
         }
     }
@@ -272,11 +288,11 @@ bool Secondaries::HitGeometry(const Geometry& geometry) const {
 }
 
 ParticleState Secondaries::RePropagateEnergy(const ParticleState& init,
+                                             const Cartesian3D& direction,
                                              double energy_lost,
                                              double max_distance) const
 {
-    auto current_sector = GetCurrentSector(init.position,
-                                           init.direction);
+    auto current_sector = GetCurrentSector(init.position, direction);
     auto& utility = get<Propagator::UTILITY>(current_sector);
     auto& density = get<Propagator::DENSITY_DISTR>(current_sector);
 
@@ -292,19 +308,19 @@ ParticleState Secondaries::RePropagateEnergy(const ParticleState& init,
 
     auto E_f = init.energy - energy_lost;
     auto new_time = init.time + utility.TimeElapsed(
-            init.energy, E_f, displacement ,density->Evaluate(init.position));
-    auto new_position = init.position + init.direction * displacement;
+            init.energy, E_f, displacement, density->Evaluate(init.position));
+    auto new_position = init.position + direction * displacement;
     auto new_propagated_distance = init.propagated_distance + displacement;
 
     return ParticleState((ParticleType)primary_def_->particle_type, new_position,
-                         init.direction, E_f, new_time, new_propagated_distance);
+                         direction, E_f, new_time, new_propagated_distance);
 }
 
-ParticleState Secondaries::RePropagateDistance(const ParticleState &init,
+ParticleState Secondaries::RePropagateDistance(const ParticleState& init,
+                                               const Cartesian3D& direction,
                                                double displacement) const
 {
-    auto current_sector = GetCurrentSector(init.position,
-                                           init.direction);
+    auto current_sector = GetCurrentSector(init.position, direction);
     auto& utility = get<Propagator::UTILITY>(current_sector);
     auto& density = get<Propagator::DENSITY_DISTR>(current_sector);
 
@@ -317,11 +333,11 @@ ParticleState Secondaries::RePropagateDistance(const ParticleState &init,
                                                displacement);
     auto E_f = utility.EnergyDistance(init.energy, advance_grammage);
     auto new_time = init.time + utility.TimeElapsed(
-            init.energy, E_f,displacement, density->Evaluate(init.position));
-    auto new_position = init.position + init.direction * displacement;
+            init.energy, E_f, displacement, density->Evaluate(init.position));
+    auto new_position = init.position + direction * displacement;
     auto new_propagated_distance = init.propagated_distance + displacement;
     return ParticleState((ParticleType)primary_def_->particle_type, new_position,
-                         init.direction, E_f, new_time, new_propagated_distance);
+                         direction, E_f, new_time, new_propagated_distance);
 }
 
 Sector Secondaries::GetCurrentSector(const Vector3D& position,

--- a/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
@@ -252,7 +252,9 @@ std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(
 
         auto distance_to_closest_approach
             = geometry.DistanceToClosestApproach(pos_i, displacement);
-        if (distance_to_closest_approach <= dist_i_f) {
+        if (distance_to_closest_approach == dist_i_f) {
+            return std::make_unique<ParticleState>(track_.at(i+1));
+        } else if (distance_to_closest_approach < dist_i_f) {
             if (distance_to_closest_approach < PARTICLE_POSITION_RESOLUTION)
                 return std::make_unique<ParticleState>(track_.at(i));
 

--- a/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
@@ -259,7 +259,7 @@ std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(
                 return std::make_unique<ParticleState>(track_[i]);
 
             auto closest_approach = RePropagateDistance(
-                    track_.at(i), displacement, distance_to_closest_approach);
+                    track_[i], displacement, distance_to_closest_approach);
             return std::make_unique<ParticleState>(closest_approach);
         }
     }


### PR DESCRIPTION
Most of the calculations in `Secondaries` didn't take multiple scattering correctly into account.
This influenced most of the calculations, including the calculation of exit points, entry points and approach points.

When calculating the possible entry point of a particle, the directions of the individual track points have been used.
However, since multiple scattering also introduces a displacement of the particle, these directions are not identical to the direct path between two track points.

This leads to a situation like in this sketch: We want to calculate the entry point with a specific geometry (red circle). However, the algorithm used the red arrow, which is the direction at track point 1. What should be done, and which is now implemented, is to use the direct line between two track points (dotted line) to calculate intersections.
![image](https://user-images.githubusercontent.com/15159319/162480292-58f39edc-b35b-475d-9eda-83f31c8f03fc.png)

This hasn't been caught in the UnitTests because there, multiple scattering has been disabled as well. Therefore, I activated multiple scattering in the UnitTest. Furthermore, I added UnitTests for the `GetClosestApproachPoint` method, which hasn't been tested before.
 


