### PR TITLE
Add LPM effect for photopair, fixes for BremsLPM 

### DIFF
--- a/docs/config_docu.md
+++ b/docs/config_docu.md
@@ -446,6 +446,7 @@ For there parametrizations, the parametrization of the shadowing effect can be c
 | ----------------- | ------- | ------- | -------------------------- |
 | `parametrization` | String  | `-`     | Parametrization to be used |
 | `multiplier`      | Number  | `1.0`   | Multiplier to scale the cross section with a coefficient |
+| `lpm`             | Boolean | `true`  | Enabling or disabling the reduction of the cross section at high energies by the Landau-Pomeranchuk-Migdal effect.  |
 
 Creation of an electron-positron pair by an ingoing photon. Available `photopair` parametrizations are:
 

--- a/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/Factories/PhotoPairProductionFactory.h
@@ -12,5 +12,6 @@ namespace PROPOSAL {
 
 namespace PROPOSAL {
     cross_ptr make_photopairproduction(const ParticleDef&, const Medium&, bool,
-                                       const nlohmann::json&);
+                                       const nlohmann::json&,
+                                       double density_correction = 1.0);
 }

--- a/src/PROPOSAL/PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h
@@ -97,7 +97,7 @@ template<>
 template <typename CrossVec, typename P, typename M>
 void DefaultCrossSections<GammaDef>::Append(CrossVec& cross_vec, P p, M m,std::shared_ptr<const EnergyCutSettings> cut, bool interpolate)
 {
-    auto photopair = std::make_tuple(crosssection::PhotoPairKochMotz{}, p, m, nullptr, interpolate);
+    auto photopair = std::make_tuple(crosssection::PhotoPairKochMotz{false}, p, m, nullptr, interpolate);
     auto compton = std::make_tuple(crosssection::ComptonKleinNishina{}, p, m, cut, interpolate);
     auto photoproduction = std::make_tuple(crosssection::PhotoproductionRhode{}, p, m, nullptr, interpolate);
     auto photoeffect = std::make_tuple(crosssection::PhotoeffectSauter{}, p, m, nullptr, interpolate);

--- a/src/PROPOSAL/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/parametrization/PhotoPairProduction.h
@@ -34,9 +34,14 @@
 
 namespace PROPOSAL {
 namespace crosssection {
+    class PhotoPairLPM;
+
     class PhotoPairProduction : public Parametrization<Component> {
+    protected:
+        std::shared_ptr<PhotoPairLPM> lpm_;
+        double density_correction_; // correction to standard medium density for LPM
     public:
-        PhotoPairProduction() = default;
+        PhotoPairProduction();
         virtual ~PhotoPairProduction() = default;
 
         double GetLowerEnergyLim(const ParticleDef&) const noexcept final;
@@ -49,7 +54,9 @@ namespace crosssection {
     };
 
     struct PhotoPairTsai : public PhotoPairProduction {
-        PhotoPairTsai() { hash_combine(hash, std::string("tsai")); }
+        PhotoPairTsai(bool lpm = false);
+        PhotoPairTsai(bool lpm, const ParticleDef&, const Medium&,
+                          double density_correction = 1.0);
         using base_param_t = PhotoPairProduction;
         std::unique_ptr<Parametrization<Component>> clone() const final;
 
@@ -58,7 +65,9 @@ namespace crosssection {
     };
 
     struct PhotoPairKochMotz : public PhotoPairProduction {
-        PhotoPairKochMotz();
+        PhotoPairKochMotz(bool lpm = false);
+        PhotoPairKochMotz(bool lpm, const ParticleDef&, const Medium&,
+                          double density_correction = 1.0);
         using base_param_t = PhotoPairProduction;
         std::unique_ptr<Parametrization<Component>> clone() const final;
 
@@ -86,5 +95,21 @@ namespace crosssection {
     template <> struct ParametrizationId<PhotoPairKochMotz> {
         static constexpr size_t value = 1000000013;
     };
+
+    // LPM effect object
+    class PhotoPairLPM {
+        size_t hash;
+        double mol_density_;
+        double mass_density_;
+        double sum_charge_;
+        double eLpm_;
+
+    public:
+        PhotoPairLPM(const ParticleDef&, const Medium&, const PhotoPairProduction&);
+        double suppression_factor(double energy, double x, const Component&,
+                                  double density_correction = 1.0) const;
+        size_t GetHash() const noexcept { return hash; }
+    };
+
 } // namespace crosssection
 } // namespace PROPOSAL

--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -485,7 +485,8 @@ Propagator::CreateCrossSectionList(const ParticleDef& p_def,
             p_def, medium, config["photoproduction"]));
     if (config.contains("photopair"))
         cross.emplace_back(make_photopairproduction(
-            p_def, medium, interpolate, config["photopair"]));
+                p_def, medium, interpolate, config["photopair"],
+                density_correction));
     if (config.contains("weak"))
         cross.emplace_back(
             make_weakinteraction(p_def, medium, interpolate, config["weak"]));

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/Bremsstrahlung.cxx
@@ -595,7 +595,7 @@ crosssection::BremsLPM::BremsLPM(const ParticleDef& p_def, const Medium& medium,
     }
     sum = sum * mass_density_;
     eLpm_ = ALPHA * mass_;
-    eLpm_ *= eLpm_ / (4. * PI * ME * RE * sum);
+    eLpm_ *= 2* eLpm_ / (PI * ME * RE * sum);
 }
 
 double crosssection::BremsLPM::suppression_factor(
@@ -610,8 +610,10 @@ double crosssection::BremsLPM::suppression_factor(
     double Z3 = std::pow(comp.GetNucCharge(), -1. / 3);
 
     double Dn = 1.54 * std::pow(comp.GetAtomicNum(), 0.27);
-    s1 = ME * Dn / (mass_ * Z3 * comp.GetLogConstant());
-    s1 = s1 * s1 * SQRT2; // TODO: is SQRT2 correct here, this factor is not in the paper?
+    double aux_nuc = mass_ / MMU * Dn;
+    s1 = ME  / (mass_ * Z3 * comp.GetLogConstant());
+    s1 = s1 * s1 * (1 + aux_nuc * aux_nuc) * SQRT2;
+    // SQRT2 appears together with s1 everywhere in Stanev et al.
 
     // Calc xi(s') from Stanev, Vankow, Streitmatter, Ellsworth, Bowen
     // Phys. Rev. D 25 (1982), 1291

--- a/src/pyPROPOSAL/detail/parametrization.cxx
+++ b/src/pyPROPOSAL/detail/parametrization.cxx
@@ -861,12 +861,18 @@ void init_parametrization(py::module& m)
     py::class_<crosssection::PhotoPairTsai,
         std::shared_ptr<crosssection::PhotoPairTsai>,
         crosssection::PhotoPairProduction>(m_sub_photopair, "Tsai")
-        .def(py::init<>());
+        .def(py::init<bool>(), py::arg("lpm") = false)
+        .def(py::init<bool, const ParticleDef&, const Medium&, double>(),
+            py::arg("lpm"), py::arg("particle_def"), py::arg("medium"),
+            py::arg("density_correction") = 1.0);
 
     py::class_<crosssection::PhotoPairKochMotz,
         std::shared_ptr<crosssection::PhotoPairKochMotz>,
         crosssection::PhotoPairProduction>(m_sub_photopair, "KochMotz")
-        .def(py::init<>());
+        .def(py::init<bool>(), py::arg("lpm") = false)
+        .def(py::init<bool, const ParticleDef&, const Medium&, double>(),
+             py::arg("lpm"), py::arg("particle_def"), py::arg("medium"),
+             py::arg("density_correction") = 1.0);
 
     py::class_<crosssection::KinematicLimits,
         std::shared_ptr<crosssection::KinematicLimits>>(
@@ -878,6 +884,16 @@ void init_parametrization(py::module& m)
             return "(v_min: " + std::to_string(lim.v_min)
                 + ", v_max: " + std::to_string(lim.v_max) + ")";
         });
+
+    py::class_<crosssection::PhotoPairLPM, std::shared_ptr<crosssection::PhotoPairLPM>>(
+        m_sub_brems, "photopair_lpm")
+        .def(py::init<const ParticleDef&, const Medium&,
+                 const crosssection::PhotoPairProduction&>(),
+            py::arg("particle_def"), py::arg("medium"),
+            py::arg("photopair"))
+        .def("supression_factor", &crosssection::PhotoPairLPM::suppression_factor,
+            py::arg("energy"), py::arg("x"), py::arg("component"),
+            py::arg("density_correction") = 1.0);
 
     // --------------------------------------------------------------------- //
     // PhotoMuPairProduction

--- a/tests/Bremsstrahlung_TEST.cxx
+++ b/tests/Bremsstrahlung_TEST.cxx
@@ -35,7 +35,7 @@ TEST(Bremsstrahlung, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -52,7 +52,7 @@ TEST(Bremsstrahlung, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -74,7 +74,7 @@ TEST(Bremsstrahlung, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -91,7 +91,7 @@ TEST(Bremsstrahlung, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -113,7 +113,7 @@ TEST(Bremsstrahlung, Test_of_e)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -133,7 +133,7 @@ TEST(Bremsstrahlung, Test_of_e)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -147,7 +147,7 @@ TEST(Bremsstrahlung, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -176,7 +176,7 @@ TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -193,7 +193,7 @@ TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -210,7 +210,7 @@ TEST(Bremsstrahlung, Test_of_dEdx_Interpolant)
             // the function that we need to integrate. However, bremsstrahlung
             // effects for taus are negligible for these energies (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e0 * dEdx_stored);
-        } else if (vcut * energy == ecut) {
+        } else if (vcut * energy == std::stod(ecut)) {
             // expecting a kink here (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
         } else if (particleName == "EMinus" && mediumName == "uranium" && energy == 1e10 && lpm == true) {
@@ -230,7 +230,7 @@ TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -247,7 +247,7 @@ TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -258,7 +258,7 @@ TEST(Bremsstrahlung, Test_of_dNdx_Interpolant)
 
         dNdx_new = cross->CalculatedNdx(energy);
 
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // expecting a kink here (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else if (particleName == "TauMinus" && energy < 1e5) {
@@ -279,7 +279,7 @@ TEST(Bremsstrahlung, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -299,7 +299,7 @@ TEST(Bremsstrahlung, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -315,11 +315,11 @@ TEST(Bremsstrahlung, Test_of_e_Interpolant)
         if (particleName == "TauMinus" && mediumName == "uranium" && energy == 1e4)
             continue; // dNdx is non-zero for the integral, but zero for the interpolant here
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto v = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // expecting a kink here (issue #250)
                 EXPECT_NEAR(v, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
             } else if (particleName == "TauMinus" && energy < 1e5) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(CMAKE_CXX_STANDARD 17)
 include(GoogleTest)
 
 SET(RESOURCE_URL https://proposal.app.tu-dortmund.de/resources)
-SET(TEST_FILES TestFiles-2022-03-11.tar.gz)
+SET(TEST_FILES TestFiles-2023-01-04.tar.gz)
 
 # download the test files
 add_custom_command(OUTPUT TestFiles

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(CMAKE_CXX_STANDARD 17)
 include(GoogleTest)
 
 SET(RESOURCE_URL https://proposal.app.tu-dortmund.de/resources)
-SET(TEST_FILES TestFiles-2023-01-04.tar.gz)
+SET(TEST_FILES TestFiles-2023-01-05.tar.gz)
 
 # download the test files
 add_custom_command(OUTPUT TestFiles

--- a/tests/Compton_TEST.cxx
+++ b/tests/Compton_TEST.cxx
@@ -20,7 +20,7 @@ TEST(Compton, Test_of_dEdx)
     std::ifstream in;
     getTestFile("Compton_dEdx.txt", in);
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -36,7 +36,7 @@ TEST(Compton, Test_of_dEdx)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -55,7 +55,7 @@ TEST(Compton, Test_of_dNdx)
     getTestFile("Compton_dNdx.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -71,7 +71,7 @@ TEST(Compton, Test_of_dNdx)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -90,7 +90,7 @@ TEST(Compton, Test_of_e)
     getTestFile("Compton_e.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -109,7 +109,7 @@ TEST(Compton, Test_of_e)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -121,7 +121,7 @@ TEST(Compton, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -141,7 +141,7 @@ TEST(Compton, Test_of_dEdx_Interpolant)
     getTestFile("Compton_dEdx.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -157,7 +157,7 @@ TEST(Compton, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -166,7 +166,7 @@ TEST(Compton, Test_of_dEdx_Interpolant)
 
         dEdx_new = cross->CalculatedEdx(energy);
 
-        if (vcut * energy == ecut)
+        if (vcut * energy == std::stod(ecut))
             // expecting a kink here (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 5e-2 * dEdx_stored);
         else
@@ -180,7 +180,7 @@ TEST(Compton, Test_of_dNdx_Interpolant)
     getTestFile("Compton_dNdx.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -196,7 +196,7 @@ TEST(Compton, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -215,7 +215,7 @@ TEST(Compton, Test_of_e_Interpolant)
     getTestFile("Compton_e.txt", in);
 
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -234,7 +234,7 @@ TEST(Compton, Test_of_e_Interpolant)
 
         ParticleDef particle_def = GammaDef();
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -246,11 +246,11 @@ TEST(Compton, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
-            if (vcut * energy == ecut || rnd1 < 0.05)
+            if (vcut * energy == std::stod(ecut) || rnd1 < 0.05)
                 // expecting a kink here (issue #250)
                 // The lower edge of the kinematic range is poorly interpolated
                 // due to a discontinuity (issue #250)

--- a/tests/Epairproduction_TEST.cxx
+++ b/tests/Epairproduction_TEST.cxx
@@ -34,7 +34,7 @@ TEST(Epairproduction, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -49,7 +49,7 @@ TEST(Epairproduction, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -70,7 +70,7 @@ TEST(Epairproduction, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -85,7 +85,7 @@ TEST(Epairproduction, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -107,7 +107,7 @@ TEST(Epairproduction, Test_Stochastic_Loss)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -126,7 +126,7 @@ TEST(Epairproduction, Test_Stochastic_Loss)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -140,7 +140,7 @@ TEST(Epairproduction, Test_Stochastic_Loss)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -162,7 +162,7 @@ TEST(Epairproduction, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -177,7 +177,7 @@ TEST(Epairproduction, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -192,7 +192,7 @@ TEST(Epairproduction, Test_of_dEdx_Interpolant)
             // Transition from zero to non-zero values is not continuous, causing
             // interpolation problems in uranium around 1e4 MeV (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e0 * dEdx_stored);
-        } else if (vcut * energy == ecut) {
+        } else if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 5e-2 * dEdx_stored);
         } else {
@@ -208,7 +208,7 @@ TEST(Epairproduction, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -223,7 +223,7 @@ TEST(Epairproduction, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -233,7 +233,7 @@ TEST(Epairproduction, Test_of_dNdx_Interpolant)
                                           config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -249,7 +249,7 @@ TEST(Epairproduction, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -267,7 +267,7 @@ TEST(Epairproduction, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -281,12 +281,12 @@ TEST(Epairproduction, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 || dNdx_for_comp == 0 ) {
+        if ( ecut == "inf" && vcut == 1 || dNdx_for_comp == 0 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
 
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
             } else if (rnd1 < 0.1) {

--- a/tests/Ionization_TEST.cxx
+++ b/tests/Ionization_TEST.cxx
@@ -34,7 +34,7 @@ TEST(Ionization, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -47,7 +47,7 @@ TEST(Ionization, Test_of_dEdx)
     {
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -67,7 +67,7 @@ TEST(Ionization, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -81,7 +81,7 @@ TEST(Ionization, Test_of_dNdx)
         ParticleDef particle_def = getParticleDef(particleName);
 
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -101,7 +101,7 @@ TEST(Ionization, Test_Stochastic_Loss)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -118,7 +118,7 @@ TEST(Ionization, Test_Stochastic_Loss)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -128,7 +128,7 @@ TEST(Ionization, Test_Stochastic_Loss)
 
         auto dNdx = cross->CalculatedNdx(energy);
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx);
@@ -150,7 +150,7 @@ TEST(Ionization, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -164,7 +164,7 @@ TEST(Ionization, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -173,7 +173,7 @@ TEST(Ionization, Test_of_dEdx_Interpolant)
                                      config);
 
         dEdx_new = cross->CalculatedEdx(energy);
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-2 * dEdx_stored);
         } else {
@@ -190,7 +190,7 @@ TEST(Ionization, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -205,7 +205,7 @@ TEST(Ionization, Test_of_dNdx_Interpolant)
         ParticleDef particle_def = getParticleDef(particleName);
 
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -214,7 +214,7 @@ TEST(Ionization, Test_of_dNdx_Interpolant)
                                      config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (vcut * energy == ecut) {
+        if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -230,7 +230,7 @@ TEST(Ionization, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -247,7 +247,7 @@ TEST(Ionization, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -257,11 +257,11 @@ TEST(Ionization, Test_of_e_Interpolant)
 
         auto dNdx = cross->CalculatedNdx(energy);
 
-        if ( ecut == INF && vcut == 1 || dNdx == 0) {
+        if ( ecut == "inf" && vcut == 1 || dNdx == 0) {
             EXPECT_THROW(cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(medium->GetHash(), energy, rnd1 * dNdx);
-            if (vcut * energy == ecut) {
+            if (vcut * energy == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
             } else if (rnd1 > 0.99) {

--- a/tests/Mupairproduction_TEST.cxx
+++ b/tests/Mupairproduction_TEST.cxx
@@ -34,7 +34,7 @@ TEST(Mupairproduction, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -48,7 +48,7 @@ TEST(Mupairproduction, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -68,7 +68,7 @@ TEST(Mupairproduction, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -82,7 +82,7 @@ TEST(Mupairproduction, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -102,7 +102,7 @@ TEST(Mupairproduction, Test_Stochastic_Loss)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -120,7 +120,7 @@ TEST(Mupairproduction, Test_Stochastic_Loss)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -133,7 +133,7 @@ TEST(Mupairproduction, Test_Stochastic_Loss)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -192,7 +192,7 @@ TEST(Mupairproduction, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -206,7 +206,7 @@ TEST(Mupairproduction, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -216,7 +216,7 @@ TEST(Mupairproduction, Test_of_dEdx_Interpolant)
 
         dEdx_new = cross->CalculatedEdx(energy);
 
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 2e-1 * dEdx_stored);
         } else {
@@ -232,7 +232,7 @@ TEST(Mupairproduction, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -246,7 +246,7 @@ TEST(Mupairproduction, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -255,7 +255,7 @@ TEST(Mupairproduction, Test_of_dNdx_Interpolant)
                                            config);
         dNdx_new = cross->CalculatedNdx(energy);
 
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -271,7 +271,7 @@ TEST(Mupairproduction, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -288,7 +288,7 @@ TEST(Mupairproduction, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -301,11 +301,11 @@ TEST(Mupairproduction, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-2 * stochastic_loss_stored);
             } else if (rnd1 > 0.95) {

--- a/tests/PhotoPair_TEST.cxx
+++ b/tests/PhotoPair_TEST.cxx
@@ -31,6 +31,7 @@ TEST(PhotoPair, Test_of_dNdx)
     std::string mediumName;
     double multiplier;
     bool lpm;
+    double density_correction;
     double energy;
     std::string parametrization;
     double dNdx_stored;
@@ -38,7 +39,7 @@ TEST(PhotoPair, Test_of_dNdx)
 
     std::cout.precision(16);
 
-    while (in >> particleName >> mediumName >> multiplier >> lpm >> energy
+    while (in >> particleName >> mediumName >> multiplier >> lpm >> density_correction >> energy
         >> parametrization >> dNdx_stored) {
 
         ParticleDef particle_def = getParticleDef(particleName);
@@ -49,7 +50,7 @@ TEST(PhotoPair, Test_of_dNdx)
         config["lpm"] = lpm;
 
         auto cross
-            = make_photopairproduction(particle_def, *medium, false, config);
+            = make_photopairproduction(particle_def, *medium, false, config, density_correction);
 
         dNdx_new = cross->CalculatedNdx(energy);
         EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-5 * dNdx_stored);
@@ -65,12 +66,13 @@ TEST(PhotoPair, Test_of_dNdx_Interpolant)
     std::string mediumName;
     double multiplier;
     bool lpm;
+    double density_correction;
     double energy;
     std::string parametrization;
     double dNdx_stored;
     double dNdx_new;
 
-    while (in >> particleName >> mediumName >> multiplier >> lpm >> energy
+    while (in >> particleName >> mediumName >> multiplier >> lpm >> density_correction >> energy
         >> parametrization >> dNdx_stored) {
 
         ParticleDef particle_def = getParticleDef(particleName);
@@ -81,10 +83,15 @@ TEST(PhotoPair, Test_of_dNdx_Interpolant)
         config["lpm"] = lpm;
 
         auto cross
-            = make_photopairproduction(particle_def, *medium, true, config);
+            = make_photopairproduction(particle_def, *medium, true, config, density_correction);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-3 * dNdx_stored);
+
+        // low-energy corrections make interpolations harder
+        if (parametrization == "kochmotz" && energy < 50.)
+            EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-2 * dNdx_stored);
+        else
+            EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-3 * dNdx_stored);
     }
 }
 

--- a/tests/PhotoPair_TEST.cxx
+++ b/tests/PhotoPair_TEST.cxx
@@ -30,6 +30,7 @@ TEST(PhotoPair, Test_of_dNdx)
     std::string particleName;
     std::string mediumName;
     double multiplier;
+    bool lpm;
     double energy;
     std::string parametrization;
     double dNdx_stored;
@@ -37,7 +38,7 @@ TEST(PhotoPair, Test_of_dNdx)
 
     std::cout.precision(16);
 
-    while (in >> particleName >> mediumName >> multiplier >> energy
+    while (in >> particleName >> mediumName >> multiplier >> lpm >> energy
         >> parametrization >> dNdx_stored) {
 
         ParticleDef particle_def = getParticleDef(particleName);
@@ -45,6 +46,7 @@ TEST(PhotoPair, Test_of_dNdx)
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
+        config["lpm"] = lpm;
 
         auto cross
             = make_photopairproduction(particle_def, *medium, false, config);
@@ -62,12 +64,13 @@ TEST(PhotoPair, Test_of_dNdx_Interpolant)
     std::string particleName;
     std::string mediumName;
     double multiplier;
+    bool lpm;
     double energy;
     std::string parametrization;
     double dNdx_stored;
     double dNdx_new;
 
-    while (in >> particleName >> mediumName >> multiplier >> energy
+    while (in >> particleName >> mediumName >> multiplier >> lpm >> energy
         >> parametrization >> dNdx_stored) {
 
         ParticleDef particle_def = getParticleDef(particleName);
@@ -75,6 +78,7 @@ TEST(PhotoPair, Test_of_dNdx_Interpolant)
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
+        config["lpm"] = lpm;
 
         auto cross
             = make_photopairproduction(particle_def, *medium, true, config);

--- a/tests/Photonuclear_TEST.cxx
+++ b/tests/Photonuclear_TEST.cxx
@@ -31,7 +31,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -48,7 +48,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -70,7 +70,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -87,7 +87,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -109,7 +109,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -128,7 +128,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -143,7 +143,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -171,7 +171,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -188,7 +188,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -202,7 +202,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dEdx_Interpolant)
         if (hard_component == 1 && energy == 1e5) {
             // kink in differential cross section (see issue #124)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
-        } else if (vcut * energy == ecut) {
+        } else if (vcut * energy == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
         } else {
@@ -218,7 +218,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -235,7 +235,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -245,7 +245,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_dNdx_Interpolant)
             = make_photonuclearreal(particle_def, *medium, ecuts, true, config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else if (hard_component == 1 && energy >= 1e10) {
@@ -274,7 +274,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -293,7 +293,7 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -310,12 +310,12 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
 
-            if ( rnd1 < 0.05 && ecut == 500) {
+            if ( rnd1 < 0.05 && std::stod(ecut) == 500) {
                 // Not enough nodes at very small losses!
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
             } else if (rnd1 < 0.02) {
@@ -327,12 +327,12 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
                 // to a hard cutoff for v=1e-7 in the differential crosssection
                 // (issue #124)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
-            } else if (energy >= 1e10 && ecut == 500) {
+            } else if (energy >= 1e10 && std::stod(ecut) == 500) {
                 // for high E, there are integration problems also without the
                 // hard component, causing problems in the dNdx interpolation
                 // (issue #124)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
-            } else if (particleName == "TauMinus" && energy >= 1e8 && ecut == 500) {
+            } else if (particleName == "TauMinus" && energy >= 1e8 && std::stod(ecut) == 500) {
                 // same issue as above, but it starts earlier when taus are involved
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-2 * stochastic_loss_stored);
             } else if (hard_component == 1 && energy == 1e5) {
@@ -343,13 +343,13 @@ TEST(PhotoRealPhotonAssumption, Test_of_e_Interpolant)
                 // Rhode parametrization hard to interpolate for this energy range
                 // due to its complicated structure
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-2 * stochastic_loss_stored);
-            } else if (vcut * energy == ecut) {
+            } else if (vcut * energy == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-2 * stochastic_loss_stored);
             } else if (rnd1 > 0.98) {
                 // inaccurate dNdx interpolant for v->1
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
-            } else if (particleName == "EMinus" && ecut == 500) {
+            } else if (particleName == "EMinus" && std::stod(ecut) == 500) {
                 // Jump in integrated functions are seen almost everywhere for
                 // electrons (issue #124)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 5e-3 * stochastic_loss_stored);
@@ -375,7 +375,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -392,7 +392,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -414,7 +414,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -431,7 +431,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -453,7 +453,7 @@ TEST(PhotoQ2Integration, Test_of_e)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -472,7 +472,7 @@ TEST(PhotoQ2Integration, Test_of_e)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -487,7 +487,7 @@ TEST(PhotoQ2Integration, Test_of_e)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
@@ -509,7 +509,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -526,7 +526,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -536,7 +536,7 @@ TEST(PhotoQ2Integration, Test_of_dEdx_Interpolant)
             = make_photonuclearQ2(particle_def, *medium, ecuts, true, config);
 
         dEdx_new = cross->CalculatedEdx(energy);
-        if (ecut == vcut * energy) {
+        if (std::stod(ecut) == vcut * energy) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dEdx_new, dEdx_stored, 1e-1 * dEdx_stored);
         } else {
@@ -552,7 +552,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -569,7 +569,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -579,7 +579,7 @@ TEST(PhotoQ2Integration, Test_of_dNdx_Interpolant)
             = make_photonuclearQ2(particle_def, *medium, ecuts, true, config);
 
         dNdx_new = cross->CalculatedNdx(energy);
-        if (energy * vcut == ecut) {
+        if (energy * vcut == std::stod(ecut)) {
             // kink in interpolated function (issue #250)
             EXPECT_NEAR(dNdx_new, dNdx_stored, 1e-1 * dNdx_stored);
         } else {
@@ -595,7 +595,7 @@ TEST(PhotoQ2Integration, Test_of_e_Interpolant)
 
     std::string particleName;
     std::string mediumName;
-    double ecut;
+    std::string ecut;
     double vcut;
     bool cont_rand = false;
     double multiplier;
@@ -614,7 +614,7 @@ TEST(PhotoQ2Integration, Test_of_e_Interpolant)
 
         ParticleDef particle_def = getParticleDef(particleName);
         auto medium = CreateMedium(mediumName);
-        auto ecuts = std::make_shared<EnergyCutSettings>(ecut, vcut, cont_rand);
+        auto ecuts = std::make_shared<EnergyCutSettings>(std::stod(ecut), vcut, cont_rand);
 
         nlohmann::json config;
         config["parametrization"] = parametrization;
@@ -629,12 +629,12 @@ TEST(PhotoQ2Integration, Test_of_e_Interpolant)
 
         auto dNdx_for_comp = cross->CalculatedNdx(energy, comp.GetHash());
 
-        if ( ecut == INF && vcut == 1 ) {
+        if ( ecut == "inf" && vcut == 1 ) {
             EXPECT_THROW(cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp), std::logic_error);
         } else {
             auto stochastic_loss = cross->CalculateStochasticLoss(comp.GetHash(), energy, rnd1 * dNdx_for_comp);
 
-            if (energy * vcut == ecut) {
+            if (energy * vcut == std::stod(ecut)) {
                 // kink in interpolated function (issue #250)
                 EXPECT_NEAR(stochastic_loss, stochastic_loss_stored, 1e-1 * stochastic_loss_stored);
             } else if (rnd1 < 0.07 || rnd1 > 0.995) {

--- a/tests/gen_testfiles_scripts/photopair.py
+++ b/tests/gen_testfiles_scripts/photopair.py
@@ -16,9 +16,12 @@ multiplier = 1.
 
 params = [
     pp.parametrization.photopair.Tsai,
+    pp.parametrization.photopair.KochMotz
 ]
 
 lpms = [0, 1]
+
+density_corrections = [1., 2.]
 
 energies = np.logspace(1, 13, num=13)
 
@@ -38,33 +41,35 @@ def create_tables(dir_name, **kwargs):
         for medium in mediums:
             for param in params:
                 for lpm in lpms:
-                    args = {
-                        "parametrization": param(lpm, particle, medium),
-                        "particle_def": particle,
-                        "target": medium,
-                        "cuts": None,
-                        "interpolate": False
-                    }
+                    for density_correction in density_corrections:
+                        args = {
+                            "parametrization": param(lpm, particle, medium, density_correction),
+                            "particle_def": particle,
+                            "target": medium,
+                            "cuts": None,
+                            "interpolate": False
+                        }
 
-                    xsection = pp.crosssection.make_crosssection(**args)
+                        xsection = pp.crosssection.make_crosssection(**args)
 
-                    for key in buf:
-                        buf[key][1] = [""]
+                        for key in buf:
+                            buf[key][1] = [""]
 
-                        for energy in energies:
-                            if key == "dNdx":
-                                result = [str(xsection.calculate_dNdx(energy))]
+                            for energy in energies:
+                                if key == "dNdx":
+                                    result = [str(xsection.calculate_dNdx(energy))]
 
-                            buf[key][1].append(particle.name)
-                            buf[key][1].append(medium.name)
-                            buf[key][1].append(str(multiplier))
-                            buf[key][1].append(str(lpm))
-                            buf[key][1].append(str(energy))
-                            buf[key][1].append(xsection.param_name)
-                            buf[key][1].extend(result)
-                            buf[key][1].append("\n")
+                                buf[key][1].append(particle.name)
+                                buf[key][1].append(medium.name)
+                                buf[key][1].append(str(multiplier))
+                                buf[key][1].append(str(lpm))
+                                buf[key][1].append(str(density_correction))
+                                buf[key][1].append(str(energy))
+                                buf[key][1].append(xsection.param_name)
+                                buf[key][1].extend(result)
+                                buf[key][1].append("\n")
 
-                        buf[key][0].write("\t".join(buf[key][1]))
+                            buf[key][0].write("\t".join(buf[key][1]))
 
 
 def main(dir_name):

--- a/tests/gen_testfiles_scripts/photopair.py
+++ b/tests/gen_testfiles_scripts/photopair.py
@@ -15,8 +15,10 @@ mediums = [
 multiplier = 1.
 
 params = [
-    pp.parametrization.photopair.Tsai(),
+    pp.parametrization.photopair.Tsai,
 ]
+
+lpms = [0, 1]
 
 energies = np.logspace(1, 13, num=13)
 
@@ -35,32 +37,34 @@ def create_tables(dir_name, **kwargs):
     for particle in particle_defs:
         for medium in mediums:
             for param in params:
-                args = {
-                    "parametrization": param,
-                    "particle_def": particle,
-                    "target": medium,
-                    "cuts": None,
-                    "interpolate": False
-                }
+                for lpm in lpms:
+                    args = {
+                        "parametrization": param(lpm, particle, medium),
+                        "particle_def": particle,
+                        "target": medium,
+                        "cuts": None,
+                        "interpolate": False
+                    }
 
-                xsection = pp.crosssection.make_crosssection(**args)
+                    xsection = pp.crosssection.make_crosssection(**args)
 
-                for key in buf:
-                    buf[key][1] = [""]
+                    for key in buf:
+                        buf[key][1] = [""]
 
-                    for energy in energies:
-                        if key == "dNdx":
-                            result = [str(xsection.calculate_dNdx(energy))]
+                        for energy in energies:
+                            if key == "dNdx":
+                                result = [str(xsection.calculate_dNdx(energy))]
 
-                        buf[key][1].append(particle.name)
-                        buf[key][1].append(medium.name)
-                        buf[key][1].append(str(multiplier))
-                        buf[key][1].append(str(energy))
-                        buf[key][1].append(xsection.param_name)
-                        buf[key][1].extend(result)
-                        buf[key][1].append("\n")
+                            buf[key][1].append(particle.name)
+                            buf[key][1].append(medium.name)
+                            buf[key][1].append(str(multiplier))
+                            buf[key][1].append(str(lpm))
+                            buf[key][1].append(str(energy))
+                            buf[key][1].append(xsection.param_name)
+                            buf[key][1].extend(result)
+                            buf[key][1].append("\n")
 
-                    buf[key][0].write("\t".join(buf[key][1]))
+                        buf[key][0].write("\t".join(buf[key][1]))
 
 
 def main(dir_name):


### PR DESCRIPTION
New PR for #334 but with clean history.

This PR adds the LPM effect for pair production of electron-positron pairs by photons.

Furthermore, this PR fixes the following issues in the implementation of the LPM effect in Bremsstrahlung:

1. An inconsistent definition of eLPM has been fixed
2. A more general definition of s1 is now used, to that the BremsLPM parametrization is not only valid for muons, but also for other particles (electrons/positrons/taus)