### PR TITLE
Add new sampling method for photopair

### DIFF
--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
@@ -2,6 +2,7 @@
 
 #include "PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionInterpolant.h"
 #include "PROPOSAL/crosssection/parametrization/PhotoPairProduction.h"
+#include "PROPOSAL/secondaries/parametrization/photopairproduction/SauterSampling.h"
 
 namespace PROPOSAL {
     namespace secondaries {
@@ -16,7 +17,7 @@ namespace PROPOSAL {
 
         };
 
-        class PhotoPairProductionKochMotzSauter : public PhotoPairProductionKochMotzForwardPeaked {
+        class PhotoPairProductionKochMotzSauter : public PhotoPairProductionKochMotzForwardPeaked, public SauterSampling {
         public:
             PhotoPairProductionKochMotzSauter() = default;
             PhotoPairProductionKochMotzSauter(ParticleDef p, Medium m)
@@ -26,30 +27,10 @@ namespace PROPOSAL {
             std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
                     const Vector3D& dir, double energy, double rho,
                     const Component& comp, double rnd1, double rnd2, double rnd3) override {
-
-                // Sampling according to EGS 5 manual, formula (2.157)
-
                 auto energies = CalculateEnergy(energy, rho);
                 double E_electron = std::get<0>(energies);
                 double E_positron = std::get<1>(energies);
-                double p_electron = std::sqrt(E_electron * E_electron - ME * ME);
-                double p_positron = std::sqrt(E_positron * E_positron - ME * ME);
-
-                // TODO: should this be two times the same random numbers, or two different ones?
-                auto cosphi0 = (E_electron * (2 * rnd2 - 1) + p_electron) / (p_electron * (2 * rnd2 - 1) + E_electron);
-                auto cosphi1 = (E_positron * (2 * rnd3 - 1) + p_positron) / (p_positron * (2 * rnd3 - 1) + E_positron);
-
-                auto theta0 = rnd1 * 2. * PI;
-                auto theta1 = std::fmod(theta0 + PI, 2. * PI);
-                if (cosphi0 == -1.)
-                    cosphi0 *= (-1);
-                if (cosphi1 == -1.)
-                    cosphi1 *= (-1);
-                auto dir_0 = Cartesian3D(dir);
-                dir_0.deflect(cosphi0, theta0);
-                auto dir_1 = Cartesian3D(dir);
-                dir_1.deflect(cosphi1, theta1);
-                return std::make_tuple(dir_0, dir_1);
+                return SauterSampling::CalculateDirections(dir, comp, rnd1, rnd2, rnd3, E_electron, E_positron);
             };
         };
 

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
@@ -6,8 +6,7 @@
 
 namespace PROPOSAL {
     namespace secondaries {
-        class PhotoPairProductionKochMotzForwardPeaked : public PhotoPairProductionInterpolant<crosssection::PhotoPairKochMotz>,
-                public DefaultSecondaries<PhotoPairProductionKochMotzForwardPeaked> {
+        class PhotoPairProductionKochMotzForwardPeaked : public PhotoPairProductionInterpolant<crosssection::PhotoPairKochMotz> {
 
         public:
             PhotoPairProductionKochMotzForwardPeaked() = default;
@@ -17,7 +16,8 @@ namespace PROPOSAL {
 
         };
 
-        class PhotoPairProductionKochMotzSauter : public PhotoPairProductionKochMotzForwardPeaked, public SauterSampling {
+        class PhotoPairProductionKochMotzSauter : public PhotoPairProductionKochMotzForwardPeaked, public SauterSampling,
+                                                  public DefaultSecondaries<PhotoPairProductionKochMotzSauter> {
         public:
             PhotoPairProductionKochMotzSauter() = default;
             PhotoPairProductionKochMotzSauter(ParticleDef p, Medium m)

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
@@ -15,5 +15,43 @@ namespace PROPOSAL {
             {}
 
         };
+
+        class PhotoPairProductionKochMotzSauter : public PhotoPairProductionKochMotzForwardPeaked {
+        public:
+            PhotoPairProductionKochMotzSauter() = default;
+            PhotoPairProductionKochMotzSauter(ParticleDef p, Medium m)
+                : PhotoPairProductionKochMotzForwardPeaked(p, m)
+            {}
+
+            std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+                    const Vector3D& dir, double energy, double rho,
+                    const Component& comp, double rnd1, double rnd2, double rnd3) override {
+
+                // Sampling according to EGS 5 manual, formula (2.157)
+
+                auto energies = CalculateEnergy(energy, rho);
+                double E_electron = std::get<0>(energies);
+                double E_positron = std::get<1>(energies);
+                double p_electron = std::sqrt(E_electron * E_electron - ME * ME);
+                double p_positron = std::sqrt(E_positron * E_positron - ME * ME);
+
+                // TODO: should this be two times the same random numbers, or two different ones?
+                auto cosphi0 = (E_electron * (2 * rnd2 - 1) + p_electron) / (p_electron * (2 * rnd2 - 1) + E_electron);
+                auto cosphi1 = (E_positron * (2 * rnd3 - 1) + p_positron) / (p_positron * (2 * rnd3 - 1) + E_positron);
+
+                auto theta0 = rnd1 * 2. * PI;
+                auto theta1 = std::fmod(theta0 + PI, 2. * PI);
+                if (cosphi0 == -1.)
+                    cosphi0 *= (-1);
+                if (cosphi1 == -1.)
+                    cosphi1 *= (-1);
+                auto dir_0 = Cartesian3D(dir);
+                dir_0.deflect(cosphi0, theta0);
+                auto dir_1 = Cartesian3D(dir);
+                dir_1.deflect(cosphi1, theta1);
+                return std::make_tuple(dir_0, dir_1);
+            };
+        };
+
     } // namespace secondaries
 } // namespace PROPOSAL

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionTsai.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionTsai.h
@@ -3,6 +3,7 @@
 #include "PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionInterpolant.h"
 #include "PROPOSAL/crosssection/parametrization/PhotoPairProduction.h"
 #include "PROPOSAL/math/Integral.h"
+#include "PROPOSAL/secondaries/parametrization/photopairproduction/SauterSampling.h"
 
 namespace PROPOSAL {
 namespace secondaries {
@@ -31,7 +32,7 @@ namespace secondaries {
                 double, double, double) override;
     };
 
-    class PhotoPairProductionTsaiSauter : public PhotoPairProductionTsaiForwardPeaked {
+    class PhotoPairProductionTsaiSauter : public PhotoPairProductionTsaiForwardPeaked, public SauterSampling {
     public:
         PhotoPairProductionTsaiSauter() = default;
         PhotoPairProductionTsaiSauter(ParticleDef p, Medium m)
@@ -41,30 +42,10 @@ namespace secondaries {
         std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
                 const Vector3D& dir, double energy, double rho,
                 const Component& comp, double rnd1, double rnd2, double rnd3) override {
-
-            // Sampling according to EGS 5 manual, formula (2.157)
-
             auto energies = CalculateEnergy(energy, rho);
             double E_electron = std::get<0>(energies);
             double E_positron = std::get<1>(energies);
-            double p_electron = std::sqrt(E_electron * E_electron - ME * ME);
-            double p_positron = std::sqrt(E_positron * E_positron - ME * ME);
-
-            // TODO: should this be two times the same random numbers, or two different ones?
-            auto cosphi0 = (E_electron * (2 * rnd2 - 1) + p_electron) / (p_electron * (2 * rnd2 - 1) + E_electron);
-            auto cosphi1 = (E_positron * (2 * rnd3 - 1) + p_positron) / (p_positron * (2 * rnd3 - 1) + E_positron);
-
-            auto theta0 = rnd1 * 2. * PI;
-            auto theta1 = std::fmod(theta0 + PI, 2. * PI);
-            if (cosphi0 == -1.)
-                cosphi0 *= (-1);
-            if (cosphi1 == -1.)
-                cosphi1 *= (-1);
-            auto dir_0 = Cartesian3D(dir);
-            dir_0.deflect(cosphi0, theta0);
-            auto dir_1 = Cartesian3D(dir);
-            dir_1.deflect(cosphi1, theta1);
-            return std::make_tuple(dir_0, dir_1);
+            return SauterSampling::CalculateDirections(dir, comp, rnd1, rnd2, rnd3, E_electron, E_positron);
         };
     };
 

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionTsai.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionTsai.h
@@ -30,5 +30,43 @@ namespace secondaries {
                 const Vector3D&, double, double, const Component&,
                 double, double, double) override;
     };
+
+    class PhotoPairProductionTsaiSauter : public PhotoPairProductionTsaiForwardPeaked {
+    public:
+        PhotoPairProductionTsaiSauter() = default;
+        PhotoPairProductionTsaiSauter(ParticleDef p, Medium m)
+            : PhotoPairProductionTsaiForwardPeaked(p, m)
+        {}
+
+        std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+                const Vector3D& dir, double energy, double rho,
+                const Component& comp, double rnd1, double rnd2, double rnd3) override {
+
+            // Sampling according to EGS 5 manual, formula (2.157)
+
+            auto energies = CalculateEnergy(energy, rho);
+            double E_electron = std::get<0>(energies);
+            double E_positron = std::get<1>(energies);
+            double p_electron = std::sqrt(E_electron * E_electron - ME * ME);
+            double p_positron = std::sqrt(E_positron * E_positron - ME * ME);
+
+            // TODO: should this be two times the same random numbers, or two different ones?
+            auto cosphi0 = (E_electron * (2 * rnd2 - 1) + p_electron) / (p_electron * (2 * rnd2 - 1) + E_electron);
+            auto cosphi1 = (E_positron * (2 * rnd3 - 1) + p_positron) / (p_positron * (2 * rnd3 - 1) + E_positron);
+
+            auto theta0 = rnd1 * 2. * PI;
+            auto theta1 = std::fmod(theta0 + PI, 2. * PI);
+            if (cosphi0 == -1.)
+                cosphi0 *= (-1);
+            if (cosphi1 == -1.)
+                cosphi1 *= (-1);
+            auto dir_0 = Cartesian3D(dir);
+            dir_0.deflect(cosphi0, theta0);
+            auto dir_1 = Cartesian3D(dir);
+            dir_1.deflect(cosphi1, theta1);
+            return std::make_tuple(dir_0, dir_1);
+        };
+    };
+
 } // namespace secondaries
 } // namespace PROPOSAL

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/SauterSampling.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/SauterSampling.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "PROPOSAL/Constants.h"
+#include "PROPOSAL/math/Cartesian3D.h"
+#include "PROPOSAL/medium/Components.h"
+
+#include <cmath>
+
+namespace PROPOSAL {
+    namespace secondaries {
+
+        struct SauterSampling {
+            std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
+                    const Vector3D& dir, const Component& comp, double rnd1, double rnd2, double rnd3,
+                    double E_electron, double E_positron) {
+
+                // Sampling according to EGS 5 manual, formula (2.157)
+
+                double p_electron = std::sqrt(E_electron * E_electron - ME * ME);
+                double p_positron = std::sqrt(E_positron * E_positron - ME * ME);
+
+                // TODO: should this be two times the same random numbers, or two different ones?
+                auto cosphi0 = (E_electron * (2 * rnd2 - 1) + p_electron) / (p_electron * (2 * rnd2 - 1) + E_electron);
+                auto cosphi1 = (E_positron * (2 * rnd3 - 1) + p_positron) / (p_positron * (2 * rnd3 - 1) + E_positron);
+
+                auto theta0 = rnd1 * 2. * PI;
+                auto theta1 = std::fmod(theta0 + PI, 2. * PI);
+                if (cosphi0 == -1.)
+                    cosphi0 *= (-1);
+                if (cosphi1 == -1.)
+                    cosphi1 *= (-1);
+                auto dir_0 = Cartesian3D(dir);
+                dir_0.deflect(cosphi0, theta0);
+                auto dir_1 = Cartesian3D(dir);
+                dir_1.deflect(cosphi1, theta1);
+                return std::make_tuple(dir_0, dir_1);
+            };
+        };
+    }
+}

--- a/src/pyPROPOSAL/detail/secondaries.cxx
+++ b/src/pyPROPOSAL/detail/secondaries.cxx
@@ -148,9 +148,15 @@ void init_secondaries(py::module& m)
     SecondariesBuilder<secondaries::PhotoPairProductionTsaiForwardPeaked,
         secondaries::PhotoPairProduction> {}
         .decl_rho_param(m_sub, "PhotoTsaiForwardPeaked");
+    SecondariesBuilder<secondaries::PhotoPairProductionTsaiSauter,
+        secondaries::PhotoPairProduction> {}
+        .decl_rho_param(m_sub, "PhotoTsaiSauter");
     SecondariesBuilder<secondaries::PhotoPairProductionKochMotzForwardPeaked,
         secondaries::PhotoPairProduction> {}
         .decl_rho_param(m_sub, "PhotoKochMotzForwardPeaked");
+    SecondariesBuilder<secondaries::PhotoPairProductionKochMotzSauter,
+        secondaries::PhotoPairProduction> {}
+        .decl_rho_param(m_sub, "PhotoKochMotzSauter");
 
     SecondariesBuilder<secondaries::PhotoeffectNoDeflection, secondaries::Photoeffect> {}
         .decl_param(m_sub, "PhotoeffectNoDeflection");


### PR DESCRIPTION
When investigating the two photopair angle sampling methods we currently use (Tsai and ForwardPeaked), I saw that the median value differs by quite a lot:

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/15159319/217542571-acca389b-28a2-45af-9075-18b9b89b1a66.png">

I looked in the EGS5 manual, where a very simple sampling method has been suggested with formula (2.157).
I implemented this method as a test, and to my surprise, it reproduces the current implementation by Tsai quite well:

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/15159319/217542897-8e30f431-1dcc-4d45-8079-8c58c44556cb.png">

Note that both plots are created for an interaction of a 1e4 MeV Photon with a nitrogen atom.

However, the Sauter implementation is almost as quick as the crude EGS4 approximation, which itself is two order of magnitudes quicker than the Tsai sampling.

I am a bit surprised that the Sauter sampling methods reproduces the results by Tsai that well, especially since in the EGS5 manual, the method is called "a crude approximation even in its region of validity". 
This good agreement also does not change for different Z or energies.
So probably, the Tsai calculation is much worse than I thought, or the Sauter approximation much better than they say in the EGS manual.

So maybe someone should investigate this a bit more before merging?