### PR TITLE
Update pybind11 version in conanfile to support python 3.11

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class PROPOSALConan(ConanFile):
         self.requires("spdlog/1.10.0")
         self.requires("nlohmann_json/3.9.1")
         if self.options.with_python:
-            self.requires("pybind11/2.6.2")
+            self.requires("pybind11/2.10.1")
         if self.options.with_testing:
             self.requires("boost/1.78.0")
             self.requires("gtest/1.11.0")

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers=
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Physics
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
pybind11 started supporting Python3.11 with version 2.10.1 (see [here](https://github.com/pybind/pybind11/releases/tag/v2.10.1))
This updates the version used in the conanfile, so `pip install proposal` works out of the box with python3.11.