### PR TITLE
Fix execution of tests in new CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -68,6 +68,12 @@ jobs:
           with:
             path: build
             key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}-${{ github.sha }}-key
+        - name: Cache tests
+          id: cache-tests
+          uses: actions/cache@v2
+          with:
+            path: build
+            key: ${{ runner.os }}-cache-tests-${{ matrix.compiler }}-${{ github.sha }}-key            
         - uses: actions/setup-python@v2
           with:
             python-version: '3.8'
@@ -123,11 +129,11 @@ jobs:
           with:
             path: ~/.conan
             key: ${{ runner.os }}-cache-conan-${{ matrix.compiler }}-${{ hashFiles('conanfile.py') }}-key
-        - name: Cache build
-          id: cache-build
+        - name: Cache tests
+          id: cache-tests
           uses: actions/cache@v2
           with:
             path: build
-            key: ${{ runner.os }}-cache-build-${{ matrix.compiler }}-${{ github.sha }}-key
+            key: ${{ runner.os }}-cache-tests-${{ matrix.compiler }}-${{ github.sha }}-key
         - name: Run tests
           run: ctest --test-dir tests -j2 --verbose -E "(Brems.*Interpolant|Photo.*Interpolant|Epair.*Interpolant|Mupair.*Interpolant)"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -97,7 +97,7 @@ jobs:
           if: ${{ matrix.os != 'windows-latest' }}
           run: cmake --build . -j2
         - name: Build PROPOSAL (Windows)
-          if: ${{ matrix.os != 'windows-latest' }}
+          if: ${{ matrix.os == 'windows-latest' }}
           run: cmake --build . -j2 --config Release
     test:
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -72,7 +72,7 @@ jobs:
           id: cache-tests
           uses: actions/cache@v2
           with:
-            path: build
+            path: tests
             key: ${{ runner.os }}-cache-tests-${{ matrix.compiler }}-${{ github.sha }}-key            
         - uses: actions/setup-python@v2
           with:
@@ -133,7 +133,7 @@ jobs:
           id: cache-tests
           uses: actions/cache@v2
           with:
-            path: build
+            path: tests
             key: ${{ runner.os }}-cache-tests-${{ matrix.compiler }}-${{ github.sha }}-key
         - name: Run tests
           run: ctest --test-dir tests -j2 --verbose -E "(Brems.*Interpolant|Photo.*Interpolant|Epair.*Interpolant|Mupair.*Interpolant)"


### PR DESCRIPTION
With the update in #365, tests were not executed anymore because they weren't cached.

This PR caches the folder where tests are saved, so they are actually run. 