### PR TITLE
Add InterpolationSettings::NODES_UTILITY

### DIFF
--- a/src/PROPOSAL/PROPOSAL/Constants.h
+++ b/src/PROPOSAL/PROPOSAL/Constants.h
@@ -56,6 +56,7 @@ struct InterpolationSettings {
     static unsigned int NODES_DE2DX;
     static unsigned int NODES_DNDX_E;
     static unsigned int NODES_DNDX_V;
+    static unsigned int NODES_UTILITY;
 };
 
 // precision parameters

--- a/src/PROPOSAL/detail/PROPOSAL/Constants.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Constants.cxx
@@ -30,6 +30,7 @@ unsigned int InterpolationSettings::NODES_DEDX = 500;
 unsigned int InterpolationSettings::NODES_DE2DX = 200;
 unsigned int InterpolationSettings::NODES_DNDX_E = 100;
 unsigned int InterpolationSettings::NODES_DNDX_V = 100;
+unsigned int InterpolationSettings::NODES_UTILITY = 500;
 
 // precision parameters
 const double PROPOSAL::COMPUTER_PRECISION = 1.e-10;

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/ContRandBuilder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/ContRandBuilder.cxx
@@ -1,5 +1,7 @@
 #include "PROPOSAL/propagation_utility/ContRandBuilder.h"
 #include "PROPOSAL/propagation_utility/PropagationUtilityInterpolant.h"
+#include "PROPOSAL/Constants.h"
+
 using namespace PROPOSAL;
 
 namespace PROPOSAL {
@@ -7,7 +9,8 @@ template <> void ContRandBuilder<UtilityIntegral>::build_tables() { }
 
 template <> void ContRandBuilder<UtilityInterpolant>::build_tables()
 {
-    cont_rand_integral.BuildTables("cont_rand_", 200, false);
+    cont_rand_integral.BuildTables("cont_rand_",
+                                   InterpolationSettings::NODES_UTILITY, false);
 }
 } // namespace PROPOSAL
 

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/DecayBuilder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/DecayBuilder.cxx
@@ -1,5 +1,6 @@
 #include "PROPOSAL/propagation_utility/DecayBuilder.h"
 #include "PROPOSAL/propagation_utility/PropagationUtilityInterpolant.h"
+#include "PROPOSAL/Constants.h"
 
 using namespace PROPOSAL;
 
@@ -19,7 +20,8 @@ DecayBuilder::DecayBuilder(
           [this](double E) { return FunctionToIntegral(E); },
           disp->GetLowerLim(), this->GetHash()))
 {
-    decay_integral->BuildTables("decay_", 500, true);
+    decay_integral->BuildTables("decay_", InterpolationSettings::NODES_UTILITY,
+                                true);
 }
 
 double DecayBuilder::EnergyDecay(double energy, double rnd, double density)

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/DisplacmentBuilder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/DisplacmentBuilder.cxx
@@ -1,5 +1,6 @@
 #include "PROPOSAL/propagation_utility/DisplacementBuilder.h"
 #include "PROPOSAL/propagation_utility/PropagationUtilityInterpolant.h"
+#include "PROPOSAL/Constants.h"
 
 using namespace PROPOSAL;
 
@@ -19,7 +20,8 @@ DisplacementBuilder::DisplacementBuilder(
           [this](double E) { return FunctionToIntegral(E); },
           this->GetLowerLim(), this->GetHash()))
 {
-    disp_integral->BuildTables("disp_", 500, false);
+    disp_integral->BuildTables("disp_", InterpolationSettings::NODES_UTILITY,
+                               false);
 }
 
 double DisplacementBuilder::SolveTrackIntegral(

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/InteractionBuilder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/InteractionBuilder.cxx
@@ -2,6 +2,7 @@
 #include "PROPOSAL/propagation_utility/DisplacementBuilder.h"
 #include "PROPOSAL/propagation_utility/PropagationUtilityInterpolant.h"
 #include "PROPOSAL/crosssection/CrossSection.h"
+#include "PROPOSAL/Constants.h"
 
 using namespace PROPOSAL;
 
@@ -21,7 +22,8 @@ InteractionBuilder::InteractionBuilder(std::shared_ptr<Displacement> _disp,
           [this](double E) { return FunctionToIntegral(E); },
           _disp->GetLowerLim(), this->GetHash()))
 {
-    interaction_integral->BuildTables("inter_", 500, false);
+    interaction_integral->BuildTables("inter_",
+                                      InterpolationSettings::NODES_UTILITY, false);
 }
 
 double InteractionBuilder::EnergyInteraction(double energy, double rnd)

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/PropagationUtilityInterpolant.cxx
@@ -40,7 +40,7 @@ void UtilityInterpolant::BuildTables(const std::string prefix, size_t nodes,
         reference_x = InterpolationSettings::UPPER_ENERGY_LIM;
     }
 
-    hash_combine(this->hash, reverse);
+    hash_combine(this->hash, nodes, reverse);
 
     if (reverse) {
         def.f = [&](double energy) {

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/TimeBuilder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/TimeBuilder.cxx
@@ -24,7 +24,8 @@ ExactTimeBuilder::ExactTimeBuilder(
           [this](double E) { return FunctionToIntegral(E); },
           _disp->GetLowerLim(), this->GetHash()))
 {
-    time_integral->BuildTables("time_", 500, false);
+    time_integral->BuildTables("time_", InterpolationSettings::NODES_UTILITY,
+                               false);
 }
 
 double ExactTimeBuilder::TimeElapsed(double initial_energy, double final_energy,

--- a/src/pyPROPOSAL/detail/pybindings.cxx
+++ b/src/pyPROPOSAL/detail/pybindings.cxx
@@ -230,7 +230,9 @@ PYBIND11_MODULE(proposal, m)
         .def_readwrite_static(
             "nodes_dndx_e", &InterpolationSettings::NODES_DNDX_E)
         .def_readwrite_static(
-            "nodes_dndx_v", &InterpolationSettings::NODES_DNDX_V);
+            "nodes_dndx_v", &InterpolationSettings::NODES_DNDX_V)
+        .def_readwrite_static(
+            "nodes_utility", &InterpolationSettings::NODES_UTILITY);
 
     /* py::class_<InterpolationDef, std::shared_ptr<InterpolationDef>>(m, */
     /*     "InterpolationDef", */


### PR DESCRIPTION
We have the nodes options in InterpolationSettings to set the number of nodes for out crosssections interpolation tables.
However, the number of nodes for the utility interpolation tables are currently hardcoded.

This MR introduces the option to adapt this parameter in a similar way, using the `InterpolationSettings::NODES_UTILITY` function. The default value is 500 for all utilities, which means that only the default number of nodes in the ContRand interpolant is changed.

The number of nodes has also been added to the hash so that multiple tables with a different number of nodes can exist at the same time.