### PR TITLE
Create `MoliereInterpol` parametrization for multiple scattering

### DIFF
--- a/docs/config_docu.md
+++ b/docs/config_docu.md
@@ -167,6 +167,7 @@ PROPOSAL provides different multiple scattering models, which can be set with th
 * `HighlandIntegral`: Gaussian approximation of Molière theory, derived by [Highland](https://doi.org/10.1016/0029-554X(75)90743-0) and corrected by [Lynch/Dahl](https://doi.org/10.1016/0168-583X(91)95671-Y). 
 * `Highland`: Same as `HighlandIntegral`, but with the approximation that the particle energy is constant during a propagation step. *This parametrization should only be used for small step sizes where this approximation is valid.*
 * `Moliere`: Scattering based on [Molière's theory](https://zfn.mpdl.mpg.de/data/Reihe_A/3/ZNA-1948-3a-0078.pdf). *Significantly slower compared to other scattering models.*
+* `MoliereInterpol`: Same as `Moliere`, but using interpolation tables to increase performance
 
 Multiple scattering effects can be scaled with a constant factor using the option `multiple_scattering_multiplier`.
 This scales the sampled deflections, which are described by their displacement in cartesian coordinates, with a constant factor for each component. 

--- a/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/Parametrization.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/Parametrization.h
@@ -35,6 +35,10 @@ namespace PROPOSAL {
 namespace multiple_scattering {
     struct ScatteringOffset {
         ScatteringOffset() : sx(0.), sy(0.), tx(0.), ty(0.) {};
+        friend std::ostream& operator<<(std::ostream& os, const ScatteringOffset& offset) {
+            os << "sx: " << offset.sx << ", sy: " << offset.sy << ", tx: " << offset.tx << ", ty: " << offset.ty  << '\n';
+            return os;
+        };
         double sx;
         double sy;
         double tx;

--- a/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/ScatteringFactory.h
+++ b/src/PROPOSAL/PROPOSAL/scattering/multiple_scattering/ScatteringFactory.h
@@ -51,14 +51,16 @@ enum class MultipleScatteringType : int {
     NoScattering,
     Moliere,
     Highland,
-    HighlandIntegral
+    HighlandIntegral,
+    MoliereInterpol
 };
 
 static const std::unordered_map<std::string, MultipleScatteringType>
     MultipleScatteringTable = { { "moliere", MultipleScatteringType::Moliere },
         { "highland", MultipleScatteringType::Highland },
         { "highlandintegral", MultipleScatteringType::HighlandIntegral },
-        { "noscattering", MultipleScatteringType::NoScattering } };
+        { "noscattering", MultipleScatteringType::NoScattering },
+        { "moliereinterpol", MultipleScatteringType::MoliereInterpol }};
 
 inline auto make_multiple_scattering(
     MultipleScatteringType t, ParticleDef const& p, Medium const& m)
@@ -68,6 +70,8 @@ inline auto make_multiple_scattering(
         return make_highland(p, m);
     case MultipleScatteringType::Moliere:
         return make_moliere(p, m);
+    case MultipleScatteringType::MoliereInterpol:
+         return make_moliereinterpol(p, m);
     case MultipleScatteringType::NoScattering:
         return std::unique_ptr<multiple_scattering::Parametrization>(nullptr);
     default:

--- a/src/pyPROPOSAL/detail/scattering.cxx
+++ b/src/pyPROPOSAL/detail/scattering.cxx
@@ -34,6 +34,8 @@ void init_scattering(py::module& m)
 
     py::class_<multiple_scattering::Highland, multiple_scattering::Parametrization,
         std::shared_ptr<multiple_scattering::Highland>>(m_sub, "Highland")
+        .def(py::init<const ParticleDef&, const Medium&>(),
+             py::arg("particle_def"), py::arg("medium"))
         .def("CalculateTheta0", &multiple_scattering::Highland::CalculateTheta0,
              py::arg("grammage"), py::arg("e_i"), py::arg("e_f"),
              R"pbdoc(
@@ -49,11 +51,22 @@ void init_scattering(py::module& m)
     py::class_<multiple_scattering::HighlandIntegral, multiple_scattering::Highland,
             std::shared_ptr<multiple_scattering::HighlandIntegral>>(m_sub, "HighlandIntegral");
 
+    py::class_<multiple_scattering::Moliere, multiple_scattering::Parametrization,
+            std::shared_ptr<multiple_scattering::Moliere>>(m_sub, "Moliere")
+            .def(py::init<const ParticleDef&, const Medium&>(),
+                 py::arg("particle_def"), py::arg("medium"));
+
+    py::class_<multiple_scattering::MoliereInterpol, multiple_scattering::Parametrization,
+            std::shared_ptr<multiple_scattering::MoliereInterpol>>(m_sub, "MoliereInterpol")
+            .def(py::init<const ParticleDef&, const Medium&>(),
+                 py::arg("particle_def"), py::arg("medium"));
+
     py::class_<multiple_scattering::ScatteringOffset>(m_sub, "scattering_offset")
             .def_readwrite("sx", &multiple_scattering::ScatteringOffset::sx)
             .def_readwrite("sy", &multiple_scattering::ScatteringOffset::sy)
             .def_readwrite("tx", &multiple_scattering::ScatteringOffset::tx)
-            .def_readwrite("ty", &multiple_scattering::ScatteringOffset::ty);
+            .def_readwrite("ty", &multiple_scattering::ScatteringOffset::ty)
+            .def("__str__", &py_print<multiple_scattering::ScatteringOffset>);
 
     m_sub.def("scatter_initial_direction", &multiple_scattering::ScatterInitialDirection);
 

--- a/tests/Scattering_TEST.cxx
+++ b/tests/Scattering_TEST.cxx
@@ -215,9 +215,10 @@ TEST(Scattering, ZeroDisplacement){
     auto cuts = std::make_shared<EnergyCutSettings>(INF, 1, false);
     auto cross = GetCrossSections(MuMinusDef(), medium, cuts, true);
 
-    std::array<std::unique_ptr<multiple_scattering::Parametrization>, 3> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
+    std::array<std::unique_ptr<multiple_scattering::Parametrization>, 4> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
                                                                                          make_multiple_scattering("highland", MuMinusDef(), medium),
-                                                                                         make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross)};
+                                                                                         make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross),
+                                                                                         make_multiple_scattering("moliereinterpol", MuMinusDef(), medium)};
 
     for(auto const& scatter: scatter_list){
         auto offset = scatter->CalculateRandomAngle(0, 1e5, 1e5, {0.1, 0.2, 0.3, 0.4});
@@ -238,9 +239,10 @@ TEST(Scattering, FirstMomentum){
     int statistics = 1e3;
     auto cross = GetCrossSections(MuMinusDef(), medium, cuts, true);
 
-    std::array<std::unique_ptr<multiple_scattering::Parametrization>, 3> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
+    std::array<std::unique_ptr<multiple_scattering::Parametrization>, 4> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
                                                                make_multiple_scattering("highland", MuMinusDef(), medium),
-                                                               make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross)};
+                                                               make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross),
+                                                               make_multiple_scattering("moliereinterpol", MuMinusDef(), medium),};
     Cartesian3D scatter_sum;
     Cartesian3D offset_sum;
 
@@ -277,15 +279,16 @@ TEST(Scattering, SecondMomentum){
     auto direction_init = Cartesian3D(0, 0, 1);
     auto cuts = std::make_shared<EnergyCutSettings>(INF, 1, false);
 
-    int statistics = 1e3;
+    int statistics = 1e5;
 
     double E_i = 1e14;
     std::array<double, 6> final_energies = {1e13, 1e11, 1e9, 1e7, 1e5, 1e3};
     auto cross = GetCrossSections(MuMinusDef(), medium, cuts, true);
 
-    std::array<std::unique_ptr<multiple_scattering::Parametrization>, 3> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
+    std::array<std::unique_ptr<multiple_scattering::Parametrization>, 4> scatter_list = {make_multiple_scattering("moliere", MuMinusDef(), medium),
                                                                make_multiple_scattering("highland", MuMinusDef(), medium),
-                                                               make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross)};
+                                                               make_multiple_scattering("highlandintegral", MuMinusDef(), medium, cross),
+                                                               make_multiple_scattering("moliereinterpol", MuMinusDef(), medium, cross)};
     double scatter_sum;
     double offset_sum;
     double displacement;


