### PR TITLE
Update ubuntu-18.04 runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -26,6 +26,11 @@ jobs:
         CXX: ${{ matrix.compilerpp }}
       steps:
         - uses: actions/checkout@v2
+        - name: add custom deb repository
+          if: ${{ matrix.compiler == 'gcc-5' }}
+          uses: myci-actions/add-deb-repo@10
+          with:
+            repo: deb http://dk.archive.ubuntu.com/ubuntu/ xenial main
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -26,7 +26,7 @@ jobs:
         CXX: ${{ matrix.compilerpp }}
       steps:
         - uses: actions/checkout@v2
-        - name: Install gcc-5
+        - name: Set up gcc5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |
             mkdir ~/Downloads
@@ -41,8 +41,6 @@ jobs:
             wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/libstdc++-5-dev_5.5.0-12ubuntu1_amd64.deb
             wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/g++-5_5.5.0-12ubuntu1_amd64.deb
             sudo apt install ./g++-5_5.5.0-12ubuntu1_amd64.deb ./gcc-5_5.5.0-12ubuntu1_amd64.deb ./gcc-5-base_5.5.0-12ubuntu1_amd64.deb ./cpp-5_5.5.0-12ubuntu1_amd64.deb ./libisl15_0.18-4_amd64.deb ./libgcc-5-dev_5.5.0-12ubuntu1_amd64.deb ./libasan2_5.5.0-12ubuntu1_amd64.deb ./libmpx0_5.5.0-12ubuntu1_amd64.deb ./libstdc++-5-dev_5.5.0-12ubuntu1_amd64.deb
-            sudo apt install g++-5
-            sudo apt install gcc-5
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20
             sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -36,7 +36,7 @@ jobs:
           uses: myci-actions/add-deb-repo@10
           with:
             repo: deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe
-            install: [g++-5, gcc-5]
+            install: g++-5, gcc-5
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -29,6 +29,7 @@ jobs:
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |
+            mkdir ~/Downloads
             cd ~/Downloads
             wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/gcc-5-base_5.5.0-12ubuntu1_amd64.deb
             wget -c http://archive.ubuntu.com/ubuntu/pool/universe/i/isl-0.18/libisl15_0.18-4_amd64.deb

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -26,11 +26,30 @@ jobs:
         CXX: ${{ matrix.compilerpp }}
       steps:
         - uses: actions/checkout@v2
-        - name: Set up GCC
-          if: ${{ matrix.compiler == 'gcc-5' }}
-          uses: egor-tensin/setup-gcc@v1
-          with:
-            version: 5
+        - name: Install gcc-5
+          if : ${{ matrix.compiler == 'gcc-5' }}
+          run: |
+            cd ~/Downloads
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/gcc-5-base_5.5.0-12ubuntu1_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/i/isl-0.18/libisl15_0.18-4_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/cpp-5_5.5.0-12ubuntu1_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/libasan2_5.5.0-12ubuntu1_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/libmpx0_5.5.0-12ubuntu1_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/libgcc-5-dev_5.5.0-12ubuntu1_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/gcc-5_5.5.0-12ubuntu1_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/libstdc++-5-dev_5.5.0-12ubuntu1_amd64.deb
+            wget -c http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-5/g++-5_5.5.0-12ubuntu1_amd64.deb
+            sudo apt install ./g++-5_5.5.0-12ubuntu1_amd64.deb ./gcc-5_5.5.0-12ubuntu1_amd64.deb ./gcc-5-base_5.5.0-12ubuntu1_amd64.deb ./cpp-5_5.5.0-12ubuntu1_amd64.deb ./libisl15_0.18-4_amd64.deb ./libgcc-5-dev_5.5.0-12ubuntu1_amd64.deb ./libasan2_5.5.0-12ubuntu1_amd64.deb ./libmpx0_5.5.0-12ubuntu1_amd64.deb ./libstdc++-5-dev_5.5.0-12ubuntu1_amd64.deb
+            sudo apt install g++-5
+            sudo apt install gcc-5
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20
+            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10
+            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20
+            sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
+            sudo update-alternatives --set cc /usr/bin/gcc
+            sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
+            sudo update-alternatives --set c++ /usr/bin/g++
         - name: Cache conan
           if: ${{ matrix.os != 'windows-latest' }}
           id: cache-conan

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,10 +14,10 @@ jobs:
             - os : "macos-latest"
               compiler : "clang"
               compilerpp : "clang++"
-            - os : "ubuntu-18.04"
+            - os : "ubuntu-20.04"
               compiler : "gcc-7"
               compilerpp : "g++-7"
-            - os : "ubuntu-18.04"
+            - os : "ubuntu-20.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
             - os : "windows-latest"
