### PR TITLE
Update spdlog and set windows-latest for CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -20,7 +20,7 @@ jobs:
             - os : "ubuntu-18.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
-            - os : "windows-2019"
+            - os : "windows-latest"
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilerpp }}
@@ -72,10 +72,10 @@ jobs:
         - name: Run build automatisation tool
           run: cmake . -B PROPOSAL_BUILD -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTING=TRUE
         - name: Build lib
-          if: ${{ matrix.os != 'windows-2019' }}
+          if: ${{ matrix.os != 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD
         - name: Build lib
-          if: ${{ matrix.os == 'windows-2019' }}
+          if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
 
     test:
@@ -96,7 +96,7 @@ jobs:
             - os : "ubuntu-18.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
-            - os : "windows-2019"
+            - os : "windows-latest"
       env:
         PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
       steps:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -77,6 +77,12 @@ jobs:
         - name: Build lib
           if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
+        - name: Cleanup conan cache
+          if: always()
+          run: |
+            conan remove -f "*" --builds
+            conan remove -f "*" --src
+            conan remove -f "*" --system-reqs
 
     test:
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -40,6 +40,7 @@ jobs:
             sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
             sudo update-alternatives --set c++ /usr/bin/g++
         - name: Cache conan
+          if: ${{ matrix.os != 'windows-latest' }}
           id: cache-conan
           uses: actions/cache@v2
           with:
@@ -102,6 +103,7 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         - name: Cache conan
+          if: ${{ matrix.os != 'windows-latest' }}
           id: cache-conan
           uses: actions/cache@v2
           with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -77,12 +77,6 @@ jobs:
         - name: Build lib
           if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
-        - name: Cleanup conan cache
-          if: always()
-          run: |
-            conan remove -f "*" --builds
-            conan remove -f "*" --src
-            conan remove -f "*" --system-reqs
 
     test:
       runs-on: ${{ matrix.os }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class PROPOSALConan(ConanFile):
 
     def requirements(self):
         self.requires("cubicinterpolation/0.1.5")
-        self.requires("spdlog/1.8.2")
+        self.requires("spdlog/1.10.0")
         self.requires("nlohmann_json/3.9.1")
         if self.options.with_python:
             self.requires("pybind11/2.6.2")

--- a/src/PROPOSAL/PROPOSAL/math/Interpolant.h
+++ b/src/PROPOSAL/PROPOSAL/math/Interpolant.h
@@ -85,16 +85,16 @@ private:
     int row_, starti_;
     bool rationalY_, relativeY_;
 
-    bool reverse_, self_, flag_; // Self is setted to true in constructor
+    bool reverse_, self_, flag_; // Self is set to true in constructor
     bool isLog_, logSubst_;
 
     double precision_, worstX_;
     double precision2_, worstX2_;
     double precisionY_, worstY_;
 
-    bool fast_; // Is setted to true in constructor
+    bool fast_; // Is set to true in constructor
 
-    double x_save_, y_save_; // Is setted to 1 and 0 in constructor
+    double x_save_, y_save_; // Is set to 1 and 0 in constructor
 
     //----------------------------------------------------------------------------//
     // Memberfunctions


### PR DESCRIPTION
Our CI is currently down. Neither the gcc builds nor the windows builds are finishing.

It looks like is is possible to fix gcc by updating the version of spdlog in conan to the newest version (there was some conflict/problem with fmt). But using the most recent version of a package should always be out goal.

And furthermore, it looks like the `windows-latest` is finally able to build boost (fixes issue #262), and this also fixes the CI. 