### PR TITLE
288 hitgeometry unreliable with multiple scattering

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Secondaries.cxx
@@ -269,16 +269,16 @@ std::shared_ptr<ParticleState> Secondaries::GetClosestApproachPoint(
 bool Secondaries::HitGeometry(const Geometry& geometry) const {
     for (unsigned int i = 0; i < track_.size() - 1; i++) {
         auto pos_a = track_[i].position;
-        auto dir_a = track_[i].direction;
         auto pos_b = track_[i+1].position;
-        auto dir_b = track_[i+1].direction;
+        auto disp = (pos_b - pos_a);
+        disp.normalize();
 
         // check if first track point lies inside geometry
-        if (geometry.IsInside(pos_a, dir_a))
+        if (geometry.IsInside(pos_a, disp))
             return true;
 
         // check if geometry lies between two track points
-        if (geometry.IsInfront(pos_a, dir_a) && geometry.IsBehind(pos_b, dir_b))
+        if (geometry.IsInfront(pos_a, disp) && geometry.IsBehind(pos_b, disp))
             return true;
     }
 

--- a/tests/Secondaries_TEST.cxx
+++ b/tests/Secondaries_TEST.cxx
@@ -237,7 +237,11 @@ TEST(SecondariesVector, HitGeometry_hierarchy) {
     auto observation_level = std::make_shared<Cylinder>(Cartesian3D(0, 0, z_detector + 0.5), 1, 1e20);
     observation_level->SetHierarchy(10);
 
-    auto prop = Propagator(p_def, {{geometry, prop_utility, density_distr}, {observation_level, prop_utility, density_distr}});
+    auto sector1 = std::make_tuple(geometry, prop_utility, density_distr);
+    auto sector2 = std::make_tuple(observation_level, prop_utility, density_distr);
+    std::vector<Sector> sec_vec = {sector1, sector2};
+
+    auto prop = Propagator(p_def, sec_vec);
 
     auto init_state = ParticleState();
     init_state.energy = 1e6;


### PR DESCRIPTION
Very identical to issue #278 

When using the `Secondaries::HitGeometry` method, multiple scattering was not correctly taken into account.
With this PR, we now use the actual track between particle positions.

In issue #288, we created this propagation environment:

> ```
> geometry = pp.geometry.Sphere(pp.Cartesian3D(0, 0, 0), 1e20)
> geometry.hierarchy = 1
> 
> detector_level = pp.geometry.Cylinder(pp.Cartesian3D(0, 0, -100000 + 0.5), 1, 1e20)
> detector_level.hierarchy = 10
> ```
> 
>
> 
> ```
> secs = prop.propagate(init_state, hierarchy_condition=5)
> ```

and checked with  `secs.hit_geometry(detector_level)` whether our particles have reached the detector level.

On the master, the z-distributions looked like this:

![1_master](https://user-images.githubusercontent.com/15159319/166246039-478b9e55-3548-49d3-b076-66d26ed6836f.png)

![2_master](https://user-images.githubusercontent.com/15159319/166246057-8772c8c5-c6e8-483d-a83a-67e9decbcafa.png)

Here we see particles with z != -100000 in the first histogram although this is unphysical.

With this PR, the distributions look like this:

![1_PR](https://user-images.githubusercontent.com/15159319/166246259-f2db9604-8946-40a1-b4fe-d51e4dc5a2cc.png)

![2_PR](https://user-images.githubusercontent.com/15159319/166246269-e15b393b-18e1-411e-b399-4acd5e4e56ae.png)

Where all particles in the first histogram are at z == -100000, as expected.


I've also added a UnitTest based on this example, which fails on the master branch.