### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ```
 ###############################################################################
 #                                                                             #
+
+[![gitcgr](https://gitcgr.com/badge/tudo-astroparticlephysics/PROPOSAL.svg)](https://gitcgr.com/tudo-astroparticlephysics/PROPOSAL)
 #            _____  _____   ____  _____   ____   _____         _              #
 #           |  __ \|  __ \ / __ \|  __ \ / __ \ / ____|  /\   | |             #
 #           | |__) | |__) | |  | | |__) | |  | | (___   /  \  | |             #


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/tudo-astroparticlephysics/PROPOSAL.svg)](https://gitcgr.com/tudo-astroparticlephysics/PROPOSAL)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).