### PR TITLE
Add maximum number of iteration steps in `Propagator::AdvanceParticle`

### DIFF
--- a/src/PROPOSAL/PROPOSAL/Constants.h
+++ b/src/PROPOSAL/PROPOSAL/Constants.h
@@ -60,6 +60,11 @@ struct InterpolationSettings {
     static unsigned int NODES_RATE_INTERPOLANT;
 };
 
+// propagation settings
+struct PropagationSettings {
+    static unsigned int ADVANCE_PARTICLE_MAX_STEPS;
+};
+
 // precision parameters
 extern const double COMPUTER_PRECISION;
 extern const double HALF_PRECISION; // std::sqrt(computerPrecision);

--- a/src/PROPOSAL/detail/PROPOSAL/Constants.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Constants.cxx
@@ -33,6 +33,10 @@ unsigned int InterpolationSettings::NODES_DNDX_V = 100;
 unsigned int InterpolationSettings::NODES_UTILITY = 500;
 unsigned int InterpolationSettings::NODES_RATE_INTERPOLANT = 10000;
 
+// propagation settings
+
+unsigned int PropagationSettings::ADVANCE_PARTICLE_MAX_STEPS = 200;
+
 // precision parameters
 const double PROPOSAL::COMPUTER_PRECISION = 1.e-10;
 const double PROPOSAL::HALF_PRECISION = 1.e-5; // std::sqrt(computerPrecision);

--- a/src/pyPROPOSAL/detail/pybindings.cxx
+++ b/src/pyPROPOSAL/detail/pybindings.cxx
@@ -237,6 +237,11 @@ PYBIND11_MODULE(proposal, m)
         .def_readwrite_static(
             "nodes_rate_interpolant", &InterpolationSettings::NODES_RATE_INTERPOLANT);
 
+    py::class_<PropagationSettings, std::shared_ptr<PropagationSettings>>(
+            m, "PropagationSettings")
+            .def_readwrite_static(
+                    "advance_particle_max_steps", &PropagationSettings::ADVANCE_PARTICLE_MAX_STEPS);
+
     /* py::class_<InterpolationDef, std::shared_ptr<InterpolationDef>>(m, */
     /*     "InterpolationDef", */
     /*     R"pbdoc( */


### PR DESCRIPTION
Issue #332 shows that the propagation can stall if the `PARTICLE_POSITION_RESOLUTION` can not be reached due to numerical uncertainties (for very large propagation steps, complicated medium intersections, non-dense media, with multiple scattering enabled). I've been trying to find a "good" way to solve this problem, but was not successful to find a solution that made me happy. 

As a "quick fix", this PR adds an (adjustable) number of maximum iteration steps in `Propagator::AdvanceParticle`.
After we reached the maximum number of propagation steps, we check the deviation from `PARTICLE_POSITION_RESOLUTION` is. If it is "still acceptable" (which is currently defined as "1 cm"), we still continue propagation. This avoids that the propagation always stops if we have the problem in issue #332. If the deviation is "not acceptable", we throw an error/exception.

Furthermore, I found a small issue with the "backscattering" (issue #267), which is solved by resampling random numbers if we run into this case twice.


I have to admit that I am still not happy with the solution, but I believe this PR provides a quickfix that doesn't complicate the algorithm even further, and it should avoid that the algorithm stalls in case someone runs into this problem. For now, I don't think that many users will run into issue #332, but if they do, they will now get a reasonable error message that we can help to debug.
At some point in the future, it is going to be necessary to revise the whole `Propagator::AdvanceParticle` algorithm again.