### PR TITLE
Fix default ionization cross sections for electrons and positrons

### DIFF
--- a/docs/default_crosssections.md
+++ b/docs/default_crosssections.md
@@ -23,14 +23,14 @@ More information about each parametrization are given [here](https://github.com/
 
 - Bremsstrahlung: `ElectronScreening` (LPM effect disabled)
 - Electron-Positron pair production: `ForElectronPositron` (LPM effect disabled)
-- Ionization: `BergerSeltzerBhabha`
+- Ionization: `BergerSeltzerMoller`
 - Nuclear interactions: `AbramowiczLevinLevyMaor97` (with the shadowing parametrization `ButkevichMikheyev`)
 
 ### Positrons:
 
 - Bremsstrahlung: `ElectronScreening` (LPM effect disabled)
 - Electron-Positron pair production: `ForElectronPositron` (LPM effect disabled)
-- Ionization: `BergerSeltzerMoller`
+- Ionization: `BergerSeltzerBhabha`
 - Nuclear interactions: `AbramowiczLevinLevyMaor97` (with the shadowing parametrization `ButkevichMikheyev`)
 - Annihilation: `Heitler`
 

--- a/src/PROPOSAL/PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/ParticleDefaultCrossSectionList.h
@@ -110,7 +110,7 @@ void DefaultCrossSections<EMinusDef>::Append(CrossVec& cross_vec, P p, M m,std::
 {
     auto brems = std::make_tuple(crosssection::BremsElectronScreening{ false }, p, m, cut, interpolate);
     auto epair = std::make_tuple(crosssection::EpairForElectronPositron{ false }, p, m, cut, interpolate);
-    auto ioniz = std::make_tuple(crosssection::IonizBergerSeltzerBhabha{ EnergyCutSettings(*cut) }, p, m, cut, interpolate);
+    auto ioniz = std::make_tuple(crosssection::IonizBergerSeltzerMoller{ EnergyCutSettings(*cut) }, p, m, cut, interpolate);
     auto photo = std::make_tuple(crosssection::PhotoAbramowiczLevinLevyMaor97 { make_unique<crosssection::ShadowButkevichMikheyev>() }, p, m, cut, interpolate);
     append_cross(cross_vec, brems, epair, ioniz, photo);
 }
@@ -121,7 +121,7 @@ void DefaultCrossSections<EPlusDef>::Append(CrossVec& cross_vec, P p, M m,std::s
 {
     auto brems = std::make_tuple(crosssection::BremsElectronScreening{ false }, p, m, cut, interpolate);
     auto epair = std::make_tuple(crosssection::EpairForElectronPositron{ false }, p, m, cut, interpolate);
-    auto ioniz = std::make_tuple(crosssection::IonizBergerSeltzerMoller{ EnergyCutSettings(*cut) }, p, m, cut, interpolate);
+    auto ioniz = std::make_tuple(crosssection::IonizBergerSeltzerBhabha{ EnergyCutSettings(*cut) }, p, m, cut, interpolate);
     auto photo = std::make_tuple(crosssection::PhotoAbramowiczLevinLevyMaor97 { make_unique<crosssection::ShadowButkevichMikheyev>() }, p, m, cut, interpolate);
     auto annih = std::make_tuple(crosssection::AnnihilationHeitler{}, p, m, nullptr, interpolate);
     append_cross(cross_vec, brems, epair, ioniz, photo, annih);


### PR DESCRIPTION
Switch Bhabha and Møller scattering in provided default cross sections