### PR TITLE
Change kinematic limits of BremsElectronScreening

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
@@ -77,7 +77,7 @@ namespace crosssection {
 
         double GetLowerEnergyLim(const ParticleDef&) const noexcept final;
         KinematicLimits GetKinematicLimits(
-            const ParticleDef&, const Component&, double) const final;
+            const ParticleDef&, const Component&, double) const override;
     };
 
     template <> struct ParametrizationName<Bremsstrahlung> {
@@ -104,6 +104,8 @@ namespace crosssection {
             double energy, double v) const final;
         double DifferentialCrossSection(const ParticleDef&, const Component&,
             double energy, double v) const final;
+        KinematicLimits GetKinematicLimits(const ParticleDef&, const Component&,
+                                           double energy) const override;
     };
 
     template <> struct ParametrizationName<BremsElectronScreening> {

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
@@ -543,7 +543,8 @@ double crosssection::BremsElectronScreening::CalculateParametrization(
     double A_fac = 1.0;
     if (energy < 50.) {
         f_c = 0;
-        A_fac = interpolant_->InterpolateArray(logZ, energy);
+        // correction tables are stored in kinetic energies
+        A_fac = interpolant_->InterpolateArray(logZ, energy - p_def.mass);
     }
 
     auto result = A_fac * comp.GetNucCharge() * (comp.GetNucCharge() + xi);
@@ -553,6 +554,15 @@ double crosssection::BremsElectronScreening::CalculateParametrization(
     result *= aux;
 
     return result;
+}
+
+crosssection::KinematicLimits crosssection::BremsElectronScreening::GetKinematicLimits(
+        const ParticleDef& p_def, const Component&, double energy) const
+{
+    auto kin_lim = KinematicLimits();
+    kin_lim.v_min = 0.;
+    kin_lim.v_max = 1 - p_def.mass / energy;
+    return kin_lim;
 }
 
 #undef BREMSSTRAHLUNG_IMPL


### PR DESCRIPTION
For BremsElectronScreening, the kinematic limits have so far been taken from Petrukhin & Shestakov, where the upper limit has been calculated by setting the corresponding screening function to zero.

However, we don't need to use this for BremsElectronScreening. Instead, we can just use the physical limit 1 - m/E. 
We have checked that this is still consistent with the condition that the screening function should be non-negative (see [this presentation](https://indico.scc.kit.edu/event/2955/contributions/11154/attachments/5345/8203/EM_comparison.pdf) for more information)

Comparing PROPOSAL with EGS4, using these improved limits also yields a better agreement in the cross section (also shown in the presentation linked above).

This PR also fixes that the tables with the correction factors are stored as kinetic energies, but have been evaluated with total energies so far.