### PR TITLE
Log message when tables are created

### DIFF
--- a/src/PROPOSAL/PROPOSAL/Logging.h
+++ b/src/PROPOSAL/PROPOSAL/Logging.h
@@ -30,6 +30,7 @@
 #include <PROPOSAL/methods.h>
 #include <spdlog/sinks/sink.h>
 #include <spdlog/spdlog.h>
+#include "spdlog/sinks/dup_filter_sink.h"
 
 #include <memory>
 #include <string>
@@ -48,8 +49,12 @@ struct Logging {
     static logger_ptr Get(std::string const& name)
     {
         auto it = Logging::logger.find(name);
-        if (it == logger.end())
-            Logging::logger[name] = Logging::Create(name);
+        if (it == logger.end()) {
+            if (name == "TableCreation")
+                Logging::logger[name] = Logging::CreateDupFiler(name);
+            else
+                Logging::logger[name] = Logging::Create(name);
+        }
         return Logging::logger[name];
     }
 
@@ -64,6 +69,16 @@ private:
     static logger_ptr Create(std::string const& name)
     {
         auto logger = std::make_shared<spdlog::logger>(name, sink);
+        logger->set_level(global_loglevel);
+        return logger;
+    }
+
+    static logger_ptr CreateDupFiler(std::string const& name)
+    {
+        // don't log duplicate messages
+        auto dup_filter = std::make_shared<spdlog::sinks::dup_filter_sink_st>(std::chrono::seconds(60));
+        dup_filter->add_sink(sink);
+        auto logger = std::make_shared<spdlog::logger>(name, dup_filter);
         logger->set_level(global_loglevel);
         return logger;
     }

--- a/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDEDX/CrossSectionDEDXBuilder.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDEDX/CrossSectionDEDXBuilder.h
@@ -14,7 +14,7 @@ template <typename... Args> auto make_dedx(bool interpolate, Args&&... args)
             ptr = std::make_unique<CrossSectionDEDXInterpolant>(
                 std::forward<Args>(args)...);
         } catch (exception_axis_builder_dedx_out_of_range const& e) {
-            Logging::Get("CrossSection.DEDX")->info(e.what());
+            Logging::Get("CrossSection.DEDX")->debug(e.what());
         }
     else
         ptr = std::make_unique<CrossSectionDEDXIntegral>(

--- a/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.h
@@ -3,6 +3,7 @@
 #include "PROPOSAL/Constants.h"
 #include "PROPOSAL/crosssection/CrossSectionDNDX/AxisBuilderDNDX.h"
 #include "PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXIntegral.h"
+#include "PROPOSAL/methods.h"
 
 #include <type_traits>
 
@@ -83,7 +84,7 @@ auto build_dndx_def(T1 const& param, ParticleDef const& p, Args... args)
     return def;
 }
 
