### PR TITLE
Fix accessed random number in NaivCompton::CalculateSecondaries

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/compton/NaivCompton.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/compton/NaivCompton.cxx
@@ -41,7 +41,7 @@ std::vector<ParticleState> secondaries::NaivCompton::CalculateSecondaries(
     auto v = loss.energy /  loss.parent_particle_energy;
     auto secondary_energies = CalculateEnergy(loss.parent_particle_energy, v);
     auto secondary_dir = CalculateDirections(loss.direction, loss.energy, v,
-                                             rnd[1]);
+                                             rnd[0]);
 
     auto sec = std::vector<ParticleState>();
     sec.emplace_back(ParticleType::Gamma, loss.position,


### PR DESCRIPTION
Using valgrind within a corsika8 shower pointed me to an invalid memory access inside the `NaivCompton` method.
To calculate the secondary particles of a Compton scattering (for an already given `v`) only requires one random number, hence [this line](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/b9fd98ae78589f5d475c5fc449913939d9cb4651/src/PROPOSAL/PROPOSAL/secondaries/parametrization/compton/NaivCompton.h#L14):
```
       static constexpr int n_rnd = 1;
``` 
This also means that only one random number is initialized, which is passed in an array to [`secondaries::NaivCompton::CalculateSecondaries`](https://github.com/tudo-astroparticlephysics/PROPOSAL/blob/b9fd98ae78589f5d475c5fc449913939d9cb4651/src/PROPOSAL/detail/PROPOSAL/secondaries/parametrization/compton/NaivCompton.cxx#L39).
However, this also means that only `rnd[0]` is initialized. However, we pass the uninitialized value `rnd[1]` to `NaivCompton::CalculateDirections`.

This random number is responsible for sampling the azimuth angle of the Compton interaction, which should normally be distributed equally.
Since the random number has not been sampled correctly, this leads to unphysical results.

## Example

I have sampled the Compton interaction of a `10 MeV` photon and the corresponding secondary particles 10000 times, both on the master and after the change in this PR. These are the zenith and azimuth angles of the corresponding electron and photon:
![zenith_photon](https://user-images.githubusercontent.com/15159319/162779124-8b3ea310-33b6-4cd7-89d2-20d4404f5794.png)
![zenith_electron](https://user-images.githubusercontent.com/15159319/162779146-be6a27b3-f78f-4c98-9c2c-d1654bf4dd77.png)
![azimuth_photon](https://user-images.githubusercontent.com/15159319/162779166-34a53b68-aad5-4f59-b615-3f709b5cdda4.png)
![azimuth_electron](https://user-images.githubusercontent.com/15159319/162779173-bdc52e4b-1612-4348-8dd9-99e4d7234005.png)

As to be expected, the zenith angle does not change. Between the master and this PR.
However, the azimuth angle is now sampled correctly. The azimuth angle on the master shows artifacts, whose shapes are probably dependent on the individual compiler and machine. 
