### PR TITLE
Avoid stuck particles

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/Propagator.cxx
@@ -252,6 +252,7 @@ int Propagator::AdvanceParticle(ParticleState &state,
             // reached geometry border
             advancement_type = ReachedBorder;
             distance = distance_to_border;
+            distance += GEOMETRY_PRECISION; // avoid particles getting stuck in front of border
         } else {
             // iteration not finished! discard energy and grammage
             advancement_type = InvalidStep;


### PR DESCRIPTION
Testing #338, I encountered (another) bug in the Propagator which can cause it to stuck.

The problem is the following situation: We do a large propagation step (in this case: 5000 km (!) in air) towards a border.
Since the step is too big, our particle is not exactly on the sector border in this step (remember that PROPOSAL saves distances in cm), but just slightly before the detector (~ 1e-7 cm). Since we have already propagated very far, we can't properly distinguish between the position before and after the sector border - Adding this remaining distance to the particle position doesn't actually change the particle position anymore.

Apparently, this is working again when we add a very small extra distance to our propagation step (GEOMETRY_PRECISION, 1e-9) so that we are always behind the sector border after a propagation step.

I have added a UnitTest, which got stuck within the first 5 particles without the bugfix, but runs through now.

I don't think that this should break other stuff, since the particle position resolution (which is relevant for other, non-geometric calculations) is much higher (1e-4cm)