@@ -61,7 +61,7 @@ jobs:
           if : steps.cache-conan.outputs.cache-hit != 'true'
           run: conan profile new default --detect
         - name: Update conan profile
-          if : ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-latest' }}
+          if : ${{ matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-latest' }}
           run: conan profile update settings.compiler.libcxx=libstdc++11 default
         - name: Update conan profile
           run: conan profile update settings.compiler.cppstd=14 default
@@ -91,10 +91,10 @@ jobs:
             - os : "macos-latest"
               compiler : "clang"
               compilerpp : "clang++"
-            - os : "ubuntu-18.04"
+            - os : "ubuntu-20.04"
               compiler : "gcc-7"
               compilerpp : "g++-7"
-            - os : "ubuntu-18.04"
+            - os : "ubuntu-20.04"
               compiler : "gcc-5"
               compilerpp : "g++-5"
             - os : "windows-latest"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -31,6 +31,11 @@ jobs:
           uses: myci-actions/add-deb-repo@10
           with:
             repo: deb http://dk.archive.ubuntu.com/ubuntu/ xenial main
+        - name: add custom deb repository
+          if: ${{ matrix.compiler == 'gcc-5' }}
+          uses: myci-actions/add-deb-repo@10
+          with:
+            repo: deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -34,8 +34,6 @@ jobs:
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |
-            sudo echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
-            sudo echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
             sudo apt update
             sudo apt install g++-5
             sudo apt install gcc-5

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -51,6 +51,12 @@ jobs:
             sudo update-alternatives --set cc /usr/bin/gcc
             sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
             sudo update-alternatives --set c++ /usr/bin/g++
+        - name: Set up gcc7
+          if : ${{ matrix.compiler == 'gcc-7' }}
+          uses: egor-tensin/setup-gcc@v1
+          with:
+            version: 7
+            platform: x64
         - name: Cache conan
           if: ${{ matrix.os != 'windows-latest' }}
           id: cache-conan

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -26,31 +26,11 @@ jobs:
         CXX: ${{ matrix.compilerpp }}
       steps:
         - uses: actions/checkout@v2
-        - name: add custom deb repository
+        - name: Set up GCC
           if: ${{ matrix.compiler == 'gcc-5' }}
-          uses: myci-actions/add-deb-repo@10
+          uses: egor-tensin/setup-gcc@v1
           with:
-            repo: deb http://dk.archive.ubuntu.com/ubuntu/ xenial main
-        - name: add custom deb repository
-          if: ${{ matrix.compiler == 'gcc-5' }}
-          uses: myci-actions/add-deb-repo@10
-          with:
-            repo: deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe
-            install: g++-5, gcc-5
-        - name: Install gcc-5
-          if : ${{ matrix.compiler == 'gcc-5' }}
-          run: |
-            sudo apt update
-            sudo apt install g++-5
-            sudo apt install gcc-5
-            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10
-            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20
-            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10
-            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20
-            sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
-            sudo update-alternatives --set cc /usr/bin/gcc
-            sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
-            sudo update-alternatives --set c++ /usr/bin/g++
+            version: 5
         - name: Cache conan
           if: ${{ matrix.os != 'windows-latest' }}
           id: cache-conan

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -29,6 +29,9 @@ jobs:
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |
+            sudo echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main" >> /etc/apt/sources.list
+            sudo echo "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe" >> /etc/apt/sources.list
+            sudo apt update
             sudo apt install g++-5
             sudo apt install gcc-5
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -70,7 +70,7 @@ jobs:
             key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}-${{ github.sha }}-key
         - uses: actions/setup-python@v2
           with:
-            python-version: '3.7'
+            python-version: '3.8'
         - name: Install python dependencies
           run: python -m pip install conan
         - name: Initialize conan

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -36,6 +36,7 @@ jobs:
           uses: myci-actions/add-deb-repo@10
           with:
             repo: deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe
+            install: [g++-5, gcc-5]
         - name: Install gcc-5
           if : ${{ matrix.compiler == 'gcc-5' }}
           run: |

--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -13,10 +13,10 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install build
         run: python -m pip install build
       - name: Build source tarball


### PR DESCRIPTION
The ubuntu-18.04 runner of GitHub actions starts deprecation in a few days (which will include temporary brownouts), with complete deprecation at the end of this year (see [this issue](https://github.com/actions/runner-images/issues/6002)).
Therefore, we should update our runners.

Since gcc5 is not trivially available on 20.04 anymore, it is now downloaded and installed manually. We should still test gcc5 because this is the oldest gcc version that is still tested by conan.

For gcc7, we can use a simpler tool that installs and initializes gcc7.