### PR TITLE
Add LPM effect for photopair, fixes for BremsLPM

### DIFF
--- a/docs/config_docu.md
+++ b/docs/config_docu.md
@@ -446,6 +446,7 @@ For there parametrizations, the parametrization of the shadowing effect can be c
 | ----------------- | ------- | ------- | -------------------------- |
 | `parametrization` | String  | `-`     | Parametrization to be used |
 | `multiplier`      | Number  | `1.0`   | Multiplier to scale the cross section with a coefficient |
+| `lpm`             | Boolean | `true`  | Enabling or disabling the reduction of the cross section at high energies by the Landau-Pomeranchuk-Migdal effect.  |
 
 Creation of an electron-positron pair by an ingoing photon. Available `photopair` parametrizations are:
 

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.h
@@ -12,5 +12,6 @@ namespace PROPOSAL {
 
 namespace PROPOSAL {
     cross_ptr make_photopairproduction(const ParticleDef&, const Medium&, bool,
-                                       const nlohmann::json&);
+                                       const nlohmann::json&,
+                                       double density_correction = 1.0);
 }

--- a/src/PROPOSAL/PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h
@@ -97,7 +97,7 @@ template<>
 template <typename CrossVec, typename P, typename M>
 void DefaultCrossSections<GammaDef>::Append(CrossVec& cross_vec, P p, M m,std::shared_ptr<const EnergyCutSettings> cut, bool interpolate)
 {
-    auto photopair = std::make_tuple(crosssection::PhotoPairKochMotz{}, p, m, nullptr, interpolate);
+    auto photopair = std::make_tuple(crosssection::PhotoPairKochMotz{false}, p, m, nullptr, interpolate);
     auto compton = std::make_tuple(crosssection::ComptonKleinNishina{}, p, m, cut, interpolate);
     auto photoproduction = std::make_tuple(crosssection::PhotoproductionRhode{}, p, m, nullptr, interpolate);
     auto photoeffect = std::make_tuple(crosssection::PhotoeffectSauter{}, p, m, nullptr, interpolate);

--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
@@ -34,9 +34,14 @@
 
 namespace PROPOSAL {
 namespace crosssection {
+    class PhotoPairLPM;
+
     class PhotoPairProduction : public Parametrization<Component> {
+    protected:
+        std::shared_ptr<PhotoPairLPM> lpm_;
+        double density_correction_; // correction to standard medium density for LPM
     public:
-        PhotoPairProduction() = default;
+        PhotoPairProduction();
         virtual ~PhotoPairProduction() = default;
 
         double GetLowerEnergyLim(const ParticleDef&) const noexcept final;
@@ -49,7 +54,9 @@ namespace crosssection {
     };
 
     struct PhotoPairTsai : public PhotoPairProduction {
-        PhotoPairTsai() { hash_combine(hash, std::string("tsai")); }
+        PhotoPairTsai(bool lpm = false);
+        PhotoPairTsai(bool lpm, const ParticleDef&, const Medium&,
+                          double density_correction = 1.0);
         using base_param_t = PhotoPairProduction;
         std::unique_ptr<Parametrization<Component>> clone() const final;
 
@@ -58,7 +65,9 @@ namespace crosssection {
     };
 
     struct PhotoPairKochMotz : public PhotoPairProduction {
-        PhotoPairKochMotz();
+        PhotoPairKochMotz(bool lpm = false);
+        PhotoPairKochMotz(bool lpm, const ParticleDef&, const Medium&,
+                          double density_correction = 1.0);
         using base_param_t = PhotoPairProduction;
         std::unique_ptr<Parametrization<Component>> clone() const final;
 
@@ -86,5 +95,21 @@ namespace crosssection {
     template <> struct ParametrizationId<PhotoPairKochMotz> {
         static constexpr size_t value = 1000000013;
     };
+
+    // LPM effect object
+    class PhotoPairLPM {
+        size_t hash;
+        double mol_density_;
+        double mass_density_;
+        double sum_charge_;
+        double eLpm_;
+
+    public:
+        PhotoPairLPM(const ParticleDef&, const Medium&, const PhotoPairProduction&);
+        double suppression_factor(double energy, double x, const Component&,
+                                  double density_correction = 1.0) const;
+        size_t GetHash() const noexcept { return hash; }
+    };
+
 } // namespace crosssection
 } // namespace PROPOSAL

--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -485,7 +485,8 @@ Propagator::CreateCrossSectionList(const ParticleDef& p_def,
             p_def, medium, config["photoproduction"]));
     if (config.contains("photopair"))
         cross.emplace_back(make_photopairproduction(
-            p_def, medium, interpolate, config["photopair"]));
+                p_def, medium, interpolate, config["photopair"],
+                density_correction));
     if (config.contains("weak"))
         cross.emplace_back(
             make_weakinteraction(p_def, medium, interpolate, config["weak"]));

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
@@ -595,7 +595,7 @@ crosssection::BremsLPM::BremsLPM(const ParticleDef& p_def, const Medium& medium,
     }
     sum = sum * mass_density_;
     eLpm_ = ALPHA * mass_;
-    eLpm_ *= eLpm_ / (4. * PI * ME * RE * sum);
+    eLpm_ *= 2* eLpm_ / (PI * ME * RE * sum);
 }
 
 double crosssection::BremsLPM::suppression_factor(
@@ -610,8 +610,10 @@ double crosssection::BremsLPM::suppression_factor(
     double Z3 = std::pow(comp.GetNucCharge(), -1. / 3);
 
     double Dn = 1.54 * std::pow(comp.GetAtomicNum(), 0.27);
-    s1 = ME * Dn / (mass_ * Z3 * comp.GetLogConstant());
-    s1 = s1 * s1 * SQRT2; // TODO: is SQRT2 correct here, this factor is not in the paper?
+    double aux_nuc = mass_ / MMU * Dn;
+    s1 = ME  / (mass_ * Z3 * comp.GetLogConstant());
+    s1 = s1 * s1 * (1 + aux_nuc * aux_nuc) * SQRT2;
+    // SQRT2 appears together with s1 everywhere in Stanev et al.
 
     // Calc xi(s') from Stanev, Vankow, Streitmatter, Ellsworth, Bowen
     // Phys. Rev. D 25 (1982), 1291

--- a/src/pyPROPOSAL/detail/parametrization.cxx
+++ b/src/pyPROPOSAL/detail/parametrization.cxx
@@ -861,12 +861,18 @@ void init_parametrization(py::module& m)
     py::class_<crosssection::PhotoPairTsai,
         std::shared_ptr<crosssection::PhotoPairTsai>,
         crosssection::PhotoPairProduction>(m_sub_photopair, "Tsai")
-        .def(py::init<>());
+        .def(py::init<bool>(), py::arg("lpm") = false)
+        .def(py::init<bool, const ParticleDef&, const Medium&, double>(),
+            py::arg("lpm"), py::arg("particle_def"), py::arg("medium"),
+            py::arg("density_correction") = 1.0);
 
     py::class_<crosssection::PhotoPairKochMotz,
         std::shared_ptr<crosssection::PhotoPairKochMotz>,
         crosssection::PhotoPairProduction>(m_sub_photopair, "KochMotz")
-        .def(py::init<>());
+        .def(py::init<bool>(), py::arg("lpm") = false)
+        .def(py::init<bool, const ParticleDef&, const Medium&, double>(),
+             py::arg("lpm"), py::arg("particle_def"), py::arg("medium"),
+             py::arg("density_correction") = 1.0);
 
     py::class_<crosssection::KinematicLimits,
         std::shared_ptr<crosssection::KinematicLimits>>(
@@ -878,6 +884,16 @@ void init_parametrization(py::module& m)
             return "(v_min: " + std::to_string(lim.v_min)
                 + ", v_max: " + std::to_string(lim.v_max) + ")";
         });
+
+    py::class_<crosssection::PhotoPairLPM, std::shared_ptr<crosssection::PhotoPairLPM>>(
+        m_sub_brems, "photopair_lpm")
+        .def(py::init<const ParticleDef&, const Medium&,
+                 const crosssection::PhotoPairProduction&>(),
+            py::arg("particle_def"), py::arg("medium"),
+            py::arg("photopair"))
+        .def("supression_factor", &crosssection::PhotoPairLPM::suppression_factor,
+            py::arg("energy"), py::arg("x"), py::arg("component"),
+            py::arg("density_correction") = 1.0);
 
     // --------------------------------------------------------------------- //
     // PhotoMuPairProduction


### PR DESCRIPTION
This PR adds the LPM effect for pair production of electron-positron pairs by photons.

Furthermore, this PR fixes the following issues in the implementation of the LPM effect in Bremsstrahlung:

1. An inconsistent definition of eLPM has been fixed
2. A more general definition of s1 is now used, to that the BremsLPM parametrization is not only valid for muons, but also for other particles (electrons/positrons/taus)