### PR TITLE
Fix ifstream in UnitTests to correctly read in `ecut==INF`

### DIFF
--- a/tests/Bremsstrahlung_TEST.cxx
+++ b/tests/Bremsstrahlung_TEST.cxx
@@ -35,7 +35,7 @@ TEST(Bremsstrahlung, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -52,7 +52,7 @@ TEST(Bremsstrahlung, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -74,7 +74,7 @@ TEST(Bremsstrahlung, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -91,7 +91,7 @@ TEST(Bremsstrahlung, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -113,7 +113,7 @@ TEST(Bremsstrahlung, Test_of_e)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -133,7 +133,7 @@ TEST(Bremsstrahlung, Test_of_e)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -147,7 +147,7 @@ TEST(Bremsstrahlung, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -176,7 +176,7 @@ TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -193,7 +193,7 @@ TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -210,7 +210,7 @@ TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
             // the function that we need to integrate. However, bremsstrahlung
             // effects for taus are negligible for these energies (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e0 * dEdx_stored);
-        } else if (vcut * energy == ecut) {
+        } else if (vcut * energy == std::stod(ecut)) {
             // expecting a kink here (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
         } else if (particleName == "EMinus" && mediumName == "uranium" && energy == 1e10 && lpm == true) {
@@ -230,7 +230,7 @@ TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -247,7 +247,7 @@ TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -258,7 +258,7 @@ TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 
         dNdx_new = cross->CalculatedNdx(energy);
 
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // expecting a kink here (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else if (particleName == "TauMinus" && energy < 1e5) {
@@ -279,7 +279,7 @@ TEST(Bremsstrahlung, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -299,7 +299,7 @@ TEST(Bremsstrahlung, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -315,11 +315,11 @@ TEST(Bremsstrahlung, Test_of_e_Interpolant)
         if (particleName == "TauMinus" && mediumName == "uranium" && energy == 1e4)
             continue; // dNdx is non-zero for the integral, but zero for the interpolant here
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto v = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // expecting a kink here (issue #250)
                 EXPECT_NEAR(v, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
             } else if (particleName == "TauMinus" && energy < 1e5) {

--- a/tests/Compton_TEST.cxx
+++ b/tests/Compton_TEST.cxx
@@ -20,7 +20,7 @@ TEST(Compton, Test_of_dEdx)
     std::ifstream in;
     getTestFile("Compton_dEdx.txt", in);
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -36,7 +36,7 @@ TEST(Compton, Test_of_dEdx)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -55,7 +55,7 @@ TEST(Compton, Test_of_dNdx)
     getTestFile("Compton_dNdx.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -71,7 +71,7 @@ TEST(Compton, Test_of_dNdx)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -90,7 +90,7 @@ TEST(Compton, Test_of_e)
     getTestFile("Compton_e.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -109,7 +109,7 @@ TEST(Compton, Test_of_e)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -121,7 +121,7 @@ TEST(Compton, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -141,7 +141,7 @@ TEST(Compton, Test_of_dEdx_Interpolant)
     getTestFile("Compton_dEdx.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -157,7 +157,7 @@ TEST(Compton, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -166,7 +166,7 @@ TEST(Compton, Test_of_dEdx_Interpolant)
 
         dEdx_new = cross->CalculatedEdx(energy);
 
-        if (vcut * energy == ecut)
+        if (vcut * energy == std::stod(ecut))
             // expecting a kink here (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 5e-2 * dEdx_stored);
         else
@@ -180,7 +180,7 @@ TEST(Compton, Test_of_dNdx_Interpolant)
     getTestFile("Compton_dNdx.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -196,7 +196,7 @@ TEST(Compton, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -215,7 +215,7 @@ TEST(Compton, Test_of_e_Interpolant)
     getTestFile("Compton_e.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -234,7 +234,7 @@ TEST(Compton, Test_of_e_Interpolant)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -246,11 +246,11 @@ TEST(Compton, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
-            if (vcut * energy == ecut || rnd1 < 0.05)
+            if (vcut * energy == std::stod(ecut) || rnd1 < 0.05)
                 // expecting a kink here (issue #250)
                 // The lower edge of the kinematic range is poorly interpolated
                 // due to a discontinuity (issue #250)

--- a/tests/Epairproduction_TEST.cxx
+++ b/tests/Epairproduction_TEST.cxx
@@ -34,7 +34,7 @@ TEST(Epairproduction, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -49,7 +49,7 @@ TEST(Epairproduction, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -70,7 +70,7 @@ TEST(Epairproduction, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -85,7 +85,7 @@ TEST(Epairproduction, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -107,7 +107,7 @@ TEST(Epairproduction, Test_Stochastic_Loss)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -126,7 +126,7 @@ TEST(Epairproduction, Test_Stochastic_Loss)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -140,7 +140,7 @@ TEST(Epairproduction, Test_Stochastic_Loss)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -162,7 +162,7 @@ TEST(Epairproduction, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -177,7 +177,7 @@ TEST(Epairproduction, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -192,7 +192,7 @@ TEST(Epairproduction, Test_of_dEdx_Interpolant)
             // Transition from zero to non-zero values is not continuous, causing
             // interpolation problems in uranium around 1e4 MeV (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e0 * dEdx_stored);
-        } else if (vcut * energy == ecut) {
+        } else if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 5e-2 * dEdx_stored);
         } else {
@@ -208,7 +208,7 @@ TEST(Epairproduction, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -223,7 +223,7 @@ TEST(Epairproduction, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -233,7 +233,7 @@ TEST(Epairproduction, Test_of_dNdx_Interpolant)
                                           config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -249,7 +249,7 @@ TEST(Epairproduction, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -267,7 +267,7 @@ TEST(Epairproduction, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -281,12 +281,12 @@ TEST(Epairproduction, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 || dNdx_for_comp == 0 ) {
+        if ( ecut == "inf" && vcut == 1 || dNdx_for_comp == 0 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
 
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
             } else if (rnd1 < 0.1) {

--- a/tests/Ionization_TEST.cxx
+++ b/tests/Ionization_TEST.cxx
@@ -34,7 +34,7 @@ TEST(Ionization, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -47,7 +47,7 @@ TEST(Ionization, Test_of_dEdx)
     {
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -67,7 +67,7 @@ TEST(Ionization, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -81,7 +81,7 @@ TEST(Ionization, Test_of_dNdx)
         ParticleDef particle_def = getParticleDef(particleName);
 
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -101,7 +101,7 @@ TEST(Ionization, Test_Stochastic_Loss)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -118,7 +118,7 @@ TEST(Ionization, Test_Stochastic_Loss)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -128,7 +128,7 @@ TEST(Ionization, Test_Stochastic_Loss)
 
         auto dNdx = cross->CalculatedNdx(energy);
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx);
@@ -150,7 +150,7 @@ TEST(Ionization, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -164,7 +164,7 @@ TEST(Ionization, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -173,7 +173,7 @@ TEST(Ionization, Test_of_dEdx_Interpolant)
                                      config);
 
         dEdx_new = cross->CalculatedEdx(energy);
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-2 * dEdx_stored);
         } else {
@@ -190,7 +190,7 @@ TEST(Ionization, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -205,7 +205,7 @@ TEST(Ionization, Test_of_dNdx_Interpolant)
         ParticleDef particle_def = getParticleDef(particleName);
 
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -214,7 +214,7 @@ TEST(Ionization, Test_of_dNdx_Interpolant)
                                      config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -230,7 +230,7 @@ TEST(Ionization, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -247,7 +247,7 @@ TEST(Ionization, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -257,11 +257,11 @@ TEST(Ionization, Test_of_e_Interpolant)
 
         auto dNdx = cross->CalculatedNdx(energy);
 
-        if ( ecut == INF && vcut == 1 || dNdx == 0) {
+        if ( ecut == "inf" && vcut == 1 || dNdx == 0) {
             EXPECT_THROW(cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx);
-            if (vcut * energy == ecut) {
+            if (vcut * energy == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
             } else if (rnd1 > 0.99) {

--- a/tests/Mupairproduction_TEST.cxx
+++ b/tests/Mupairproduction_TEST.cxx
@@ -34,7 +34,7 @@ TEST(Mupairproduction, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -48,7 +48,7 @@ TEST(Mupairproduction, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -68,7 +68,7 @@ TEST(Mupairproduction, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -82,7 +82,7 @@ TEST(Mupairproduction, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -102,7 +102,7 @@ TEST(Mupairproduction, Test_Stochastic_Loss)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -120,7 +120,7 @@ TEST(Mupairproduction, Test_Stochastic_Loss)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -133,7 +133,7 @@ TEST(Mupairproduction, Test_Stochastic_Loss)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -192,7 +192,7 @@ TEST(Mupairproduction, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -206,7 +206,7 @@ TEST(Mupairproduction, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -216,7 +216,7 @@ TEST(Mupairproduction, Test_of_dEdx_Interpolant)
 
         dEdx_new = cross->CalculatedEdx(energy);
 
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 2e-1 * dEdx_stored);
         } else {
@@ -232,7 +232,7 @@ TEST(Mupairproduction, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -246,7 +246,7 @@ TEST(Mupairproduction, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -255,7 +255,7 @@ TEST(Mupairproduction, Test_of_dNdx_Interpolant)
                                            config);
         dNdx_new = cross->CalculatedNdx(energy);
 
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -271,7 +271,7 @@ TEST(Mupairproduction, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -288,7 +288,7 @@ TEST(Mupairproduction, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -301,11 +301,11 @@ TEST(Mupairproduction, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-2 * stochastic_loss_stored);
             } else if (rnd1 > 0.95) {

--- a/tests/Photonuclear_TEST.cxx
+++ b/tests/Photonuclear_TEST.cxx
@@ -31,7 +31,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -48,7 +48,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -70,7 +70,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -87,7 +87,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -109,7 +109,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -128,7 +128,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -143,7 +143,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -171,7 +171,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -188,7 +188,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -202,7 +202,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
         if (hard_component == 1 && energy == 1e5) {
             // kink in differential cross section (see issue #124)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
-        } else if (vcut * energy == ecut) {
+        } else if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
         } else {
@@ -218,7 +218,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -235,7 +235,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -245,7 +245,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
             = make_photonuclearreal(particle_def, *medium, ecuts, true, config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else if (hard_component == 1 && energy >= 1e10) {
@@ -274,7 +274,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -293,7 +293,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -310,12 +310,12 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
 
-            if ( rnd1 < 0.05 && ecut == 500) {
+            if ( rnd1 < 0.05 && std::stod(ecut) == 500) {
                 // Not enough nodes at very small losses!
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
             } else if (rnd1 < 0.02) {
@@ -327,12 +327,12 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
                 // to a hard cutoff for v=1e-7 in the differential crosssection
                 // (issue #124)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
-            } else if (energy >= 1e10 && ecut == 500) {
+            } else if (energy >= 1e10 && std::stod(ecut) == 500) {
                 // for high E, there are integration problems also without the
                 // hard component, causing problems in the dNdx interpolation
                 // (issue #124)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
-            } else if (particleName == "TauMinus" && energy >= 1e8 && ecut == 500) {
+            } else if (particleName == "TauMinus" && energy >= 1e8 && std::stod(ecut) == 500) {
                 // same issue as above, but it starts earlier when taus are involved
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-2 * stochastic_loss_stored);
             } else if (hard_component == 1 && energy == 1e5) {
@@ -343,13 +343,13 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
                 // Rhode parametrization hard to interpolate for this energy range
                 // due to its complicated structure
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
-            } else if (vcut * energy == ecut) {
+            } else if (vcut * energy == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-2 * stochastic_loss_stored);
             } else if (rnd1 > 0.98) {
                 // inaccurate dNdx interpolant for v->1
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
-            } else if (particleName == "EMinus" && ecut == 500) {
+            } else if (particleName == "EMinus" && std::stod(ecut) == 500) {
                 // Jump in integrated functions are seen almost everywhere for
                 // electrons (issue #124)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-3 * stochastic_loss_stored);
@@ -375,7 +375,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -392,7 +392,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -414,7 +414,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -431,7 +431,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -453,7 +453,7 @@ TEST(PhotoQ2Integration, Test_of_e)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -472,7 +472,7 @@ TEST(PhotoQ2Integration, Test_of_e)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -487,7 +487,7 @@ TEST(PhotoQ2Integration, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -509,7 +509,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -526,7 +526,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -536,7 +536,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
             = make_photonuclearQ2(particle_def, *medium, ecuts, true, config);
 
         dEdx_new = cross->CalculatedEdx(energy);
-        if (ecut == vcut * energy) {
+        if (std::stod(ecut) == vcut * energy) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
         } else {
@@ -552,7 +552,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -569,7 +569,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -579,7 +579,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
             = make_photonuclearQ2(particle_def, *medium, ecuts, true, config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -595,7 +595,7 @@ TEST(PhotoQ2Integration, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -614,7 +614,7 @@ TEST(PhotoQ2Integration, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -629,12 +629,12 @@ TEST(PhotoQ2Integration, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
 
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
             } else if (rnd1 < 0.07 || rnd1 > 0.995) {


### PR DESCRIPTION
In PROPOSAL 6 and before, an "infinite ecut" has been represented by `ecut = -1`. With PROPOSAL 7, we changed this to `ecut = INF`, with `INF = PROPOSAL::INF = std::numeric_limits<double>::infinity()`.

At first, in the TestFiles, an infinite `ecut` was still stored as `-1` and manually converted to `INF` within the UnitTests. This has been changed with PR #242, where it has been changed to store `inf` to the TestFiles as well. 

However, while writing `INF` to a file is not a problem in C++, parsing `inf` from a file directly to a double using ifstream is not possible. This means that the UnitTests stopped as soon as they encountered `ecut == INF`. 

The easiest solution I've been able to find is to parse the value for `ecut` to a `std::string` first, and then convert it do a double using `std::stod`, which can correctly interpret `inf`.