### PR TITLE
error in bremsstrahlung deflection for low energies 

### DIFF
--- a/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/BremsGinneken.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/BremsGinneken.h
@@ -15,7 +15,7 @@ namespace stochastic_deflection {
         }
 
         double f_nu_g(double, double, double) const;
-        double get_nu_g(double, double, double) const;
+        double get_nu_g(double, double) const;
         double get_rms_theta(double, double, double, double) const;
 
     public: 

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/BremsGinneken.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/BremsGinneken.cxx
@@ -15,7 +15,7 @@ double stochastic_deflection::BremsGinneken::f_nu_g(double nu, double n, double 
     return pow(nu, (1/n + 1)) + pow((0.2/k_4), (1/n)) * nu - pow((0.2/k_4), (1/n));
 }
 
-double stochastic_deflection::BremsGinneken::get_nu_g(double E, double n, double k_4) const {
+double stochastic_deflection::BremsGinneken::get_nu_g(double n, double k_4) const {
     auto f = [=](double nu) {
         return f_nu_g(nu, n, k_4);
     };
@@ -24,7 +24,7 @@ double stochastic_deflection::BremsGinneken::get_nu_g(double E, double n, double
         auto nu_g_x = Bisection(f, 0.5, 1., 1e-5, 100);
         return (nu_g_x.first + nu_g_x.second) / 2;
     } 
-    return 0.5;
+    return 0.5; // return boundary value of parametrization
 }
 
 double stochastic_deflection::BremsGinneken::get_rms_theta(double e_i, double e_f, double mass, double Z) const {
@@ -44,7 +44,7 @@ double stochastic_deflection::BremsGinneken::get_rms_theta(double e_i, double e_
         if (rms_theta < 0.2) {
             return rms_theta; 
         } else {
-            double nu_g = get_nu_g(e_i, n, k_4);
+            double nu_g = get_nu_g(n, k_4);
             auto k_5 = k_4 * pow(nu_g, 1 + n) * pow(1 - nu_g, 0.5 - n);
             rms_theta = k_5 * pow(1 - nu, -0.5);
             if (rms_theta < 0.2) {

--- a/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/BremsGinneken.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/stochastic_deflection/bremsstrahlung/BremsGinneken.cxx
@@ -15,21 +15,10 @@ double stochastic_deflection::BremsGinneken::f_nu_g(double nu, double n, double 
 }
 
 double stochastic_deflection::BremsGinneken::get_nu_g(double E, double n, double k_4) const {
-    // auto f = [this, &n, &k_4](double nu) {
-    //     return f_nu_g(nu, n, k_4);
-    // };
-
     auto f = [&, n, k_4](double nu) {
         return f_nu_g(nu, n, k_4);
     };
-
-    if (f_nu_g(0.5, n, k_4) * f_nu_g(1., n, k_4) > 0) {
-        Logging::Get("proposal.deflection")->warn("Boundaries of Bisection are: {} and {}, E = {}", f_nu_g(0.5, n, k_4), f_nu_g(1., n, k_4), E);
-    }
-
-    Logging::Get("proposal.deflection")->warn("Use Bisection: {}, {}", f_nu_g(0.5, n, k_4), f_nu_g(1., n, k_4));
     auto nu_g_x = Bisection(f, 0.5, 1., 1e-5, 100);
-    
     return (nu_g_x.first + nu_g_x.second) / 2;
 }
 
@@ -55,7 +44,6 @@ double stochastic_deflection::BremsGinneken::get_rms_theta(double e_i, double e_
                 nu_g = get_nu_g(e_i, n, k_4);
             };
 
-            cout << "final nu_g = " << nu_g << ", E = " << e_i << endl;
             auto k_5 = k_4 * pow(nu_g, 1 + n) * pow(1 - nu_g, 0.5 - n);
             rms_theta = k_5 * pow(1 - nu, -0.5);
             if (rms_theta < 0.2) {


### PR DESCRIPTION
The parametrizations of Van Ginneken are check for energies `3 GeV < E < 30 TeV`. For high energy losses `nu > 0.5` and low energies `E < 0.7 GeV`, it is not possible to determine the parameter `nu_g` in the bremsstrahlungs parametrization. In that case, the value is set as `nu_g = 0.5`. 
In the propagation tool MUSIC, this is the standard value for all cases.