### PR TITLE
Update modules and fix CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -62,6 +62,9 @@ jobs:
         - name: Update conan profile
           if : ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-latest' }}
           run: conan profile update settings.compiler.libcxx=libstdc++11 default
+        - name: Update conan profile
+          if : ${{ matrix.os == 'macos-latest' }}
+          run: conan profile update settings.compiler.cppstd=14 default
         - name: create build directory
           if : steps.cache-build.outputs.cache-hit != 'true'
           run: mkdir PROPOSAL_BUILD

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -63,7 +63,6 @@ jobs:
           if : ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-latest' }}
           run: conan profile update settings.compiler.libcxx=libstdc++11 default
         - name: Update conan profile
-          if : ${{ matrix.os == 'macos-latest' }}
           run: conan profile update settings.compiler.cppstd=14 default
         - name: create build directory
           if : steps.cache-build.outputs.cache-hit != 'true'

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class PROPOSALConan(ConanFile):
         if self.options.with_python:
             self.requires("pybind11/2.6.2")
         if self.options.with_testing:
-            self.requires("boost/1.75.0")
+            self.requires("boost/1.78.0")
             self.requires("gtest/1.11.0")
         if self.options.with_documentation:
             self.requires("doxygen/1.8.20")

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class PROPOSALConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("cubicinterpolation/0.1.4")
+        self.requires("cubicinterpolation/0.1.5")
         self.requires("spdlog/1.8.2")
         self.requires("nlohmann_json/3.9.1")
         if self.options.with_python:


### PR DESCRIPTION
This PR includes some updates, with which the CI is also running again. This includes

- Explicitly setting `settings.compiler.cppstd` for conan (see issue #291)
- Updating boost version for testing
- Updating cubicinterpolation version (this only includes changes to the build process, but not to the module itself)