### PR TITLE
Catch calculation that can become `nan` in Highland::CalculateTheta0

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/scattering/multiple_scattering/Highland.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/scattering/multiple_scattering/Highland.cxx
@@ -60,7 +60,7 @@ double Highland::CalculateTheta0(double grammage, double ei, double ef)
     double momentum_Sq = (ei - mass) * (ei + mass);
     double beta_p = momentum_Sq / ei; // beta * p = p^2/sqrt(p^2 + m^2)
     y = 13.6 * std::abs(charge) / (beta_p)*std::sqrt(y)
-        * (1. + 0.088 * std::log10(y));
+        * std::max(1. + 0.088 * std::log10(y), 0.);
     return y;
 }
 

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -209,6 +209,25 @@ TEST(Scattering, BorderCases){
     }
 }
 
+TEST(Scattering, ZeroDisplacement){
+    // No displacement should mean no scattering
+    auto medium = StandardRock();
+    auto cuts = std::make_shared<EnergyCutSettings>(INF, 1, false);
+    auto cross = GetCrossSections(MuMinusDef(), medium, cuts, true);
+
+    std::array<std::unique_ptr<multiple_scattering::Parametrization>, 3> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
+                                                                                         make_multiple_scattering("highland", MuMinusDef(), medium),
+                                                                                         make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross)};
+
+    for(auto const& scatter: scatter_list){
+        auto offset = scatter->CalculateRandomAngle(0, 1e5, 1e5, {0.1, 0.2, 0.3, 0.4});
+        EXPECT_EQ(offset.sx, 0);
+        EXPECT_EQ(offset.sy, 0);
+        EXPECT_EQ(offset.tx, 0);
+        EXPECT_EQ(offset.ty, 0);
+    }
+}
+
 TEST(Scattering, FirstMomentum){
     RandomGenerator::Get().SetSeed(24601);
     auto medium = StandardRock();


### PR DESCRIPTION
For zero displacement, y will be zero, which will create a nan here.
This is now avoided the same way it is avoided in HighlandIntegral::CalculateTheta0.