### PR TITLE
Avoid possible nan in LeptonicDecayChannel::DecayRate.

### DIFF
--- a/src/PROPOSAL/detail/PROPOSAL/decay/LeptonicDecayChannel.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/decay/LeptonicDecayChannel.cxx
@@ -213,7 +213,7 @@ double LeptonicDecayChannel::DecayRate(double x, double M, double E_max, double 
     double m2 = m * m;
 
     double E_l     = E_max * x;
-    double sqrt_EM = std::sqrt(E_l * E_l - m2);
+    double sqrt_EM = std::sqrt(std::max(0.0, E_l * E_l - m2));
 
     return 1.5 * m2 * m2 * M * std::log(sqrt_EM + E_l) +
            sqrt_EM * ((M2 + m2 - M * E_l) * (E_l * E_l - m2) - 1.5 * M * E_l * m2) - right_side;


### PR DESCRIPTION
This has been an issue observed in icetray simulations on specific MacOS machines, and since the decay code is still identical, this might also become a problem for PROPOSAL 7.