### PR TITLE
Fix sources for local conanfile.py to use local files

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -35,6 +35,8 @@ class PROPOSALConan(ConanFile):
         "with_documentation": False,
     }
 
+    exports_sources = "*"
+
     @property
     def _min_cppstd(self):
         return "14"
@@ -93,9 +95,6 @@ class PROPOSALConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support"
             )
-
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Fixes #368 

Doing something like `conan create . 7.6.3@jean/local01` (with conan 1.x) didn't work because it tried fetching the sources from some external url defined in a conandata.yml. This makes sense for the conanfile.py in the conan-center-index, but not locally in the GitHub repository. Instead, we just want to use the source files within this repository, which is done with `export_sources`.