### PR DESCRIPTION
When profiling the performance of multiple scattering calculations, we already knew that `Moliere` takes much longer to calculate than `Highland` or `HighlandIntegral`. For applications such as CORSIKA 8, where an accurate description of large-scattering angles is mandatory, this starts to becomes a performance issue.

When profiling the execution of `Moliere`, I figured out that most of the time is spent in the functions `f1M`, `f2M`, `F1M` `F2M`, where an expression is evaluated using Horner's method. Looking at the manual of EGS, I found out that they use interpolation tables to store the values of these functions instead of evaluating them for every execution.

Therefore, I implemented a similar approach for PROPOSAL, using the `cubicinterpolation` classes. 

First of all, these are validations that the interpolation works smoothly:

 <details>
  <summary>Validation of f1M</summary>
  
![image](https://user-images.githubusercontent.com/15159319/232249506-99b91034-afb6-4d4d-b395-f0421dd07bc7.png)
![image](https://user-images.githubusercontent.com/15159319/232249511-b4c8205d-b26c-4fac-a396-7886d7304a09.png)

</details>

 <details>
  <summary>Validation of f2M</summary>
  
![image](https://user-images.githubusercontent.com/15159319/232249534-ab3a324b-ab4c-49bf-bf98-fda816fe7073.png)
![image](https://user-images.githubusercontent.com/15159319/232249538-d5e01d66-84fa-4c45-810b-232ccf7070ac.png)

</details>


</details>

 <details>
  <summary>Validation of F1M</summary>
  
![image](https://user-images.githubusercontent.com/15159319/232249549-03918258-2f8b-4dcf-b452-92a6d2c2d249.png)
![image](https://user-images.githubusercontent.com/15159319/232249552-3f24e0d6-57bf-4f77-bc08-fb18d08c506d.png)


</details>


</details>

 <details>
  <summary>Validation of F2M</summary>
  
![image](https://user-images.githubusercontent.com/15159319/232249560-3c057ea5-c659-44b1-85df-69f50cdf0193.png)
![image](https://user-images.githubusercontent.com/15159319/232249581-14936069-249d-4d71-be8a-3c25a84a4801.png)

</details>

The results of the scattering angles stays true to the results without the interpolation. This plots shows the scattering angles for electrons in air, with a fixed initial energy of 1 GeV and a fixed final energy of 0.9 GeV.

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/15159319/232249678-4eeeba3c-4dfa-4858-a31b-c61a57ab8a7e.png">

The runtime improvement can be seen in the following plot, which shows the computing time per scattering angle.

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/15159319/232249708-0140d8b7-a2e1-4625-bdb3-3ed88e9a39bd.png">

While the actual runtime improvement always depends on the specific usecase, it is at least of a factor of two.

This PR also include some smaller improvements, namely:

- Add a direct print/cout method for `multiple_scattering::ScatteringOffset`
- Add a warning if `Moliere::CalculateRandomAngle` doesn't seem to converge (normally, only about 5 iterations are necessary)
- Add direct python bindings for Moliere, and add a python binding for the simple constructors
