### PR TITLE
Upgrade boost version in conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -72,7 +72,7 @@ class PROPOSALConan(ConanFile):
         if self.options.with_python:
             self.requires("pybind11/2.10.1")
         if self.options.with_testing:
-            self.requires("boost/1.75.0")
+            self.requires("boost/1.83.0")
             self.requires("gtest/1.11.0")
         if self.options.with_documentation:
             self.requires("doxygen/1.8.20")


### PR DESCRIPTION
This changes the version of boost to be consistent with the version used in the cubic_interpolation package. This avoids versioning errors which appeared in the CI.

This only affects building proposal with tests.