-class CrossSectionDNDXInterpolant : public CrossSectionDNDX {
+class CrossSectionDNDXInterpolant : public CrossSectionDNDX, public LogTableCreation {
     std::function<double(double, double, double)> transform_v;
     std::function<double(double, double, double)> retransform_v;
     cubic_splines::Interpolant<cubic_splines::BicubicSplines<double>>
@@ -99,7 +100,7 @@ public:
     CrossSectionDNDXInterpolant(Param param, ParticleDef const& p,
         Target const& t, std::shared_ptr<const EnergyCutSettings> cut,
         size_t hash = 0)
-        : CrossSectionDNDX(param, p, t, cut, gen_hash(hash))
+        : CrossSectionDNDX(param, p, t, cut, gen_hash(hash)), LogTableCreation(gen_path(), gen_name())
         , transform_v(transform_loss<Param>)
         , retransform_v(retransform_loss<Param>)
         , interpolant(build_dndx_def(param, p, t, cut), gen_path(), gen_name())

--- a/src/PROPOSAL/PROPOSAL/methods.h
+++ b/src/PROPOSAL/PROPOSAL/methods.h
@@ -33,6 +33,8 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #define PROPOSAL_MAKE_HASHABLE(type, ...)                                      \
     namespace std {                                                            \
@@ -77,6 +79,12 @@ inline void hash_combine(std::size_t& seed, const T& v, Rest... rest)
 class Interpolant;
 struct InterpolantBuilder;
 
+// This object checks whether the table under path/filename is already existing. Needs to be created before the table
+// creation process has started.
+struct LogTableCreation {
+    LogTableCreation(const std::string& path, const std::string& filename);
+};
+
 namespace Helper {
 
     // ----------------------------------------------------------------------------
@@ -95,6 +103,13 @@ namespace Helper {
         bool operator()(std::string const& lhs, std::string const& rhs) const;
     };
 
+    inline bool file_exists (const std::string& path_to_file) {
+        if (access(path_to_file.c_str(), F_OK) != 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 } // namespace Helper
 
 

--- a/src/PROPOSAL/PROPOSAL/methods.h
+++ b/src/PROPOSAL/PROPOSAL/methods.h
@@ -113,7 +113,7 @@ namespace Helper {
     }
 
     inline bool is_folder_writable(const std::string& path_to_file) {
-        return access( path_to_file.c_str(), W_OK ) == 0;
+        return access( path_to_file.c_str(), 2 ) == 0;
     }
 
 } // namespace Helper

--- a/src/PROPOSAL/PROPOSAL/methods.h
+++ b/src/PROPOSAL/PROPOSAL/methods.h
@@ -34,8 +34,11 @@
 #include <memory>
 #include <vector>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
-
+#endif
 #define PROPOSAL_MAKE_HASHABLE(type, ...)                                      \
     namespace std {                                                            \
     template <> struct hash<type> {                                            \

--- a/src/PROPOSAL/PROPOSAL/methods.h
+++ b/src/PROPOSAL/PROPOSAL/methods.h
@@ -36,8 +36,9 @@
 #include <sys/stat.h>
 #ifdef _WIN32
 #include <io.h>
+   #define access    _access_s
 #else
-#include <unistd.h>
+    #include <unistd.h>
 #endif
 #define PROPOSAL_MAKE_HASHABLE(type, ...)                                      \
     namespace std {                                                            \
@@ -106,12 +107,9 @@ namespace Helper {
         bool operator()(std::string const& lhs, std::string const& rhs) const;
     };
 
+    // TODO: use std::filesystem when we switch to c++17
     inline bool file_exists (const std::string& path_to_file) {
-        if (access(path_to_file.c_str(), F_OK) != 0) {
-            return false;
-        } else {
-            return true;
-        }
+        return access( path_to_file.c_str(), 0 ) == 0;
     }
 } // namespace Helper
 

--- a/src/PROPOSAL/PROPOSAL/methods.h
+++ b/src/PROPOSAL/PROPOSAL/methods.h
@@ -111,6 +111,11 @@ namespace Helper {
     inline bool file_exists (const std::string& path_to_file) {
         return access( path_to_file.c_str(), 0 ) == 0;
     }
+
+    inline bool is_folder_writable(const std::string& path_to_file) {
+        return access( path_to_file.c_str(), W_OK ) == 0;
+    }
+
 } // namespace Helper
 
 

--- a/src/PROPOSAL/detail/PROPOSAL/Logging.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Logging.cxx
@@ -8,4 +8,4 @@ std::unordered_map<std::string, std::shared_ptr<spdlog::logger>> Logging::logger
 std::shared_ptr<spdlog::sinks::sink> Logging::sink
     = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 
-spdlog::level::level_enum Logging::global_loglevel = spdlog::level::level_enum::warn;
+spdlog::level::level_enum Logging::global_loglevel = spdlog::level::level_enum::info;

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSection.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSection.cxx
@@ -56,12 +56,12 @@ namespace detail {
         auto logger = Logging::Get("Crosssection");
         auto interaction_type =static_cast<InteractionType>(id);
         auto interaction_name = Type_Interaction_Name_Map.at(interaction_type);
-        logger->info("Building {} cross section for interaction type {}.", param_name,
+        logger->debug("Building {} cross section for interaction type {}.", param_name,
             interaction_name);
         logger->debug("-> with particle {}", p.name);
         logger->debug("-> with target {}", m.GetName());
         if (cut)
-            logger->debug("-> with e cut {} and v_cut {}", cut->GetEcut(),
+            logger->debug("-> with e_cut {} and v_cut {}", cut->GetEcut(),
                 cut->GetVcut());
         return logger;
     };

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDE2DX/CrossSectionDE2DX.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDE2DX/CrossSectionDE2DX.cxx
@@ -23,7 +23,7 @@ CrossSectionDE2DX::CrossSectionDE2DX(size_t _hash)
     : hash(_hash)
     , logger(Logging::Get("CrossSection.DE2DX"))
 {
-    logger->info("Creating dEdx.");
+    logger->debug("Creating dE2dx.");
 }
 
 CrossSectionDE2DX::CrossSectionDE2DX(

--- a/src/PROPOSAL/detail/PROPOSAL/geometry/Cylinder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/geometry/Cylinder.cxx
@@ -16,7 +16,6 @@ Cylinder::Cylinder(const Vector3D& position, double z, double radius, double inn
     , inner_radius_(inner_radius)
     , z_(z)
 {
-    Logging::Get("proposal.geometry")->info("Order of function parameters for Cylinder constructor has been changed in vesion 7.");
     if (inner_radius_ > radius_)
     {
         Logging::Get("proposal.geometry")->error("Inner radius {} is greater then radius {} (will be swaped)", inner_radius_, radius_);

--- a/src/PROPOSAL/detail/PROPOSAL/methods.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/methods.cxx
@@ -10,10 +10,21 @@
 // #include <stdlib.h>
 
 #include "PROPOSAL/methods.h"
+#include "PROPOSAL/Logging.h"
 #include <algorithm>
 #include <string>
 
 namespace PROPOSAL {
+
+LogTableCreation::LogTableCreation(const std::string &path, const std::string &filename) {
+    // TODO: use std::filesystem when we switch to c++17
+    auto combined = path + "/" + filename;
+    if (!Helper::file_exists(combined)) {
+        Logging::Get("TableCreation")->info("Tables not existing and need to be created. This may take some time.");
+    } else {
+        Logging::Get("TableCreation")->info("Tables are existing and are read from file.");
+    }
+}
 
 namespace Helper {
 

--- a/src/PROPOSAL/detail/PROPOSAL/methods.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/methods.cxx
@@ -20,9 +20,17 @@ LogTableCreation::LogTableCreation(const std::string &path, const std::string &f
     // TODO: use std::filesystem when we switch to c++17
     auto combined = path + "/" + filename;
     if (!Helper::file_exists(combined)) {
-        Logging::Get("TableCreation")->info("Tables not existing and need to be created. This may take some time.");
+        if (Helper::is_folder_writable(path)) {
+            Logging::Get("TableCreation")->info("Tables are not available and need to be created. "
+                                                "This will take some minutes.");
+        } else {
+            Logging::Get("TableCreation")->info("Tables are not available and need to be created. "
+                                                "This will take some minutes. PROPOSAL is unable to write to the "
+                                                "requested path {}. Therefore, tables will only be stored in memory.",
+                                                path);
+        }
     } else {
-        Logging::Get("TableCreation")->info("Tables are existing and are read from file.");
+        Logging::Get("TableCreation")->debug("Tables are available and are read from file.");
     }
 }
 


### PR DESCRIPTION
This is a first draft for improving the logging for table creation.

Every time before we create a table (either dndx, dedx, de2dx or a utility interpolant), PROPOSAL will check whether a file under this name already exists. If not, PROPOSAL prints a logging message `Tables not existing and need to be created. This may take some time.` If the tables do exist, PROPOSAL prints a logging message `Tables are existing and are read from file.`

However, with a normal logger, this would mean that we would get dozens of identical logging messages.
To avoid this, I am using `spdlog::sinks::dup_filter_sink_st`, which avoids duplicate logging messages that would occur during a specific time interval (at the moment set to 1 minute). This avoids a ton of logging output, but gives still enough logging output to inform the user that things are happening.

For example, when calling `GetStdCrossSections`, but there are no tables, the output looks like this:

```
[2022-08-03 19:59:56.937] [Crosssection] [info] Building KelnerKokoulinPetrukhin cross section for interaction type Brems.
[2022-08-03 19:59:56.937] [TableCreation] [info] Tables not existing and need to be created. This may take some time.
[2022-08-03 19:59:57.235] [Crosssection] [info] Building KelnerKokoulinPetrukhin cross section for interaction type Epair.
[2022-08-03 20:00:27.754] [Crosssection] [info] Building BetheBlochRossi cross section for interaction type Ioniz.
[2022-08-03 20:00:27.937] [Crosssection] [info] Building AbramowiczLevinLevyMaor97 cross section for interaction type Photonuclear.
[2022-08-03 20:01:29.280] [TableCreation] [info] Skipped 16 duplicate messages..
[2022-08-03 20:01:29.280] [TableCreation] [info] Tables not existing and need to be created. This may take some time.
```

Note that there is also an logging information when we start to build a specific crosssection (this has already been implemented before, but has been suppressed because the default loglevel was warn)

When the tables already exist, we only get this output:

```
[2022-08-03 20:04:07.827] [Crosssection] [info] Building KelnerKokoulinPetrukhin cross section for interaction type Brems.
[2022-08-03 20:04:07.827] [TableCreation] [info] Tables are existing and are read from file.
[2022-08-03 20:04:07.828] [Crosssection] [info] Building KelnerKokoulinPetrukhin cross section for interaction type Epair.
[2022-08-03 20:04:07.847] [Crosssection] [info] Building BetheBlochRossi cross section for interaction type Ioniz.
[2022-08-03 20:04:07.851] [Crosssection] [info] Building AbramowiczLevinLevyMaor97 cross section for interaction type Photonuclear.
```

The questions:
- Should the specific information about what crosssection is currently built be printed on loglevel info (like above), or on debug, so that we only see the info *that* tables are currently built?
- Should we log any other events (like when we are writing to memory instead of to files?)
- Should there even be a logging output when the tables are read from a file, or can this also be set to debug?
- Are the messages clear, or should they be changed?
- Should the default loglevel be `info`? It has been `warn` before, but this would suppress these log messages (unless we change their loglevel to `warn`, but this is not intuitive to me)