### PR TITLE
Adapt transformation function for PhotoPairInterpolant

### DIFF
--- a/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.h
+++ b/src/PROPOSAL/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.h
@@ -16,21 +16,24 @@ double transform_relative_loss(double v_cut, double v_max, double v, double c = 
 double retransform_relative_loss(double v_cut, double v_max, double v, double c = 1);
 double transform_loss_log(double v_cut, double v_max, double v);
 double retransform_loss_log(double v_cut, double v_max, double v);
+double transform_loss_linear(double v_cut, double v_max, double v);
+double retransform_loss_linear(double v_cut, double v_max, double v);
 
 namespace crosssection {
     struct Compton;
     struct Ionization;
+    struct PhotoPairProduction;
 }
 
 // general transformation rules for v nodes
 // TODO: in C++17, this section can be rewritten much cleaner using if constexpr
 
-template <typename Param, std::enable_if_t<!(std::is_base_of<crosssection::Ionization, Param>::value || std::is_base_of<crosssection::Compton, Param>::value), bool> = true>
+template <typename Param, std::enable_if_t<!(std::is_base_of<crosssection::Ionization, Param>::value || std::is_base_of<crosssection::Compton, Param>::value || std::is_base_of<crosssection::PhotoPairProduction, Param>::value), bool> = true>
 double transform_loss(double v_cut, double v_max, double v) {
     return transform_relative_loss(v_cut, v_max, v);
 }
 
-template <typename Param, std::enable_if_t<!(std::is_base_of<crosssection::Ionization, Param>::value || std::is_base_of<crosssection::Compton, Param>::value), bool> = true>
+template <typename Param, std::enable_if_t<!(std::is_base_of<crosssection::Ionization, Param>::value || std::is_base_of<crosssection::Compton, Param>::value || std::is_base_of<crosssection::PhotoPairProduction, Param>::value), bool> = true>
 double retransform_loss(double v_cut, double v_max, double v) {
     return retransform_relative_loss(v_cut, v_max, v);
 }
@@ -58,6 +61,18 @@ template <typename Param, std::enable_if_t<std::is_base_of<crosssection::Compton
 double retransform_loss(double v_cut, double v_max, double v) {
     return retransform_loss_log(v_cut, v_max, v);
 }
+
+// specifications for PhotoPairProduction
+
+    template <typename Param, std::enable_if_t<std::is_base_of<crosssection::PhotoPairProduction, Param>::value, bool> = true>
+    double transform_loss(double v_cut, double v_max, double v) {
+        return transform_loss_linear(v_cut, v_max, v);
+    }
+
+    template <typename Param, std::enable_if_t<std::is_base_of<crosssection::PhotoPairProduction, Param>::value, bool> = true>
+    double retransform_loss(double v_cut, double v_max, double v) {
+        return retransform_loss_linear(v_cut, v_max, v);
+    }
 
 template <typename T1, typename... Args>
 auto build_dndx_def(T1 const& param, ParticleDef const& p, Args... args)

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionInterpolant.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionInterpolant.h
@@ -28,9 +28,9 @@ namespace secondaries {
         static constexpr int n_rnd = 4;
 
         PhotoPairProductionInterpolant() = default;
-        PhotoPairProductionInterpolant(ParticleDef p, Medium m)
+        PhotoPairProductionInterpolant(ParticleDef p, Medium m, bool interpol = true)
             : medium(m)
-            , dndx(detail::build_dndx(std::true_type {}, true,
+            , dndx(detail::build_dndx(std::true_type {}, interpol,
                                       Param(), p, medium, nullptr))
         {}
 

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionKochMotz.h
@@ -10,8 +10,8 @@ namespace PROPOSAL {
 
         public:
             PhotoPairProductionKochMotzForwardPeaked() = default;
-            PhotoPairProductionKochMotzForwardPeaked(ParticleDef p, Medium m)
-                : PhotoPairProductionInterpolant<crosssection::PhotoPairKochMotz>(p, m)
+            PhotoPairProductionKochMotzForwardPeaked(ParticleDef p, Medium m, bool interpol = true)
+                : PhotoPairProductionInterpolant<crosssection::PhotoPairKochMotz>(p, m, interpol)
             {}
 
         };
@@ -20,8 +20,8 @@ namespace PROPOSAL {
                                                   public DefaultSecondaries<PhotoPairProductionKochMotzSauter> {
         public:
             PhotoPairProductionKochMotzSauter() = default;
-            PhotoPairProductionKochMotzSauter(ParticleDef p, Medium m)
-                : PhotoPairProductionKochMotzForwardPeaked(p, m)
+            PhotoPairProductionKochMotzSauter(ParticleDef p, Medium m, bool interpol = true)
+                : PhotoPairProductionKochMotzForwardPeaked(p, m, interpol)
             {}
 
             std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(

--- a/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionTsai.h
+++ b/src/PROPOSAL/PROPOSAL/secondaries/parametrization/photopairproduction/PhotoPairProductionTsai.h
@@ -11,8 +11,8 @@ namespace secondaries {
 
     public:
         PhotoPairProductionTsaiForwardPeaked() = default;
-        PhotoPairProductionTsaiForwardPeaked(ParticleDef p, Medium m)
-            : PhotoPairProductionInterpolant<crosssection::PhotoPairTsai>(p, m)
+        PhotoPairProductionTsaiForwardPeaked(ParticleDef p, Medium m, bool interpol = true)
+            : PhotoPairProductionInterpolant<crosssection::PhotoPairTsai>(p, m, interpol)
             {}
 
     };
@@ -24,8 +24,8 @@ namespace secondaries {
 
     public:
         PhotoPairProductionTsai() = default;
-        PhotoPairProductionTsai(ParticleDef p, Medium m)
-            : PhotoPairProductionTsaiForwardPeaked(p, m) {}
+        PhotoPairProductionTsai(ParticleDef p, Medium m, bool interpol = true)
+            : PhotoPairProductionTsaiForwardPeaked(p, m, interpol) {}
 
         std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(
                 const Vector3D&, double, double, const Component&,
@@ -35,8 +35,8 @@ namespace secondaries {
     class PhotoPairProductionTsaiSauter : public PhotoPairProductionTsaiForwardPeaked, public SauterSampling {
     public:
         PhotoPairProductionTsaiSauter() = default;
-        PhotoPairProductionTsaiSauter(ParticleDef p, Medium m)
-            : PhotoPairProductionTsaiForwardPeaked(p, m)
+        PhotoPairProductionTsaiSauter(ParticleDef p, Medium m, bool interpol = true)
+            : PhotoPairProductionTsaiForwardPeaked(p, m, interpol)
         {}
 
         std::tuple<Cartesian3D, Cartesian3D> CalculateDirections(

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/CrossSectionDNDX/CrossSectionDNDXInterpolant.cxx
@@ -39,6 +39,24 @@ namespace PROPOSAL {
         auto xi = std::log((1. - v_cut)/(1 - v_max));
         return 1. - std::log((1. - v)/(1. - v_max)) / xi;
     }
+
+    double transform_loss_linear(double v_cut, double v_max, double v)
+    {
+        if (v < 0 || v_max == 0)
+            return v_cut;
+        if (v >= 1)
+            return v_max;
+        return v_cut + (v_max - v_cut) * v;
+    }
+
+    double retransform_loss_linear(double v_cut, double v_max, double v)
+    {
+        if (v <= v_cut)
+            return 0;
+        if (v >= v_max)
+            return 1;
+        return (v - v_cut) / (v_max - v_cut);
+    }
 }
 
 std::string CrossSectionDNDXInterpolant::gen_path() const

--- a/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/PhotoPairProduction.cxx
+++ b/src/PROPOSAL/detail/PROPOSAL/crosssection/parametrization/PhotoPairProduction.cxx
@@ -126,7 +126,7 @@ double crosssection::PhotoPairKochMotz::DifferentialCrossSection(
     };
     auto dNdx_nocorrection = i.Integrate(limits.v_min, limits.v_max, integrand, 3);
     auto A = interpolant_->InterpolateArray(comp.GetNucCharge(), energy) / dNdx_nocorrection;
-    return A * DifferentialCrossSectionWithoutA(p, comp, energy, v);
+    return std::max(A * DifferentialCrossSectionWithoutA(p, comp, energy, v), 0.);
 }
 
 double crosssection::PhotoPairKochMotz::DifferentialCrossSectionWithoutA(

--- a/src/pyPROPOSAL/detail/secondaries.cxx
+++ b/src/pyPROPOSAL/detail/secondaries.cxx
@@ -54,6 +54,24 @@ template <typename T, typename BaseT> struct SecondariesBuilder {
                 :math:`\frac{E_-}{E_{\gamma}}`.
             )pbdoc");
     }
+
+    template <typename... Args> auto decl_rho_param_interpol(Args... args)
+    {
+        py::class_<T, BaseT, std::shared_ptr<T>>(args...)
+                .def(py::init<ParticleDef, Medium, bool>(), py::arg("particle_def"),
+                     py::arg("medium"), py::arg("interpolate") = true)
+                .def("calculate_rho", &T::CalculateRho,
+                     R"pbdoc(
+                Samples the asymmetry factor for interactions where two particles
+                are created. For EpairProduction and MupairProduction, this
+                factor is defined as :math:`\frac{E_+ - E_-}{E_+ + E_-}`, where
+                :math:`E_-` is the energy of the created particle and :math:`E_+`
+                the energy of the created antiparticle. For annihilation and
+                photopairproduction, this factor is defined as
+                :math:`\frac{E_{\gamma,1}}{E_+ + m_e}`, respectively
+                :math:`\frac{E_-}{E_{\gamma}}`.
+            )pbdoc");
+    }
 };
 
 void init_secondaries(py::module& m)
@@ -147,19 +165,19 @@ void init_secondaries(py::module& m)
 
     SecondariesBuilder<secondaries::PhotoPairProductionTsai,
         secondaries::PhotoPairProduction> {}
-        .decl_rho_param(m_sub, "PhotoTsai");
+        .decl_rho_param_interpol(m_sub, "PhotoTsai");
     SecondariesBuilder<secondaries::PhotoPairProductionTsaiForwardPeaked,
         secondaries::PhotoPairProduction> {}
-        .decl_rho_param(m_sub, "PhotoTsaiForwardPeaked");
+        .decl_rho_param_interpol(m_sub, "PhotoTsaiForwardPeaked");
     SecondariesBuilder<secondaries::PhotoPairProductionTsaiSauter,
         secondaries::PhotoPairProduction> {}
-        .decl_rho_param(m_sub, "PhotoTsaiSauter");
+        .decl_rho_param_interpol(m_sub, "PhotoTsaiSauter");
     SecondariesBuilder<secondaries::PhotoPairProductionKochMotzForwardPeaked,
         secondaries::PhotoPairProduction> {}
-        .decl_rho_param(m_sub, "PhotoKochMotzForwardPeaked");
+        .decl_rho_param_interpol(m_sub, "PhotoKochMotzForwardPeaked");
     SecondariesBuilder<secondaries::PhotoPairProductionKochMotzSauter,
         secondaries::PhotoPairProduction> {}
-        .decl_rho_param(m_sub, "PhotoKochMotzSauter");
+        .decl_rho_param_interpol(m_sub, "PhotoKochMotzSauter");
 
     SecondariesBuilder<secondaries::PhotoeffectNoDeflection, secondaries::Photoeffect> {}
         .decl_param(m_sub, "PhotoeffectNoDeflection");


### PR DESCRIPTION
This is an attempt at solving issue #382 

The first approach that brought better results was to adapt the transformation function in `x` for the interpolation tables.

At the moment, the nodes in `x` in the interpolation tables are distributed linearly in the logarithmic room. However, as x is always between 0 and 1, and symmetric around 0.5, this transformation rule is not really suitable here. 
Therefore, I have changed the notes to be linear in x.

For large energies, this significantly improves the results. For small energies, there are still some problems, although the distribution at least looks more symmetric now.

I have also implemented functions to use the CrossSectionIntegral instead of CrossSectionInterpol functions for the secondary calculators of PhotoPairProduction, see #382, so I am able to make comparisons.

### Improvements

Here are the sampled distributions for the current master and with this PR.
Note that the computation time stays identical.

#### 1e5 MeV Photons:

Old distributions:

![image](https://github.com/tudo-astroparticlephysics/PROPOSAL/assets/15159319/6a19273d-ab0b-466d-9084-ddba5fa15339)


New distributions:

![image](https://github.com/tudo-astroparticlephysics/PROPOSAL/assets/15159319/c7053c90-e94d-4459-9d5f-0dac6c913541)


##### 10 MeV photons:

Old distributions:

![image](https://github.com/tudo-astroparticlephysics/PROPOSAL/assets/15159319/1f2d8136-9d56-43d4-b960-517e041a969b)


New distributions:

![image](https://github.com/tudo-astroparticlephysics/PROPOSAL/assets/15159319/dffc1de9-37e9-4da5-8914-e28222105c1e)


##### 2 MeV photons:

Here one can still see a significant deviation between Integral and Interpol. 

Old distributions:


![image](https://github.com/tudo-astroparticlephysics/PROPOSAL/assets/15159319/c45941e6-aade-4575-b92f-27c7272542b2)


New distributions:

![image](https://github.com/tudo-astroparticlephysics/PROPOSAL/assets/15159319/0322570a-4e44-43c6-9bc7-06d676e0e41c)


