### PR TITLE
Indicate multiple inheritance structure of `crosssection::Photoproduction` classes in pybindings

### DIFF
--- a/src/pyPROPOSAL/detail/parametrization.cxx
+++ b/src/pyPROPOSAL/detail/parametrization.cxx
@@ -697,22 +697,22 @@ void init_parametrization(py::module& m)
 
     py::class_<crosssection::PhotoproductionBezrukovBugaev,
     std::shared_ptr<crosssection::PhotoproductionBezrukovBugaev>,
-    crosssection::Photoproduction>(m_sub_photoproduction, "BezrukovBugaev")
+    crosssection::Photoproduction>(m_sub_photoproduction, "BezrukovBugaev", py::multiple_inheritance())
         .def(py::init<>());
 
     py::class_<crosssection::PhotoproductionCaldwell,
     std::shared_ptr<crosssection::PhotoproductionCaldwell>,
-    crosssection::Photoproduction>(m_sub_photoproduction, "Caldwell")
+    crosssection::Photoproduction>(m_sub_photoproduction, "Caldwell", py::multiple_inheritance())
         .def(py::init<>());
 
     py::class_<crosssection::PhotoproductionKokoulin,
     std::shared_ptr<crosssection::PhotoproductionKokoulin>,
-    crosssection::Photoproduction>(m_sub_photoproduction, "Kokoulin")
+    crosssection::Photoproduction>(m_sub_photoproduction, "Kokoulin", py::multiple_inheritance())
         .def(py::init<>());
 
     py::class_<crosssection::PhotoproductionRhode,
     std::shared_ptr<crosssection::PhotoproductionRhode>,
-    crosssection::Photoproduction>(m_sub_photoproduction, "Rhode")
+    crosssection::Photoproduction>(m_sub_photoproduction, "Rhode", py::multiple_inheritance())
         .def(py::init<>());
 
     // --------------------------------------------------------------------- //


### PR DESCRIPTION
Fixes #351 

The Photoproduction parametrizations use a rather complicated inheritance structure, including multiple inheritance. This is due do the fact that some parametrization "borrow" from other parametrizations.

However, this needs to be explicitly mentioned to pybind11, see [here](https://github.com/pybind/pybind11/issues/2071).
If this is done correctly, all functions calls work correctly.