### PR TITLE
Add missing entry for InteractionType::Photoeffect

### DIFF
--- a/src/PROPOSAL/PROPOSAL/particle/Particle.h
+++ b/src/PROPOSAL/PROPOSAL/particle/Particle.h
@@ -83,7 +83,8 @@ static const std::unordered_map<InteractionType, std::string,
         { InteractionType::Photopair, "Photopair" },
         { InteractionType::Photoproduction, "Photoproduction" },
         { InteractionType::PhotoMuPair, "PhotoMuPairProduction" },
-    };
+        { InteractionType::Photoeffect, "Photoeffect" },
+};
 } // namespace PROPOSAL
 
 namespace PROPOSAL {


### PR DESCRIPTION
Add missing entry for InteractionType::Photoeffect to Type_Interaction_Name_Map

Without this, it is currently impossible to search for Photoeffect losses in `Secondaries::GetStochasticLosses(const std::string& interaction_type)`,  so that one has to use `Secondaries::GetStochasticLosses(const InteractionType& type)` instead.

Most of the other uses of this map affect logging messages for building tables - But there are no tables built for the photoeffect.