### PR TITLE
Check if dE2dx tables have been built when creating ContRand builder

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/CrossSection.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/CrossSection.h
@@ -60,6 +60,7 @@ struct CrossSectionBase {
     virtual size_t GetHash() const noexcept = 0;
     virtual InteractionType GetInteractionType() const noexcept = 0;
     virtual std::string GetParametrizationName() const noexcept = 0;
+    virtual std::shared_ptr<const EnergyCutSettings> GetEnergyCutSettings() const noexcept = 0;
 };
 
 namespace detail {
@@ -230,6 +231,7 @@ protected:
     double lower_energy_lim;
     InteractionType interaction_type;
     std::string param_name;
+    std::shared_ptr<const EnergyCutSettings> cut;
 
 public:
     template <typename Param,
@@ -250,6 +252,7 @@ public:
         , lower_energy_lim(param.GetLowerEnergyLim(p))
         , interaction_type(static_cast<InteractionType>(_id::value))
         , param_name(_name::value)
+        , cut(cut)
     {
         // initialize hash
         hash = 0;
@@ -375,6 +378,11 @@ public:
     inline std::string GetParametrizationName() const noexcept override
     {
         return param_name;
+    }
+
+    std::shared_ptr<const EnergyCutSettings> GetEnergyCutSettings() const noexcept override
+    {
+        return cut;
     }
 };
 

--- a/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDirect.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDirect.h
@@ -49,6 +49,10 @@ namespace PROPOSAL {
             return param_name;
         };
 
+        std::shared_ptr<const EnergyCutSettings> GetEnergyCutSettings() const noexcept override {
+            return cut;
+        }
+
     private:
         std::unique_ptr<crosssection::ParametrizationDirect> param;
         ParticleDef p;

--- a/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionMultiplier.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionMultiplier.h
@@ -53,6 +53,10 @@ namespace PROPOSAL {
             return cross_->GetParametrizationName();
         }
 
+        std::shared_ptr<const EnergyCutSettings> GetEnergyCutSettings() const noexcept override {
+            return cross_->GetEnergyCutSettings();
+        }
+
     private:
         std::shared_ptr<CrossSectionBase> cross_;
         double multiplier_;

--- a/src/PROPOSAL/PROPOSAL/propagation_utility/ContRand.h
+++ b/src/PROPOSAL/PROPOSAL/propagation_utility/ContRand.h
@@ -18,14 +18,7 @@ struct ContRand {
 
     crossbase_list_t cross_list;
 
-    ContRand(std::shared_ptr<Displacement> _disp,
-        std::vector<std::shared_ptr<CrossSectionBase>> const& cross)
-        : disp(_disp)
-        , hash(0)
-        , cross_list(cross)
-    {
-        CalculateHash();
-    }
+    ContRand(std::shared_ptr<Displacement> _disp, std::vector<std::shared_ptr<CrossSectionBase>> const& cross);
 
     virtual ~ContRand() = default;
 

--- a/src/PROPOSAL/detail/PROPOSAL/propagation_utility/ContRand.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/propagation_utility/ContRand.cxx
@@ -6,6 +6,25 @@ using namespace PROPOSAL;
 
 Interpolant1DBuilder::Definition ContRand::interpol_def = { 200 };
 
+ContRand::ContRand(std::shared_ptr<Displacement> _disp, std::vector<std::shared_ptr<CrossSectionBase>> const& cross)
+    : disp(_disp)
+    , hash(0)
+    , cross_list(cross)
+{
+    // Check if there is at least one crosssection where dE2dx tables have been built.
+    // Otherwise, it doesn't make sense to build a dE2dx object, so we throw an exception.
+    bool has_dE2dx = false; // is there at least one crosssection with cont_rand enabled?
+    for (auto& c : cross) {
+        if (c->GetEnergyCutSettings()) // avoid accessing nullptr
+            has_dE2dx = has_dE2dx || c->GetEnergyCutSettings()->GetContRand();
+    }
+    if (has_dE2dx == false)
+        throw std::invalid_argument("Can not build ContRand because no dE2dx tables have been built. You need to use "
+                                    "continuous_randomization=True when creating the EnergyCutSettings object to be "
+                                    "able to use continuous randomization.");
+    CalculateHash();
+}
+
 double ContRand::FunctionToIntegral(double energy)
 {
     assert(energy >= 0);

--- a/src/pyPROPOSAL/detail/crosssection.cxx
+++ b/src/pyPROPOSAL/detail/crosssection.cxx
@@ -73,6 +73,7 @@ void init_crosssection(py::module& m)
             "lower_energy_limit", &CrossSectionBase::GetLowerEnergyLim)
         .def_property_readonly("type", &CrossSectionBase::GetInteractionType)
         .def_property_readonly("param_name", &CrossSectionBase::GetParametrizationName)
+        .def_property_readonly("cuts", &CrossSectionBase::GetEnergyCutSettings)
         .def_property_readonly("hash", &CrossSectionBase::GetHash)
         .def("calculate_dEdx",
             py::vectorize(&CrossSectionBase::CalculatedEdx),

--- a/tests/ContinuousRandomization_TEST.cxx
+++ b/tests/ContinuousRandomization_TEST.cxx
@@ -27,11 +27,22 @@ ParticleDef getParticleDef(const std::string& name)
 
 TEST(ContinuousRandomization, Constructor)
 {
-    auto p_def = MuMinusDef();
+    auto p_def = EPlusDef();
     auto medium = Ice();
     auto cuts = std::make_shared<EnergyCutSettings>(INF, 1, true);
     auto cross = GetStdCrossSections(p_def, medium, cuts, false);
     auto cont_rand = make_contrand(cross, false);
+}
+
+TEST(ContinuousRandomization, ConstructorNoTables)
+{
+    // when continuous_randomization is set to false in the EnergyCutSettings
+    // creating a ContRand object should throw an exception
+    auto p_def = EPlusDef();
+    auto medium = Ice();
+    auto cuts = std::make_shared<EnergyCutSettings>(INF, 1, false);
+    auto cross = GetStdCrossSections(p_def, medium, cuts, false);
+    EXPECT_THROW(make_contrand(cross, false), std::logic_error);
 }
 
 TEST(ContinuousRandomization, FirstMomentum)


### PR DESCRIPTION
When creating a EnergyCutSettings object, a boolean `continuous_randomization` indicated whether dE2dx tables should be built.
However, one can still initialize a ContRand object if this option has been set to false. In this case, the object will exist, but actually make no continuous randomization. 
This is not useful, and is probably not wanted by the user. Therfore, this PR adds a check whether at least one dE2dx table has been built, and if this is not the case, an exception is thrown:

```
Can not build ContRand because no dE2dx tables have been built. You need to use continuous_randomization=True when creating the EnergyCutSettings object to be able to use continuous randomization.
```

This also means that the ContRand object needs to know about the EnergyCutSettings that are being used by the CrossSection objects. Therefore, a `GetEnergyCutSettings` method has been added to the CrossSection classes.