### PR TITLE
Adapt LowerEnergyLim of Compton

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Compton.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Compton.cxx
@@ -11,7 +11,9 @@ using namespace PROPOSAL;
 double crosssection::Compton::GetLowerEnergyLim(
     const ParticleDef&) const noexcept
 {
-    return pow(ALPHA, 2) * ME / 2; // ionization energy of K-shell electron for hydrogen
+    // Ionization energy of K-shell electron for hydrogen.
+    // This ensures that the LowerEnergyLim for Compton is always at least as low as the limit for the Photoeffect.
+    return pow(ALPHA, 2) * ME / 2;
 }
 
 crosssection::KinematicLimits crosssection::Compton::GetKinematicLimits(

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Compton.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Compton.cxx
@@ -11,7 +11,7 @@ using namespace PROPOSAL;
 double crosssection::Compton::GetLowerEnergyLim(
     const ParticleDef&) const noexcept
 {
-    return 2. * ME;
+    return pow(ALPHA, 2) * ME / 2; // ionization energy of K-shell electron for hydrogen
 }
 
 crosssection::KinematicLimits crosssection::Compton::GetKinematicLimits(


### PR DESCRIPTION
Fixes issue #301 

The lower energy limit of Compton is somewhat arbitrary, and has been set to 2*ME before. Now, we set it to the ionization energy of the K-shell electron of hydrogen to have a new lower limit which works better with the now-implemented Photoeffect.