### PR TITLE
Catch negative variances in ContRandBuilder.h

### DIFF
--- a/src/PROPOSAL/PROPOSAL/propagation_utility/ContRandBuilder.h
+++ b/src/PROPOSAL/PROPOSAL/propagation_utility/ContRandBuilder.h
@@ -29,7 +29,7 @@ public:
     inline double EnergyRandomize(
         double initial_energy, double final_energy, double rnd, double min_energy = 0) final
     {
-        auto std = std::sqrt(Variance(initial_energy, final_energy));
+        auto std = std::sqrt(std::max(Variance(initial_energy, final_energy), 0.0));
         // the parameter 'min' passed to SampleFromGaussian has been
         // min(disp->GetLowerLim(), final_energy) before min_energy was added
         return SampleFromGaussian(final_energy, std, rnd,


### PR DESCRIPTION
fixes #398 

Simple patch to avoid negative variances, which lead to undefined behavior during propagation.