### PR TITLE
Restructure Bremsstrahlung::GetKinematicLimits

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/Bremsstrahlung.h
@@ -39,6 +39,9 @@
                                                                                \
         double CalculateParametrization(const ParticleDef&, const Component&,  \
             double energy, double v) const final;                              \
+                                                                               \
+        KinematicLimits GetKinematicLimits(                                    \
+            const ParticleDef&, const Component&, double) const override;      \
     };                                                                         \
                                                                                \
     template <> struct ParametrizationName<Brems##param> {                     \
@@ -104,8 +107,6 @@ namespace crosssection {
             double energy, double v) const final;
         double DifferentialCrossSection(const ParticleDef&, const Component&,
             double energy, double v) const final;
-        KinematicLimits GetKinematicLimits(const ParticleDef&, const Component&,
-                                           double energy) const override;
     };
 
     template <> struct ParametrizationName<BremsElectronScreening> {


### PR DESCRIPTION
We have two types of KinematicLimits for Bremsstrahlung:
Firstly those who follow from the condition that E>m0 for all particle involved needs to be fulfilled, and secondly those who are derived by requiring the screening functions to be non-zero.

The first condition is more general, and is now implemented as `Bremsstrahlung::GetKinematicLimits`, i.e. as the default method for all Bremsstrahlungs parametrizations.
If the kinematic limits using the screening function condition is supposed to be used, the `GetKinematicLimits` method will now be overwritten by the specific parametrizations classes (which is currently the case for all parametrizations but `ElectronScreening`).

This way, the structure becomes more clear: The base class has the most general implementation of kinematic limits, while the derived classes overwrite this definition with their specific implementations of the kinematic limits.

This doesn't change any physics.

In future, we might want to investigate whether it is appropriate that all parametrizations (but `ElectronScreening`) use the kinematic limits derived from Petrukhin&Shestakov, or whether it makes a difference when one derives the kinematic limits for every parametrization from the specific screening functions from the corresponding parametrization. 
This awaits development by some fresh, energetic PROPOSAL user.