### PR TITLE
Fix CI again

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -20,7 +20,7 @@ jobs:
             - os : "ubuntu-18.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
-            - os : "windows-2019"
+            - os : "windows-latest"
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilerpp }}
@@ -40,6 +40,7 @@ jobs:
             sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
             sudo update-alternatives --set c++ /usr/bin/g++
         - name: Cache conan
+          if: ${{ matrix.os != 'windows-latest' }}
           id: cache-conan
           uses: actions/cache@v2
           with:
@@ -72,10 +73,10 @@ jobs:
         - name: Run build automatisation tool
           run: cmake . -B PROPOSAL_BUILD -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_TESTING=TRUE
         - name: Build lib
-          if: ${{ matrix.os != 'windows-2019' }}
+          if: ${{ matrix.os != 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD
         - name: Build lib
-          if: ${{ matrix.os == 'windows-2019' }}
+          if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build PROPOSAL_BUILD --target ALL_BUILD --config Release
 
     test:
@@ -96,12 +97,13 @@ jobs:
             - os : "ubuntu-18.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
-            - os : "windows-2019"
+            - os : "windows-latest"
       env:
         PROPOSAL_TEST_FILES: ${{ github.workspace }}/PROPOSAL_BUILD/tests/TestFiles
       steps:
         - uses: actions/checkout@v2
         - name: Cache conan
+          if: ${{ matrix.os != 'windows-latest' }}
           id: cache-conan
           uses: actions/cache@v2
           with:

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class PROPOSALConan(ConanFile):
 
     def requirements(self):
         self.requires("cubicinterpolation/0.1.5")
-        self.requires("spdlog/1.8.2")
+        self.requires("spdlog/1.10.0")
         self.requires("nlohmann_json/3.9.1")
         if self.options.with_python:
             self.requires("pybind11/2.6.2")


### PR DESCRIPTION
The CI has been broken for some time now. This should fix it now with the following steps:

- Using the newest version of spdlog in our conanfile. With the old version, there was some problem with finding the `fmt` package. This caused the gcc builds to fail with the conan error:
    ```
  Could NOT find fmt: Found unsuitable version "None", but required is at
  least "5.3.0" (found None)
    ```
- Using `windows-latest` for the CI runner. As desribed in issue #262, we haven't been using the latest windows runner. However, on the old version, weird linker errors started to appear. They are gone with the newest version.
- Disabling conan caches for the windows-runner. Building PROPOSAL and its dependencies works without a problem. However, reloading the caches fails with conan throwing the error message 
   ```
   ERROR: Error, the file to download already exists: 'C:\Users\runneradmin\.conan\data\boost\1.78.0\_\_\dl\export   \conan_sources.tgz'. [Remote: conancenter]
   The 'boost/1.78.0' package has 'exports_sources' but sources not found in local cache.
   Probably it was installed from a remote that is no longer available.
   ```
   Therefore, the cache has been disabled for the windows build for now. This means that it will take an additional ~15 minutes to build the dependencies every time, but the windows tests take over three hours in total, so this isn't too severe in comparison. Still, it would be nice to fix this again, but for now this at least makes the CI run again.
