### PR TITLE
Fix and issue warning if mean free path becomes negative

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/InteractionBuilder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/InteractionBuilder.cxx
@@ -82,8 +82,11 @@ double InteractionBuilder::MeanFreePath(double energy) {
         if (energy < rate_lower_energy_lim)
             return INF;
         auto rate = rate_interpolant_->evaluate(energy);
-        if (rate < 0)
-            throw std::logic_error("Negative MeanFreePath detected!");
+        if (rate < 0) {
+            Logging::Get("proposal.interaction")->warn(
+                    "Negative MeanFreePath detected at energy {} MeV. Returning INF instead.", energy);
+            return INF;
+        }
         return 1. / rate;
     }
     return 1. / calculate_total_rate(energy);

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/InteractionBuilder.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/InteractionBuilder.cxx
@@ -81,7 +81,10 @@ double InteractionBuilder::MeanFreePath(double energy) {
     if (rate_interpolant_) {
         if (energy < rate_lower_energy_lim)
             return INF;
-        return 1. / rate_interpolant_->evaluate(energy);
+        auto rate = rate_interpolant_->evaluate(energy);
+        if (rate < 0)
+            throw std::logic_error("Negative MeanFreePath detected!");
+        return 1. / rate;
     }
     return 1. / calculate_total_rate(energy);
 }


### PR DESCRIPTION
We have implemented a check for negative dNdx values in PR #277, which sets dNdx to zero and issues a warning if an interpolant returns a negative value (for example due to oscillations in the interpolant).

However, there is no such check for the MeanFreePath (which is a separate interpolant). This has already caused problems in CORSIKA 8, which lead to the discovery of the issue described in PR #317. However, it would have been much easier to catch this with a correct error message.

While it is straightforward to just set dNdx to zero if it becomes negative, I am not sure whether there is a consistent solution for the mean free path if it becomes negative. Using either INF or 0 as an alternative return value seems like is could cause unwanted behavior. Therefore, I implemented an exception. This avoids any unwanted behavior, but will also interrupt the execution and is therefore very "intrusive".

I am open for discussion or better solutions for how to handle this situation.