### PR TITLE
Add missing clone function to HighlandIntegral

### DIFF
--- a/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/Highland.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/Highland.h
@@ -53,8 +53,7 @@ namespace multiple_scattering {
 
         std::unique_ptr<Parametrization> clone() const override
         {
-            return std::unique_ptr<Parametrization>(
-                std::make_unique<Highland>(*this));
+            return std::make_unique<Highland>(*this);
         }
 
         ScatteringOffset CalculateRandomAngle(double grammage, double ei,

--- a/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/HighlandIntegral.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/HighlandIntegral.h
@@ -39,7 +39,7 @@ namespace PROPOSAL {
 namespace PROPOSAL {
 namespace multiple_scattering {
     class HighlandIntegral : public Highland {
-        std::unique_ptr<UtilityIntegral> highland_integral;
+        std::shared_ptr<UtilityIntegral> highland_integral;
 
         inline double Integral(Displacement&, double);
 
@@ -49,6 +49,11 @@ namespace multiple_scattering {
 
         HighlandIntegral(const ParticleDef& p, Medium const& m,
             std::shared_ptr<Displacement> disp, std::true_type);
+
+        std::unique_ptr<Parametrization> clone() const override
+        {
+            return std::make_unique<HighlandIntegral>(*this);
+        }
 
         double CalculateTheta0(double, double, double) final;
     };

--- a/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/Moliere.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/Moliere.h
@@ -45,8 +45,7 @@ namespace multiple_scattering {
 
         std::unique_ptr<Parametrization> clone() const final
         {
-            return std::unique_ptr<Parametrization>(
-                std::make_unique<Moliere>(*this));
+            return std::make_unique<Moliere>(*this);
         }
 
         int numComp_; // number of components in medium


### PR DESCRIPTION
This PR adds a missing clone function for multiple_scattering::HighlandIntegral. Due to the inheritance structure, this meant that the clone function of multiple_scattering::Highland has been called instead, which caused issue #284. 

Also added some simplifications for the clone function.

Fixes issue #284.