### PR TITLE
Fix CI (on windows)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class PROPOSALConan(ConanFile):
         if self.options.with_python:
             self.requires("pybind11/2.6.2")
         if self.options.with_testing:
-            self.requires("boost/1.78.0")
+            self.requires("boost/1.75.0")
             self.requires("gtest/1.11.0")
         if self.options.with_documentation:
             self.requires("doxygen/1.8.20")


### PR DESCRIPTION
The windows CI is broken again, this time, something seems to be wrong with boost.
I put the boost version back to 1.75.0, as this is the same version used in cubicinterpolation (maybe this mismatch caused a problem?)

